### PR TITLE
fix: auto-delete disposable profile clones on browser close

### DIFF
--- a/src/stealth_chrome_devtools_mcp/embedded/browser_manager.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/browser_manager.py
@@ -412,6 +412,7 @@ class BrowserManager:
                     browser._process,
                     user_data_dir=actual_user_data_dir,
                     uses_custom_data_dir=uses_custom_data_dir,
+                    auto_clone=options.auto_clone,
                 )
             else:
                 debug_logger.log_warning("browser_manager", "spawn_browser", 

--- a/src/stealth_chrome_devtools_mcp/embedded/models.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/models.py
@@ -96,6 +96,7 @@ class BrowserOptions(BaseModel):
     extra_headers: Dict[str, str] = Field(default_factory=dict, description="Extra HTTP headers")
     user_data_dir: Optional[str] = Field(default=None, description="Path to user data directory")
     sandbox: bool = Field(default=True, description="Enable browser sandbox mode")
+    auto_clone: bool = Field(default=False, description="Internal: profile is a disposable auto-clone of master and is deleted when the browser closes. Set by the server from the resolved profile role, never by callers.")
 
 
 class NavigationOptions(BaseModel):

--- a/src/stealth_chrome_devtools_mcp/embedded/process_cleanup.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/process_cleanup.py
@@ -140,6 +140,7 @@ class ProcessCleanup:
                     "create_time": None,
                     "user_data_dir": None,
                     "uses_custom_data_dir": None,
+                    "auto_clone": False,
                     "timestamp": 0,
                 }
             elif isinstance(raw_value, dict):
@@ -151,6 +152,7 @@ class ProcessCleanup:
                     "create_time": raw_value.get("create_time"),
                     "user_data_dir": raw_value.get("user_data_dir"),
                     "uses_custom_data_dir": raw_value.get("uses_custom_data_dir"),
+                    "auto_clone": bool(raw_value.get("auto_clone", False)),
                     "timestamp": raw_value.get("timestamp", 0),
                 }
             else:
@@ -457,7 +459,7 @@ class ProcessCleanup:
         Returns:
             bool: True if cleanup succeeded or nothing needed to be removed.
         """
-        if metadata.get("uses_custom_data_dir") is True:
+        if metadata.get("uses_custom_data_dir") is True and not metadata.get("auto_clone"):
             return False
 
         profile_dir = metadata.get("user_data_dir")
@@ -465,6 +467,30 @@ class ProcessCleanup:
             return False
 
         return self._cleanup_profile_dir(profile_dir, instance_id, active_profile_dirs)
+
+    @staticmethod
+    def _should_untrack_after_cleanup(metadata: Dict[str, Any], cleaned: bool) -> bool:
+        """Decide whether a tracked entry can be dropped after a cleanup attempt.
+
+        Auto-clones stay tracked until their directory is actually removed, so a
+        Windows-locked delete is retried later by ``cleanup_deferred_profiles``
+        and startup recovery.  Named/master profiles (custom dir, not an
+        auto-clone) are never deleted, so they are dropped immediately.
+
+        Args:
+            metadata (Dict[str, Any]): Tracked process metadata.
+            cleaned (bool): Whether the profile directory was just removed.
+
+        Returns:
+            bool: True when the tracked entry should be untracked now.
+        """
+        if cleaned:
+            return True
+        if not metadata.get("user_data_dir"):
+            return True
+        if metadata.get("uses_custom_data_dir") is True and not metadata.get("auto_clone"):
+            return True
+        return False
 
     def _sweep_orphaned_temp_profiles(self) -> int:
         """
@@ -566,6 +592,7 @@ class ProcessCleanup:
         browser_process,
         user_data_dir: Optional[str] = None,
         uses_custom_data_dir: Optional[bool] = None,
+        auto_clone: bool = False,
     ) -> bool:
         """
         Track a browser process and its profile metadata for future cleanup.
@@ -575,6 +602,8 @@ class ProcessCleanup:
             browser_process: Browser process object with `.pid`.
             user_data_dir: Browser profile directory.
             uses_custom_data_dir: Whether the profile directory was explicitly provided by the user.
+            auto_clone: Whether the profile is a disposable auto-clone of master
+                that should be deleted once its browser closes.
 
         Returns:
             bool: True if tracking was successful.
@@ -599,6 +628,7 @@ class ProcessCleanup:
                 "create_time": create_time,
                 "user_data_dir": self._normalize_path(user_data_dir),
                 "uses_custom_data_dir": uses_custom_data_dir,
+                "auto_clone": bool(auto_clone),
                 "timestamp": time.time(),
             }
             self.browser_processes[instance_id] = metadata
@@ -681,11 +711,7 @@ class ProcessCleanup:
                 metadata,
                 active_profile_dirs=active_profile_dirs,
             )
-            if (
-                cleaned
-                or metadata.get("uses_custom_data_dir") is True
-                or not metadata.get("user_data_dir")
-            ):
+            if self._should_untrack_after_cleanup(metadata, cleaned):
                 self.untrack_browser_process(instance_id)
             else:
                 metadata["pid"] = None
@@ -720,11 +746,7 @@ class ProcessCleanup:
             metadata,
             active_profile_dirs=active_profile_dirs,
         )
-        if (
-            cleaned
-            or metadata.get("uses_custom_data_dir") is True
-            or not metadata.get("user_data_dir")
-        ):
+        if self._should_untrack_after_cleanup(metadata, cleaned):
             self.untrack_browser_process(instance_id)
             return True
 
@@ -757,11 +779,7 @@ class ProcessCleanup:
                 metadata,
                 active_profile_dirs=active_profile_dirs,
             )
-            if (
-                cleaned
-                or metadata.get("uses_custom_data_dir") is True
-                or not metadata.get("user_data_dir")
-            ):
+            if self._should_untrack_after_cleanup(metadata, cleaned):
                 if self.untrack_browser_process(instance_id):
                     finalized_count += 1
 

--- a/src/stealth_chrome_devtools_mcp/embedded/server.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/server.py
@@ -835,7 +835,12 @@ async def spawn_browser(
         idle_timeout_seconds (Optional[int]): Idle timeout override in seconds for automatic instance cleanup.
         block_resources (List[str]): List of resource types to block (e.g., ['image', 'font', 'stylesheet']).
         extra_headers (Dict[str, str]): Additional HTTP headers.
-        user_data_dir (Optional[str]): Path to user data directory for persistent sessions.
+        user_data_dir (Optional[str]): Leave UNSET for normal use. When unset, the server
+            automatically clones a disposable session from the master profile and deletes it
+            as soon as the browser closes — you never need to manage or clean up sessions.
+            Only set this when the user has EXPLICITLY asked for a persistent/named profile:
+            a named profile is NOT auto-cleaned and persists on disk indefinitely, so treat
+            creating one as a deliberate, space-consuming action. Do not invent names.
         sandbox (Optional[Any]): Enable browser sandbox. Accepts bool, string ('true'/'false'), int (1/0), or None for auto-detect.
 
     Returns:
@@ -870,7 +875,8 @@ async def spawn_browser(
                 block_resources=block_resources or [],
                 extra_headers=extra_headers or {},
                 user_data_dir=selected_user_data_dir,
-                sandbox=sandbox
+                sandbox=sandbox,
+                auto_clone=(profile_selection.get("profile_role") == "clone"),
             )
             try:
                 instance = await browser_manager.spawn_browser(options)
@@ -895,6 +901,12 @@ async def spawn_browser(
             spawn_diagnostics["profile_selection"] = _public_profile_selection(profile_selection)
             if spawn_errors:
                 spawn_diagnostics["profile_selection"]["spawn_retries"] = spawn_errors
+            if profile_selection.get("profile_role") == "explicit":
+                spawn_diagnostics["profile_selection"]["warning"] = (
+                    "Named profile created — it is NOT auto-cleaned and persists on disk. "
+                    "Only pass user_data_dir when the user explicitly asks for a persistent "
+                    "profile; otherwise omit it so the session is auto-cloned and auto-deleted."
+                )
         return {
             "instance_id": instance.instance_id,
             "state": instance.state,

--- a/tests/test_browser_integration.py
+++ b/tests/test_browser_integration.py
@@ -372,3 +372,71 @@ class TestFileUpload:
                 await upload(instance_id=iid, selector="body", file_paths=str(f))
         finally:
             await close(instance_id=iid)
+
+
+class TestAutoCloneDeletion:
+    """End-to-end: disposable auto-clones are deleted on close, while the
+    master profile and explicit named profiles are always preserved.
+    """
+
+    @pytest.mark.asyncio
+    async def test_auto_clone_deleted_master_survives(self, tmp_session_root):
+        from process_cleanup import process_cleanup as _pc
+
+        spawn = _get_fn("spawn_browser")
+        close = _get_fn("close_instance")
+        dirs = tmp_session_root
+
+        # First spawn with no user_data_dir takes the master profile directly.
+        master_inst = await spawn(headless=True, **_sandbox_kwargs())
+        master_iid = master_inst["instance_id"]
+        try:
+            master_sel = master_inst["spawn_diagnostics"]["profile_selection"]
+            assert master_sel["profile_role"] == "master", master_sel
+
+            # Master is busy now → a second spawn must clone from the snapshot.
+            clone_inst = await spawn(headless=True, **_sandbox_kwargs())
+            clone_iid = clone_inst["instance_id"]
+            sel = clone_inst["spawn_diagnostics"]["profile_selection"]
+            assert sel["profile_role"] == "clone", sel
+            clone_dir = Path(sel["user_data_dir"])
+            assert clone_dir.exists()
+            assert str(dirs["sessions"]) in str(clone_dir)
+
+            # Closing the clone must delete its directory. Force deferred
+            # finalization to absorb any brief Windows file-lock after exit.
+            await close(instance_id=clone_iid)
+            for _ in range(40):
+                if not clone_dir.exists():
+                    break
+                _pc.cleanup_deferred_profiles()
+                await asyncio.sleep(0.25)
+            assert not clone_dir.exists(), f"auto-clone not cleaned: {clone_dir}"
+
+            # Master directory is never auto-deleted, even while in use.
+            assert dirs["master"].exists()
+        finally:
+            await close(instance_id=master_iid)
+
+        # Master survives its own close too (only the snapshot is refreshed).
+        assert dirs["master"].exists()
+
+    @pytest.mark.asyncio
+    async def test_named_profile_survives_close(self, tmp_session_root):
+        spawn = _get_fn("spawn_browser")
+        close = _get_fn("close_instance")
+
+        inst = await spawn(
+            headless=True, user_data_dir="keep-me-session", **_sandbox_kwargs()
+        )
+        iid = inst["instance_id"]
+        sel = inst["spawn_diagnostics"]["profile_selection"]
+        named_dir = Path(sel["user_data_dir"])
+        assert sel["profile_role"] == "explicit", sel
+        assert named_dir.exists()
+        # The AI-facing nudge must be surfaced when a named profile is created.
+        assert "warning" in sel
+
+        await close(instance_id=iid)
+        await asyncio.sleep(1.0)
+        assert named_dir.exists(), f"named profile wrongly deleted: {named_dir}"

--- a/tests/test_process_cleanup.py
+++ b/tests/test_process_cleanup.py
@@ -278,3 +278,175 @@ class TestPidFilePersistence:
         assert "inst-1" in loaded
         assert loaded["inst-1"]["pid"] == 1234
         assert loaded["inst-1"]["create_time"] == 1700000000.0
+
+
+# ---------------------------------------------------------------------------
+# Auto-clone lifecycle (disposable profiles copied from master)
+# ---------------------------------------------------------------------------
+
+class TestAutoCloneCleanup:
+    """Auto-clones (profile_role == 'clone') must be deleted on close even
+    though they carry a user_data_dir (uses_custom_data_dir is True), while
+    named/master profiles with the same flag must be preserved.
+    """
+
+    def _make_cleanup(self, tmp_path):
+        pc = ProcessCleanup.__new__(ProcessCleanup)
+        pc.pid_file = tmp_path / "pids.json"
+        pc.tracked_pids = set()
+        pc.browser_processes = {}
+        pc.orphan_profile_max_age_seconds = 21600
+        pc._init_time = time.time()
+        return pc
+
+    def test_auto_clone_deleted_despite_custom_dir(self, tmp_path):
+        """auto_clone=True overrides the uses_custom_data_dir skip → dir removed."""
+        pc = self._make_cleanup(tmp_path)
+        clone = tmp_path / "sessions" / "ws-abc123"
+        clone.mkdir(parents=True)
+        (clone / "Cookies").write_bytes(b"stub")
+        metadata = {
+            "pid": 4242,
+            "create_time": None,
+            "user_data_dir": str(clone),
+            "uses_custom_data_dir": True,
+            "auto_clone": True,
+            "timestamp": 0,
+        }
+        result = pc._cleanup_profile_for_metadata("inst", metadata, active_profile_dirs=set())
+        assert result is True
+        assert not clone.exists()
+
+    def test_named_profile_preserved(self, tmp_path):
+        """A user-named profile (auto_clone False, custom dir) is never deleted."""
+        pc = self._make_cleanup(tmp_path)
+        named = tmp_path / "sessions" / "github-session"
+        named.mkdir(parents=True)
+        (named / "Cookies").write_bytes(b"stub")
+        metadata = {
+            "pid": 4243,
+            "create_time": None,
+            "user_data_dir": str(named),
+            "uses_custom_data_dir": True,
+            "auto_clone": False,
+            "timestamp": 0,
+        }
+        result = pc._cleanup_profile_for_metadata("inst", metadata, active_profile_dirs=set())
+        assert result is False
+        assert named.exists()
+
+    def test_master_like_profile_preserved(self, tmp_path):
+        """master role (no auto_clone) must survive close even with custom dir."""
+        pc = self._make_cleanup(tmp_path)
+        master = tmp_path / "master"
+        master.mkdir(parents=True)
+        (master / "Cookies").write_bytes(b"stub")
+        metadata = {
+            "pid": 4245,
+            "create_time": None,
+            "user_data_dir": str(master),
+            "uses_custom_data_dir": True,
+            "auto_clone": False,
+            "timestamp": 0,
+        }
+        result = pc._cleanup_profile_for_metadata("inst", metadata, active_profile_dirs=set())
+        assert result is False
+        assert master.exists()
+
+    def test_live_auto_clone_not_deleted(self, tmp_path):
+        """An auto-clone whose browser is still running must not be deleted."""
+        pc = self._make_cleanup(tmp_path)
+        clone = tmp_path / "sessions" / "ws-live"
+        clone.mkdir(parents=True)
+        normalized = pc._normalize_path(str(clone))
+        metadata = {
+            "pid": 4244,
+            "create_time": None,
+            "user_data_dir": str(clone),
+            "uses_custom_data_dir": True,
+            "auto_clone": True,
+            "timestamp": 0,
+        }
+        # Profile reported active on every probe → deletion must be refused.
+        with patch.object(pc, "_get_active_browser_profile_dirs", return_value={normalized}), \
+             patch("process_cleanup.time.sleep"):
+            result = pc._cleanup_profile_for_metadata(
+                "inst", metadata, active_profile_dirs={normalized}
+            )
+        assert result is False
+        assert clone.exists()
+
+
+class TestShouldUntrackAfterCleanup:
+    """Untrack policy: auto-clones stay tracked until their dir is actually
+    removed (so the deferred retry can finish a Windows-locked delete), while
+    named/master profiles stop tracking immediately (they are never deleted).
+    """
+
+    def test_cleaned_always_untracks(self):
+        meta = {"user_data_dir": "/x", "uses_custom_data_dir": True, "auto_clone": True}
+        assert ProcessCleanup._should_untrack_after_cleanup(meta, cleaned=True) is True
+
+    def test_no_dir_untracks(self):
+        meta = {"user_data_dir": None}
+        assert ProcessCleanup._should_untrack_after_cleanup(meta, cleaned=False) is True
+
+    def test_named_profile_untracks_without_delete(self):
+        meta = {"user_data_dir": "/x", "uses_custom_data_dir": True, "auto_clone": False}
+        assert ProcessCleanup._should_untrack_after_cleanup(meta, cleaned=False) is True
+
+    def test_auto_clone_stays_tracked_until_deleted(self):
+        meta = {"user_data_dir": "/x", "uses_custom_data_dir": True, "auto_clone": True}
+        assert ProcessCleanup._should_untrack_after_cleanup(meta, cleaned=False) is False
+
+    def test_temp_profile_stays_tracked_until_deleted(self):
+        meta = {"user_data_dir": "/x", "uses_custom_data_dir": False, "auto_clone": False}
+        assert ProcessCleanup._should_untrack_after_cleanup(meta, cleaned=False) is False
+
+
+class TestAutoCloneMetadata:
+    """auto_clone must round-trip through tracking and the PID file."""
+
+    def test_track_stores_auto_clone(self, tmp_path):
+        pc = ProcessCleanup.__new__(ProcessCleanup)
+        pc.pid_file = tmp_path / "pids.json"
+        pc.tracked_pids = set()
+        pc.browser_processes = {}
+        pc.orphan_profile_max_age_seconds = 21600
+        pc._init_time = time.time()
+
+        proc = MagicMock()
+        proc.pid = 5555
+        ok = pc.track_browser_process(
+            "inst",
+            proc,
+            user_data_dir=str(tmp_path / "clone"),
+            uses_custom_data_dir=True,
+            auto_clone=True,
+        )
+        assert ok is True
+        assert pc.browser_processes["inst"]["auto_clone"] is True
+
+    def test_track_defaults_auto_clone_false(self, tmp_path):
+        pc = ProcessCleanup.__new__(ProcessCleanup)
+        pc.pid_file = tmp_path / "pids.json"
+        pc.tracked_pids = set()
+        pc.browser_processes = {}
+        pc.orphan_profile_max_age_seconds = 21600
+        pc._init_time = time.time()
+
+        proc = MagicMock()
+        proc.pid = 5556
+        pc.track_browser_process("inst", proc, user_data_dir=str(tmp_path / "m"))
+        assert pc.browser_processes["inst"]["auto_clone"] is False
+
+    def test_normalize_preserves_auto_clone(self):
+        raw = {"i": {"pid": 1, "auto_clone": True, "user_data_dir": "/x"}}
+        out = ProcessCleanup._normalize_process_metadata(raw)
+        assert out["i"]["auto_clone"] is True
+
+    def test_normalize_defaults_auto_clone_false(self):
+        raw = {"modern": {"pid": 1, "user_data_dir": "/x"}, "legacy": 999}
+        out = ProcessCleanup._normalize_process_metadata(raw)
+        assert out["modern"]["auto_clone"] is False
+        assert out["legacy"]["auto_clone"] is False


### PR DESCRIPTION
## Problem

Auto-clones — profiles copied from `master` whenever master is busy — were **never cleaned up**. Every spawn re-copies from master/snapshot and left the previous clone behind under `sessions/`, accumulating dead weight. Root cause: every spawn passes a `user_data_dir`, so all profiles are flagged `uses_custom_data_dir=True`, and `_cleanup_profile_for_metadata` bails out for those — on close the clone was *untracked without its directory being deleted*.

## Fix

Introduce an internal `auto_clone` flag, set by the server from the resolved profile role (`role == "clone"`) and plumbed into the tracked process metadata. It is **never a caller/AI-facing parameter**.

- `_cleanup_profile_for_metadata` now deletes auto-clones while still protecting `master`, the snapshot, and explicit named profiles.
- A new `_should_untrack_after_cleanup` helper keeps an auto-clone tracked until its directory is *actually* removed, so a Windows-locked delete is retried by the existing deferred/recovery machinery instead of leaking. Named/master/temp untrack behavior is unchanged.
- Because every close path (explicit `close_instance`, idle-timeout reaper, MCP shutdown, startup crash recovery) funnels through this one layer, clones are reclaimed everywhere with no new call sites.

Fully automatic and invisible: the AI keeps calling `spawn_browser` exactly as before and never manages cleanup.

### Named-profile guardrail
The `user_data_dir` tool doc now warns it is a deliberate, **non-auto-cleaned**, space-consuming action to be used only on explicit user request, and a runtime `warning` is surfaced in `spawn_diagnostics` whenever a named profile is created.

## Design notes
- **No data-loss risk (structural):** deletion is gated on `auto_clone`; master/snapshot/named profiles are excluded. `_cleanup_profile_dir` also refuses any directory with a live browser, so a clone is only ever deleted after its browser is dead.
- **Kept cleanup synchronous (deliberate):** an earlier idea to thread the `rmtree` was dropped — it would race the idle reaper on the shared `browser_processes`/PID-file state (today safe only because all cleanup runs on the event loop thread). `close_instance` already blocks the loop with a synchronous `psutil` scan, so a synchronous `rmtree` is consistent, not a new category.
- **Out of scope:** the global PID file (`~/.stealth_browser_pids.json`) can let a second server's startup recovery touch a first server's browsers — pre-existing and unchanged here (only disposable clones are affected; named/master are never deleted).

## Tests
- 13 new unit tests: cleanup eligibility, untrack policy, metadata round-trip.
- 2 new real-browser integration tests: a clone is deleted on close while master and named profiles survive.
- Full suite green: **197 unit, 13 integration**.