### PR TITLE
fix: remove redundant force-include that broke the wheel build (uvx -32000)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/stealth_chrome_devtools_mcp"]
-
-[tool.hatch.build.targets.wheel.force-include]
-"src/stealth_chrome_devtools_mcp/embedded/js" = "stealth_chrome_devtools_mcp/embedded/js"
+# NOTE: do not add a force-include for embedded/js here. Those files are tracked
+# and live inside the package, so `packages` already bundles them; force-including
+# the same path makes hatchling fail the wheel build with a duplicate-file error
+# (which only surfaces when uvx/pip builds the wheel, not under `uv run`).

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,44 @@
+"""Guards the wheel build — the uvx/pip install path that `uv run` and the rest
+of the suite bypass.
+
+Regression test for a hatchling `force-include` that duplicated package files
+already covered by `packages`, breaking `build_wheel` with a duplicate-file
+error. That made `uvx --from git+...` fail to start the server (JSON-RPC -32000)
+even though every source-run test still passed.
+"""
+import shutil
+import subprocess
+import zipfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_wheel_builds_and_bundles_runtime_js(tmp_path):
+    """The wheel must build cleanly and still contain the embedded js assets."""
+    uv = shutil.which("uv")
+    if uv is None:
+        pytest.skip("uv not available to build the wheel")
+
+    result = subprocess.run(
+        [uv, "build", "--wheel", "--out-dir", str(tmp_path)],
+        cwd=str(ROOT),
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert result.returncode == 0, (
+        "wheel build failed — this is exactly what breaks `uvx`/`pip install`:\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+
+    wheels = list(tmp_path.glob("*.whl"))
+    assert len(wheels) == 1, f"expected exactly one wheel, got {wheels}"
+
+    names = zipfile.ZipFile(wheels[0]).namelist()
+    js_assets = [n for n in names if n.endswith(".js")]
+    assert any(
+        n.endswith("embedded/js/comprehensive_element_extractor.js") for n in js_assets
+    ), f"runtime js assets missing from the wheel: {js_assets}"


### PR DESCRIPTION
## Symptom
`/mcp` reconnect failed with **JSON-RPC -32000** — the server would not start.

## Root cause
`uvx --from git+...` builds a **wheel** from git. `embedded/js/*.js` were added twice:
- once by `packages = ["src/stealth_chrome_devtools_mcp"]` (the files are tracked and live inside the package), and
- again by `[tool.hatch.build.targets.wheel.force-include]` mapping the same path.

Hatchling rejects the duplicate (`A second file is being added to the wheel archive at the same path: .../comprehensive_element_extractor.js`) → `build_wheel` fails → no server → -32000.

This is a **pre-existing latent bug** in the build config (predates PR #3 — I never touched `pyproject.toml`). Merging #3 created a new commit, which forced `uvx` to rebuild the wheel and surfaced it. **`uv run` and the entire pytest suite run from source and never build a wheel**, and CI builds no wheel either — so everything stayed green while the real install path was broken.

## Fix
Drop the redundant `force-include` (`packages` already bundles the js assets). Verified the built wheel still contains all 7 js files.

## Regression guard
`tests/test_packaging.py` builds the wheel and asserts it succeeds **and** contains the runtime js assets. Runs in the unit lane, so CI now catches wheel-build breakage — closing the gap that let this through.

## Verification
- `uv build --wheel` succeeds locally; wheel contains all 7 `embedded/js/*.js`.
- **Real `uvx --refresh --from git+ssh://...@fix/wheel-build-force-include` builds, starts, and returns all 96 tools** over a stdio handshake (exit 0).
- Unit suite: **198 passed** (incl. new packaging test), 16 integration deselected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
