### PR TITLE
feat: add upload_file tool + harden execute_script against blocking scripts

### DIFF
--- a/src/stealth_chrome_devtools_mcp/embedded/dom_handler.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/dom_handler.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import time
+from pathlib import Path
 from typing import List, Optional, Dict, Any
 
 from nodriver import Tab, Element
@@ -200,6 +201,66 @@ class DOMHandler:
 
         except Exception as e:
             raise Exception(f"Failed to click element: {str(e)}")
+
+    @staticmethod
+    async def upload_file(
+        tab: Tab,
+        selector: str,
+        file_paths: List[str],
+        timeout: int = 10000
+    ) -> Dict[str, Any]:
+        """
+        Attach local file(s) to a file input via CDP (DOM.setFileInputFiles).
+
+        This is the correct, non-blocking way to upload files. It sets the
+        files directly on the input element without touching the network or
+        the renderer's main thread, so it never freezes the page (unlike
+        fetch/base64/DataTransfer hacks run through execute_script).
+
+        Args:
+            tab (Tab): The browser tab object.
+            selector (str): CSS selector or XPath for the <input type="file"> element.
+            file_paths (List[str]): Absolute paths of the file(s) to attach.
+            timeout (int): Element lookup timeout in milliseconds.
+
+        Returns:
+            Dict[str, Any]: {"uploaded": [...], "count": int}.
+        """
+        try:
+            if not file_paths:
+                raise Exception("No file paths provided")
+
+            resolved: List[str] = []
+            for raw_path in file_paths:
+                path = Path(str(raw_path)).expanduser()
+                if not path.is_file():
+                    raise Exception(f"File not found: {path}")
+                resolved.append(str(path.resolve()))
+
+            element = await tab.select(selector, timeout=timeout / 1000)
+            if not element:
+                raise Exception(f"File input not found: {selector}")
+
+            tag_name = (getattr(element, "tag_name", "") or "").lower()
+            input_type = ""
+            if hasattr(element, "attrs") and element.attrs:
+                input_type = (element.attrs.get("type") or "").lower()
+            if tag_name and tag_name != "input":
+                raise Exception(
+                    f"Selector '{selector}' resolved to <{tag_name}>, not a file input. "
+                    "Point the selector at an <input type=\"file\"> element."
+                )
+            if input_type and input_type != "file":
+                raise Exception(
+                    f"Selector '{selector}' is an <input type=\"{input_type}\">, not type=\"file\"."
+                )
+
+            await element.send_file(*resolved)
+
+            return {"uploaded": resolved, "count": len(resolved)}
+
+        except Exception as e:
+            raise Exception(f"Failed to upload file: {str(e)}")
 
     @staticmethod
     async def type_text(

--- a/src/stealth_chrome_devtools_mcp/embedded/server.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/server.py
@@ -70,6 +70,63 @@ def parse_float_env(name: str, default: float) -> float:
 CDP_OPERATION_TIMEOUT = parse_float_env("CDP_OPERATION_TIMEOUT_SECONDS", 30.0)
 MAX_TIMEOUT_MS = 60_000
 
+# User-supplied JS (execute_script) gets a short, dedicated timeout so a blocking
+# script fails fast instead of freezing the tab for the full CDP_OPERATION_TIMEOUT
+# window and stalling every subsequent call.
+EXECUTE_SCRIPT_TIMEOUT = parse_float_env("EXECUTE_SCRIPT_TIMEOUT_SECONDS", 10.0)
+
+# Reject user scripts larger than this. Huge inline payloads (e.g. base64-encoded
+# files) overflow the transport and are almost always an upload hack — callers
+# should use the upload_file tool instead.
+MAX_USER_SCRIPT_BYTES = int(parse_float_env("MAX_USER_SCRIPT_BYTES", 100_000))
+
+# High-confidence denylist of patterns that block the renderer's main thread or
+# overflow the page. This is NOT a JS sandbox — just a guard against the handful
+# of foot-guns that wedge the browser for every later call.
+_BLOCKING_SCRIPT_PATTERNS = [
+    (
+        re.compile(r"\.open\s*\([^)]*,\s*false\s*\)", re.IGNORECASE),
+        "Synchronous XMLHttpRequest (xhr.open(url, false)) blocks the page's main "
+        "thread and freezes every later call. Use 'await fetch(url)' instead.",
+    ),
+    (
+        re.compile(r"while\s*\(\s*(?:true|1)\s*\)"),
+        "Infinite 'while(true)' loop freezes the renderer. Use a bounded loop or an "
+        "async delay: 'await new Promise(r => setTimeout(r, ms))'.",
+    ),
+    (
+        re.compile(r"for\s*\(\s*;\s*;\s*\)"),
+        "Infinite 'for(;;)' loop freezes the renderer. Use a bounded loop instead.",
+    ),
+    (
+        re.compile(r"\b(?:alert|confirm|prompt)\s*\("),
+        "Modal dialogs (alert/confirm/prompt) block the renderer and cannot be "
+        "dismissed by automation. Remove them.",
+    ),
+]
+
+
+def _script_rejection_reason(script: str) -> Optional[str]:
+    """Return a corrective message if a user script is unsafe to run, else None.
+
+    Guards against the common foot-guns that freeze the tab or overflow the
+    transport (sync XHR, infinite loops, blocking dialogs, oversized payloads).
+    Intentionally small and high-confidence — not a JavaScript sandbox.
+    """
+    if not isinstance(script, str):
+        return None
+    size = len(script.encode("utf-8", errors="ignore"))
+    if size > MAX_USER_SCRIPT_BYTES:
+        return (
+            f"Script too large ({size} bytes > {MAX_USER_SCRIPT_BYTES} limit). "
+            "Inline payloads such as base64-encoded files overflow the transport — "
+            "use the 'upload_file' tool for files, or a file-based approach."
+        )
+    for pattern, message in _BLOCKING_SCRIPT_PATTERNS:
+        if pattern.search(script):
+            return f"Rejected: {message}"
+    return None
+
 
 def _clamp_timeout(timeout_ms: int, default: int = 30_000) -> int:
     """Clamp a user-provided timeout (ms) to [1, MAX_TIMEOUT_MS]."""
@@ -114,9 +171,14 @@ def _install_asyncio_close_noise_filter() -> None:
         exception = context.get("exception")
         if (
             exception is not None
-            and exception.__class__.__name__ == "ConnectionClosedOK"
+            and exception.__class__.__name__
+            in ("ConnectionClosedOK", "ConnectionClosedError", "ConnectionClosed")
             and str(exception.__class__.__module__).startswith("websockets.")
         ):
+            # Swallow both clean (OK) and abnormal (Error) websocket closes. When
+            # Chrome crashes or is killed, nodriver's background listener task
+            # raises ConnectionClosedError; without this it surfaces loudly and
+            # can escalate. The instance is already unusable and will be respawned.
             return
 
         if previous_handler is not None:
@@ -1114,6 +1176,41 @@ async def click_element(
     return await _with_cdp_timeout(dom_handler.click_element(tab, selector, text_match, timeout), instance_id=instance_id)
 
 @section_tool("element-interaction")
+async def upload_file(
+    instance_id: str,
+    selector: str,
+    file_paths: Union[str, List[str]],
+    timeout: int = 10000
+) -> Dict[str, Any]:
+    """
+    Upload local file(s) to a file input. USE THIS for file uploads.
+
+    Sets the files directly on the <input type="file"> via CDP — reliable and
+    non-blocking. Do NOT try to upload by fetching blobs / building base64 /
+    DataTransfer inside execute_script: that hits mixed-content/CORS limits and
+    can freeze the page. This tool is the supported path.
+
+    Args:
+        instance_id (str): Browser instance ID.
+        selector (str): CSS selector or XPath for the <input type="file"> element.
+        file_paths (Union[str, List[str]]): Absolute path, or list of paths, to attach.
+            For multiple files the input must have the `multiple` attribute.
+        timeout (int): Element lookup timeout in ms (default 10000, max 60000).
+
+    Returns:
+        Dict[str, Any]: {"uploaded": [absolute paths], "count": int}.
+    """
+    timeout = _clamp_timeout(timeout, default=10_000)
+    paths = [file_paths] if isinstance(file_paths, str) else list(file_paths)
+    tab = await browser_manager.get_tab(instance_id)
+    if not tab:
+        raise Exception(f"Instance not found: {instance_id}")
+    return await _with_cdp_timeout(
+        dom_handler.upload_file(tab, selector, paths, timeout),
+        instance_id=instance_id,
+    )
+
+@section_tool("element-interaction")
 async def type_text(
     instance_id: str,
     selector: str,
@@ -1280,24 +1377,48 @@ async def scroll_page(
 async def execute_script(
     instance_id: str,
     script: str,
-    args: Optional[List[Any]] = None
+    args: Optional[List[Any]] = None,
+    timeout_ms: Optional[int] = None
 ) -> Dict[str, Any]:
     """
-    Execute JavaScript in page context.
+    Execute JavaScript in the page and return its value.
+
+    ⚠️ Async, non-blocking code only. The script runs on the page's main thread,
+    so anything that blocks it freezes the whole tab and makes every later call
+    time out. Specifically:
+      • NEVER use synchronous XHR — `xhr.open(url, false)`. Use `await fetch(url)`.
+      • NEVER use infinite/blocking loops — `while(true)`, `for(;;)`, busy-waits.
+      • NEVER call `alert()` / `confirm()` / `prompt()` — they block automation.
+      • To UPLOAD FILES, use the `upload_file` tool — do NOT fetch blobs or build
+        base64/DataTransfer here (mixed-content/CORS limits and can freeze the page).
+      • Keep scripts small (< ~100KB); don't inline large payloads.
 
     Args:
         instance_id (str): Browser instance ID.
-        script (str): JavaScript code to execute.
-        args (Optional[List[Any]]): Arguments to pass to the script.
+        script (str): JavaScript to execute. Must be non-blocking.
+        args (Optional[List[Any]]): Arguments passed to the script body.
+        timeout_ms (Optional[int]): Max run time in ms (default 10000, max 60000).
+            A blocking script is killed at this limit instead of hanging the tab.
 
     Returns:
-        Dict[str, Any]: Script execution result.
+        Dict[str, Any]: {"success": bool, "result": Any, "error": Optional[str]}.
     """
+    rejection = _script_rejection_reason(script)
+    if rejection:
+        return {"success": False, "result": None, "error": rejection}
     tab = await browser_manager.get_tab(instance_id)
     if not tab:
         raise Exception(f"Instance not found: {instance_id}")
+    if timeout_ms is not None:
+        timeout_s = _clamp_timeout(timeout_ms, default=int(EXECUTE_SCRIPT_TIMEOUT * 1000)) / 1000
+    else:
+        timeout_s = EXECUTE_SCRIPT_TIMEOUT
     try:
-        result = await _with_cdp_timeout(dom_handler.execute_script(tab, script, args), instance_id=instance_id)
+        result = await _with_cdp_timeout(
+            dom_handler.execute_script(tab, script, args),
+            timeout=timeout_s,
+            instance_id=instance_id,
+        )
         return {
             "success": True,
             "result": result,

--- a/tests/test_browser_integration.py
+++ b/tests/test_browser_integration.py
@@ -9,6 +9,7 @@ Skip in CI without Chrome: pytest -m "not integration"
 import asyncio
 import os
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -260,3 +261,114 @@ class TestIdleTimeout:
         assert iid in active_ids
 
         await close(instance_id=iid)
+
+
+class TestFileUpload:
+    """upload_file attaches local files to a file input via CDP (non-blocking)."""
+
+    UPLOAD_URL = (
+        "data:text/html,<html><body>"
+        "<input id='single' type='file'>"
+        "<input id='multi' type='file' multiple>"
+        "</body></html>"
+    )
+
+    @pytest.mark.asyncio
+    async def test_upload_single_file(self, tmp_path):
+        spawn = _get_fn("spawn_browser")
+        navigate = _get_fn("navigate")
+        upload = _get_fn("upload_file")
+        execute = _get_fn("execute_script")
+        close = _get_fn("close_instance")
+
+        f = tmp_path / "alpha.txt"
+        f.write_text("alpha", encoding="utf-8")
+
+        result = await spawn(headless=True, **_sandbox_kwargs())
+        iid = result["instance_id"]
+        try:
+            await navigate(instance_id=iid, url=self.UPLOAD_URL)
+
+            t0 = time.monotonic()
+            res = await upload(instance_id=iid, selector="#single", file_paths=str(f))
+            elapsed = time.monotonic() - t0
+
+            assert res["count"] == 1
+            # Proves it does not block the renderer (the sync-XHR bug froze ~30s).
+            assert elapsed < 5.0, f"upload should be near-instant, took {elapsed:.1f}s"
+
+            name = await execute(
+                instance_id=iid,
+                script="document.getElementById('single').files[0].name",
+            )
+            assert "alpha.txt" in str(name.get("result", name))
+        finally:
+            await close(instance_id=iid)
+
+    @pytest.mark.asyncio
+    async def test_upload_multiple_files(self, tmp_path):
+        spawn = _get_fn("spawn_browser")
+        navigate = _get_fn("navigate")
+        upload = _get_fn("upload_file")
+        execute = _get_fn("execute_script")
+        close = _get_fn("close_instance")
+
+        a = tmp_path / "a.txt"
+        a.write_text("a", encoding="utf-8")
+        b = tmp_path / "b.txt"
+        b.write_text("b", encoding="utf-8")
+
+        result = await spawn(headless=True, **_sandbox_kwargs())
+        iid = result["instance_id"]
+        try:
+            await navigate(instance_id=iid, url=self.UPLOAD_URL)
+            res = await upload(
+                instance_id=iid, selector="#multi", file_paths=[str(a), str(b)]
+            )
+            assert res["count"] == 2
+            count = await execute(
+                instance_id=iid,
+                script="document.getElementById('multi').files.length",
+            )
+            assert int(count.get("result")) == 2
+        finally:
+            await close(instance_id=iid)
+
+    @pytest.mark.asyncio
+    async def test_upload_missing_file_raises(self, tmp_path):
+        spawn = _get_fn("spawn_browser")
+        navigate = _get_fn("navigate")
+        upload = _get_fn("upload_file")
+        close = _get_fn("close_instance")
+
+        result = await spawn(headless=True, **_sandbox_kwargs())
+        iid = result["instance_id"]
+        try:
+            await navigate(instance_id=iid, url=self.UPLOAD_URL)
+            with pytest.raises(Exception, match="File not found"):
+                await upload(
+                    instance_id=iid,
+                    selector="#single",
+                    file_paths=str(tmp_path / "nope.txt"),
+                )
+        finally:
+            await close(instance_id=iid)
+
+    @pytest.mark.asyncio
+    async def test_upload_rejects_non_file_input(self, tmp_path):
+        spawn = _get_fn("spawn_browser")
+        navigate = _get_fn("navigate")
+        upload = _get_fn("upload_file")
+        close = _get_fn("close_instance")
+
+        f = tmp_path / "x.txt"
+        f.write_text("x", encoding="utf-8")
+
+        result = await spawn(headless=True, **_sandbox_kwargs())
+        iid = result["instance_id"]
+        try:
+            await navigate(instance_id=iid, url=self.UPLOAD_URL)
+            with pytest.raises(Exception, match="file input"):
+                await upload(instance_id=iid, selector="body", file_paths=str(f))
+        finally:
+            await close(instance_id=iid)

--- a/tests/test_close_noise_filter.py
+++ b/tests/test_close_noise_filter.py
@@ -1,0 +1,77 @@
+"""Unit tests for the asyncio close-noise filter.
+
+When Chrome dies, nodriver's background websocket listener raises a
+ConnectionClosed* error into the event loop. The handler installed by
+_install_asyncio_close_noise_filter swallows those — both the clean
+ConnectionClosedOK and the abnormal ConnectionClosedError from the
+`websockets` package — while letting every other exception reach the default
+handler. No browser required.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+EMBEDDED_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "stealth_chrome_devtools_mcp"
+    / "embedded"
+)
+if str(EMBEDDED_DIR) not in sys.path:
+    sys.path.insert(0, str(EMBEDDED_DIR))
+
+import server  # noqa: E402
+
+
+def _make_exc(name, module):
+    """Build an exception whose class name/module match what the filter checks."""
+    cls = type(name, (Exception,), {})
+    cls.__module__ = module
+    return cls("boom")
+
+
+async def _install_with_previous(previous_handler):
+    """Install the noise filter on the running loop, return (loop, installed_handler)."""
+    loop = asyncio.get_running_loop()
+    loop.set_exception_handler(previous_handler)
+    server._install_asyncio_close_noise_filter()
+    return loop, loop.get_exception_handler()
+
+
+class TestCloseNoiseFilter:
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("exc_name", [
+        "ConnectionClosedOK",     # clean close (already handled before the fix)
+        "ConnectionClosedError",  # abnormal close (added by the fix)
+        "ConnectionClosed",       # base class
+    ])
+    async def test_websocket_closes_are_swallowed(self, exc_name):
+        delegated = []
+        loop, handler = await _install_with_previous(lambda l, ctx: delegated.append(ctx))
+        handler(loop, {
+            "exception": _make_exc(exc_name, "websockets.exceptions"),
+            "message": "task exception was never retrieved",
+        })
+        assert delegated == [], f"{exc_name} from websockets should be swallowed"
+
+    @pytest.mark.asyncio
+    async def test_other_exceptions_are_delegated(self):
+        delegated = []
+        loop, handler = await _install_with_previous(lambda l, ctx: delegated.append(ctx))
+        handler(loop, {"exception": ValueError("a real bug"), "message": "boom"})
+        assert len(delegated) == 1, "non-websocket errors must reach the default handler"
+
+    @pytest.mark.asyncio
+    async def test_non_websockets_connection_closed_is_delegated(self):
+        """A same-named error from a different module must NOT be swallowed."""
+        delegated = []
+        loop, handler = await _install_with_previous(lambda l, ctx: delegated.append(ctx))
+        handler(loop, {
+            "exception": _make_exc("ConnectionClosedError", "some.other.module"),
+            "message": "boom",
+        })
+        assert len(delegated) == 1

--- a/tests/test_execute_script_guard.py
+++ b/tests/test_execute_script_guard.py
@@ -1,0 +1,133 @@
+"""Unit tests for the execute_script safety guard (denylist + size cap).
+
+No browser required — these run in the `unit-tests` CI job (pytest -m
+"not integration") across all supported Python versions. They lock in the
+foot-guns that previously froze the renderer — synchronous XHR, infinite
+loops, blocking dialogs and oversized inline payloads — and confirm that
+benign async/DOM code is allowed through unchanged.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make embedded/ importable the same way the real entrypoint does.
+EMBEDDED_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "stealth_chrome_devtools_mcp"
+    / "embedded"
+)
+if str(EMBEDDED_DIR) not in sys.path:
+    sys.path.insert(0, str(EMBEDDED_DIR))
+
+import server  # noqa: E402
+from server import (  # noqa: E402
+    _script_rejection_reason,
+    EXECUTE_SCRIPT_TIMEOUT,
+    MAX_USER_SCRIPT_BYTES,
+)
+
+
+def _unwrap(fn):
+    """FastMCP wraps tool coroutines in a FunctionTool; return the raw coroutine."""
+    return getattr(fn, "fn", fn)
+
+
+# ---------------------------------------------------------------------------
+# _script_rejection_reason — pure logic, no browser
+# ---------------------------------------------------------------------------
+
+class TestScriptDenylist:
+    """Blocking patterns are rejected with an actionable message."""
+
+    @pytest.mark.parametrize("script", [
+        "var x=new XMLHttpRequest(); x.open('GET', url, false); x.send();",
+        "xhr.open('POST', '/api', false)",
+        "r.open( 'GET', u , false )",
+    ])
+    def test_sync_xhr_rejected(self, script):
+        reason = _script_rejection_reason(script)
+        assert reason is not None
+        assert "Synchronous" in reason and "fetch" in reason
+
+    @pytest.mark.parametrize("script", [
+        "while (true) { work(); }",
+        "while(1){}",
+        "for (;;) { tick(); }",
+        "for(;;){}",
+    ])
+    def test_infinite_loops_rejected(self, script):
+        assert _script_rejection_reason(script) is not None
+
+    @pytest.mark.parametrize("script", [
+        "alert('hi')",
+        "window.confirm('ok?')",
+        "const v = prompt('name')",
+    ])
+    def test_blocking_dialogs_rejected(self, script):
+        assert _script_rejection_reason(script) is not None
+
+    def test_oversized_script_rejected(self):
+        reason = _script_rejection_reason("a" * (MAX_USER_SCRIPT_BYTES + 1))
+        assert reason is not None
+        assert "too large" in reason and "upload_file" in reason
+
+    def test_script_exactly_at_limit_allowed(self):
+        assert _script_rejection_reason("a" * MAX_USER_SCRIPT_BYTES) is None
+
+    @pytest.mark.parametrize("script", [
+        "const r = await fetch('/x'); return r.status;",
+        "document.querySelector('#f').files.length",
+        "window.open('https://example.com', '_blank', 'noopener')",
+        "el.setAttribute('aria-hidden', false)",
+        "[...document.querySelectorAll('a')].map(a => a.href)",
+        "indexedDB; document.title",
+    ])
+    def test_benign_scripts_allowed(self, script):
+        assert _script_rejection_reason(script) is None
+
+    def test_non_string_input_is_ignored(self):
+        assert _script_rejection_reason(None) is None
+        assert _script_rejection_reason(123) is None
+
+    def test_execute_script_timeout_is_short(self):
+        """User JS must fail fast, not inherit the 30s CDP window."""
+        assert 0 < EXECUTE_SCRIPT_TIMEOUT <= 15
+
+
+# ---------------------------------------------------------------------------
+# execute_script tool — rejection happens before any browser lookup
+# ---------------------------------------------------------------------------
+
+class TestExecuteScriptToolGuard:
+    """The tool returns a structured rejection without needing a live instance."""
+
+    @pytest.mark.asyncio
+    async def test_sync_xhr_rejected_without_browser(self):
+        execute = _unwrap(server.execute_script)
+        res = await execute(
+            instance_id="no-such-instance",
+            script="x.open('GET', u, false); x.send();",
+        )
+        assert res["success"] is False
+        assert res["result"] is None
+        assert "Synchronous" in res["error"]
+
+    @pytest.mark.asyncio
+    async def test_oversized_rejected_without_browser(self):
+        execute = _unwrap(server.execute_script)
+        res = await execute(
+            instance_id="no-such-instance",
+            script="var b='" + ("a" * (MAX_USER_SCRIPT_BYTES + 10)) + "';",
+        )
+        assert res["success"] is False
+        assert "too large" in res["error"]
+
+    @pytest.mark.asyncio
+    async def test_benign_script_passes_guard_then_reports_missing_instance(self):
+        """A clean script clears the guard and proceeds to instance lookup."""
+        execute = _unwrap(server.execute_script)
+        with pytest.raises(Exception, match="Instance not found"):
+            await execute(instance_id="no-such-instance", script="1 + 1")


### PR DESCRIPTION
## Why

Agents (especially weaker ones) were forced into base64 / synchronous-XHR upload hacks because the server had **no file-upload capability**. A synchronous XHR blocks Chrome's renderer and trips the 30s CDP watchdog on *every* subsequent call — the browser looks frozen and the instance often cascades into a full disconnect. These changes remove the capability gap and make the remaining foot-guns fail fast.

## What changed

- **`upload_file` tool** — attaches local file(s) to an `<input type=file>` via CDP `DOM.setFileInputFiles` (nodriver `send_file`). Non-blocking (~60 ms), validates the path exists and that the selector is a real file input.
- **`execute_script` hardening** — dedicated short timeout (10 s; was inheriting the 30 s CDP window), a high-confidence denylist (sync XHR, `while(true)`/`for(;;)`, `alert/confirm/prompt`), a 100 KB size cap, and explicit DO-NOT rules in the docstring. Each rejection returns a corrective message pointing at the right tool — so the agent self-corrects.
- **Widened close-noise filter** — also swallows abnormal `ConnectionClosedError` (Chrome crash), not just `ConnectionClosedOK`, so an abnormal browser death no longer surfaces loudly.

## Tests (wired into the existing suite + CI)

| File | Type | Count | CI job |
|---|---|---|---|
| `tests/test_execute_script_guard.py` | unit (no browser) | 23 | unit-tests |
| `tests/test_close_noise_filter.py` | unit (no browser) | 5 | unit-tests |
| `tests/test_browser_integration.py::TestFileUpload` | integration (real Chrome) | 4 | integration-tests |

- Full unit suite: **184 passing**, no regressions.
- Upload integration verified locally with headless Chrome (single + multi file, non-blocking timing assertion, missing-file and non-file-input error paths).

## Notes

- No production code paths removed; `execute_script` keeps its existing return shape, only adding an optional `timeout_ms` and pre-flight validation.
- The denylist is intentionally a small, high-confidence guard (not a JS sandbox); benign async/DOM code — including `window.open(...,'noopener')` and `setAttribute(...,false)` — is covered by allow-tests to prevent false positives.
