### PR TITLE
Fix: use CDP mouse events for isTrusted click detection

### DIFF
--- a/src/stealth_chrome_devtools_mcp/embedded/dom_handler.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/dom_handler.py
@@ -193,9 +193,9 @@ class DOMHandler:
             await asyncio.sleep(0.5)
 
             try:
-                await element.click()
-            except Exception:
                 await element.mouse_click()
+            except Exception:
+                await element.click()
 
             return True
 


### PR DESCRIPTION
## Summary
- Swaps `element.click()` and `element.mouse_click()` priority in `click_element`
- `element.click()` uses JS `(el) => el.click()` via `Runtime.callFunctionOn` → `isTrusted: false`
- `element.mouse_click()` uses CDP `Input.dispatchMouseEvent` → `isTrusted: true`

This fixes all three detection vectors reported in #7:
1. `isTrusted` check on click events
2. Anonymous stack trace detection
3. `HTMLElement.prototype.click` override detection

Fixes #7