### PR TITLE
perf: fix startup disconnects, slow teardown, and bloated profile clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ C:\stealth-mcp-browser-sessions\
 4. Clones carry all cookies, logins, and session data
 5. Stale snapshots are auto-refreshed when auth files change
 
+Clones exclude regenerable Chrome caches, so each is a few MB rather than
+multiple GB. Disposable auto-clones are deleted on close, and a storage cap
+(`STEALTH_MCP_CLONE_STORAGE_CAP_GB`, default 10 GB) reclaims the oldest **idle**
+clones if any ever leak — so `sessions/` stays bounded. Named profiles you
+create explicitly (e.g. `github-session`) persist and are never auto-deleted.
+
 ### Stealth Arg Filtering
 
 The server automatically strips Chrome flags that would compromise stealth:
@@ -180,6 +186,7 @@ All optional. Defaults work for normal use.
 | `BROWSER_MASTER_SNAPSHOT_DIR` | `<root>/master-snapshot` | Snapshot clone source |
 | `BROWSER_PROFILE_CLONE_ROOT` | `<root>/sessions` | Folder for profile copies |
 | `BROWSER_PROFILE_REFRESH_DAYS` | `7` | Refresh copies after N days (`0` = disable) |
+| `STEALTH_MCP_CLONE_STORAGE_CAP_GB` | `10` | Cap on total auto-clone storage; oldest **idle** clones are reclaimed when exceeded (`0` = disable). Named profiles and in-use clones are never touched. |
 | `BROWSER_IDLE_TIMEOUT` | `0` | Idle cleanup timeout (`0` = disabled) |
 | `STEALTH_CHROME_PROFILE_KEY` | unset | Force a stable clone key |
 | `STEALTH_BROWSER_DEBUG` | `false` | Enable debug logging |

--- a/README.md
+++ b/README.md
@@ -99,8 +99,15 @@ C:\stealth-mcp-browser-sessions\
 Clones exclude regenerable Chrome caches, so each is a few MB rather than
 multiple GB. Disposable auto-clones are deleted on close, and a storage cap
 (`STEALTH_MCP_CLONE_STORAGE_CAP_GB`, default 10 GB) reclaims the oldest **idle**
-clones if any ever leak — so `sessions/` stays bounded. Named profiles you
-create explicitly (e.g. `github-session`) persist and are never auto-deleted.
+clones if any ever leak — so `sessions/` stays bounded.
+
+Named profiles you create explicitly (e.g. `github-session`) persist and are
+never deleted. But even a "persistent" profile is ~98% regenerable (caches plus
+Chrome's multi-GB on-device AI model). So when `sessions/` exceeds
+`STEALTH_MCP_SESSION_STORAGE_CAP_GB` (default 20 GB), the largest **idle** named
+profiles are trimmed of those regenerable dirs while **every login is
+preserved** — Chrome rebuilds them on next launch. In-use profiles are never
+touched.
 
 ### Stealth Arg Filtering
 
@@ -187,6 +194,7 @@ All optional. Defaults work for normal use.
 | `BROWSER_PROFILE_CLONE_ROOT` | `<root>/sessions` | Folder for profile copies |
 | `BROWSER_PROFILE_REFRESH_DAYS` | `7` | Refresh copies after N days (`0` = disable) |
 | `STEALTH_MCP_CLONE_STORAGE_CAP_GB` | `10` | Cap on total auto-clone storage; oldest **idle** clones are reclaimed when exceeded (`0` = disable). Named profiles and in-use clones are never touched. |
+| `STEALTH_MCP_SESSION_STORAGE_CAP_GB` | `20` | Cap on total `sessions/` storage; when exceeded, the largest **idle** named profiles are trimmed of regenerable cache/model dirs — logins kept (`0` = disable). |
 | `BROWSER_IDLE_TIMEOUT` | `0` | Idle cleanup timeout (`0` = disabled) |
 | `STEALTH_CHROME_PROFILE_KEY` | unset | Force a stable clone key |
 | `STEALTH_BROWSER_DEBUG` | `false` | Enable debug logging |

--- a/src/stealth_chrome_devtools_mcp/embedded/browser_manager.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/browser_manager.py
@@ -639,32 +639,43 @@ class BrowserManager:
                         f"Failed to close tabs for {instance_id}: {tabs_err}",
                     )
 
-                try:
-                    import asyncio
-                    if hasattr(browser, 'connection') and browser.connection:
-                        asyncio.get_event_loop().create_task(browser.connection.disconnect())
-                        debug_logger.log_info("browser_manager", "close_connection", "closed connection using get_event_loop().create_task()")
-                except RuntimeError:
-                    try:
-                        import asyncio
-                        if hasattr(browser, 'connection') and browser.connection:
-                            await asyncio.wait_for(browser.connection.disconnect(), timeout=2.0)
-                            debug_logger.log_info("browser_manager", "close_connection", "closed connection with direct await and timeout")
-                    except (asyncio.TimeoutError, Exception) as e:
-                        debug_logger.log_info("browser_manager", "close_connection", f"connection disconnect failed or timed out: {e}")
-                        pass
-                except Exception as e:
-                    debug_logger.log_info("browser_manager", "close_connection", f"connection disconnect failed: {e}")
-                    pass
-
+                # Graceful shutdown FIRST, while the CDP websocket is still
+                # live: Browser.close lets Chrome flush session state (cookies,
+                # Local Storage, logins) to disk before it exits. Bounded so a
+                # missing response can never stall teardown.
+                #
+                # Order matters. Disconnecting first (the old behaviour) closed
+                # the websocket, so nodriver's send() silently reconnected and
+                # then awaited a reply the dying browser never sends — hanging
+                # for the whole 5s wait_for budget and making every close 6-8s.
                 try:
                     import nodriver.cdp.browser as cdp_browser
-                    if hasattr(browser, 'connection') and browser.connection:
-                        await browser.connection.send(cdp_browser.close())
-                except Exception as cdp_err:
-                    debug_logger.log_warning(
+                    if getattr(browser, "connection", None) and not browser.connection.closed:
+                        await asyncio.wait_for(
+                            browser.connection.send(cdp_browser.close()),
+                            timeout=2.0,
+                        )
+                except (asyncio.TimeoutError, Exception) as cdp_err:
+                    debug_logger.log_info(
                         "browser_manager", "close_instance",
-                        f"CDP browser.close() failed for {instance_id}: {cdp_err}",
+                        f"CDP browser.close() skipped for {instance_id}: {cdp_err}",
+                    )
+
+                # Then tear down the websocket connection itself, bounded so a
+                # half-dead socket cannot hang the close either.
+                try:
+                    if getattr(browser, "connection", None):
+                        await asyncio.wait_for(
+                            browser.connection.disconnect(), timeout=2.0
+                        )
+                        debug_logger.log_info(
+                            "browser_manager", "close_connection",
+                            "closed websocket connection",
+                        )
+                except (asyncio.TimeoutError, Exception) as e:
+                    debug_logger.log_info(
+                        "browser_manager", "close_connection",
+                        f"connection disconnect failed or timed out: {e}",
                     )
 
                 try:

--- a/src/stealth_chrome_devtools_mcp/embedded/process_cleanup.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/process_cleanup.py
@@ -279,12 +279,16 @@ class ProcessCleanup:
             Set[str]: Normalized active browser profile directories.
         """
         active_profile_dirs: Set[str] = set()
-        for process in psutil.process_iter(["name", "cmdline"]):
+        # Enumerate only the cheap `name` field for every process; reading
+        # `cmdline` for the whole process table is the dominant cost on Windows
+        # (one PEB read per process). Pull cmdline lazily for the handful of
+        # browser-named processes only.
+        for process in psutil.process_iter(["name"]):
             try:
                 process_name = process.info.get("name") or ""
                 if not self._is_browser_process_name(process_name):
                     continue
-                cmdline = process.info.get("cmdline") or []
+                cmdline = process.cmdline() or []
                 profile_dir = self._extract_profile_dir_from_cmdline(cmdline)
                 if profile_dir:
                     active_profile_dirs.add(profile_dir)
@@ -313,12 +317,14 @@ class ProcessCleanup:
             return set()
 
         matching_pids: Set[int] = set()
-        for process in psutil.process_iter(["pid", "name", "cmdline"]):
+        # See _get_active_browser_profile_dirs: enumerate cheap `name`/`pid`
+        # only and read the expensive `cmdline` lazily for browser processes.
+        for process in psutil.process_iter(["pid", "name"]):
             try:
                 process_name = process.info.get("name") or ""
                 if not self._is_browser_process_name(process_name):
                     continue
-                cmdline = process.info.get("cmdline") or []
+                cmdline = process.cmdline() or []
                 profile_dir = self._extract_profile_dir_from_cmdline(cmdline)
                 if profile_dir == normalized_profile_dir:
                     matching_pids.add(process.info["pid"])

--- a/src/stealth_chrome_devtools_mcp/embedded/server.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/server.py
@@ -287,6 +287,114 @@ def _profile_has_running_browser(profile_dir: Path) -> bool:
     )
 
 
+def _clone_storage_cap_bytes() -> int:
+    """Cap (in bytes) on total auto-clone storage under the clone root.
+
+    Default 10 GiB; override with ``STEALTH_MCP_CLONE_STORAGE_CAP_GB``. A value
+    <= 0 disables the cap entirely. Only disposable auto-clones count against
+    this — user-named/explicit profiles are never measured or reclaimed.
+    """
+    gb = parse_float_env("STEALTH_MCP_CLONE_STORAGE_CAP_GB", 10.0)
+    if gb <= 0:
+        return 0
+    return int(gb * (1024 ** 3))
+
+
+def _dir_size_bytes(path: Path) -> int:
+    total = 0
+    for root, _dirs, files in os.walk(path):
+        for name in files:
+            try:
+                total += (Path(root) / name).stat().st_size
+            except OSError:
+                pass
+    return total
+
+
+def _clone_is_auto(clone_dir: Path) -> bool:
+    """True only for server-created disposable auto-clones.
+
+    Never true for user-named/explicit profiles (they persist by design) or for
+    directories the server did not create (no clone marker). The marker carries
+    an explicit ``auto_clean`` flag; markers written before that flag existed
+    fall back to the source-kind heuristic (explicit profiles use an
+    ``explicit-*`` source kind).
+    """
+    marker = clone_dir / ".stealth_chrome_devtools_mcp_clone.json"
+    if not marker.exists():
+        return False
+    try:
+        data = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    if "auto_clean" in data:
+        return bool(data["auto_clean"])
+    return not str(data.get("source_kind", "")).startswith("explicit")
+
+
+def _enforce_clone_storage_cap_in(clone_root: Path, cap_bytes: int, reason: str = "") -> int:
+    """Reclaim the oldest idle auto-clones until total auto-clone storage under
+    ``clone_root`` is within ``cap_bytes``. Returns the number of dirs removed.
+
+    Safety invariants (this is the backstop that turns "grows slower" into
+    "provably bounded"):
+      * Named/explicit profiles and unmarked directories are never touched.
+      * A clone a live browser is currently using is never deleted.
+      * Deletion is oldest-first (by mtime), so the freshest sessions survive.
+    ``cap_bytes <= 0`` disables the sweep.
+    """
+    if cap_bytes <= 0 or not clone_root.exists():
+        return 0
+
+    autos = []  # (mtime, size, path, is_running)
+    total = 0
+    try:
+        entries = list(clone_root.iterdir())
+    except OSError:
+        return 0
+    for entry in entries:
+        try:
+            if not entry.is_dir() or not _clone_is_auto(entry):
+                continue
+            size = _dir_size_bytes(entry)
+            mtime = entry.stat().st_mtime
+        except OSError:
+            continue
+        total += size
+        autos.append((mtime, size, entry, _profile_has_running_browser(entry)))
+
+    if total <= cap_bytes:
+        return 0
+
+    removed = 0
+    for _mtime, size, entry, is_running in sorted(autos, key=lambda item: item[0]):
+        if total <= cap_bytes:
+            break
+        if is_running:
+            continue  # never evict a live session to satisfy the cap
+        _rmtree_robust(entry)
+        if not entry.exists():
+            total -= size
+            removed += 1
+            debug_logger.log_info(
+                "server",
+                "clone_cap_sweep",
+                f"reclaimed auto-clone {entry.name} ({size} bytes) reason={reason}",
+            )
+    return removed
+
+
+def _enforce_clone_storage_cap(reason: str = "") -> int:
+    """Apply the configured cap to the live clone root (thin runtime wrapper)."""
+    try:
+        return _enforce_clone_storage_cap_in(
+            _clone_root_dir(), _clone_storage_cap_bytes(), reason
+        )
+    except Exception as error:  # never let housekeeping break a spawn/startup
+        debug_logger.log_warning("server", "clone_cap_sweep", f"sweep failed: {error}")
+        return 0
+
+
 def _profile_ignore_names(directory: str, names: List[str]) -> set:
     volatile_names = {
         "BrowserMetrics",
@@ -440,6 +548,9 @@ def _copy_profile_tree(source: Path, target: Path, clone_root: Path, source_kind
         "source": str(source),
         "source_kind": source_kind,
         "created_at": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        # Disposable auto-clones may be reclaimed by the storage-cap sweep;
+        # explicit/named profiles (explicit-* source kinds) never are.
+        "auto_clean": not str(source_kind).startswith("explicit"),
     }
     (target / ".stealth_chrome_devtools_mcp_clone.json").write_text(
         json.dumps(marker, indent=2),
@@ -666,6 +777,10 @@ async def _resolve_profile_selection(
     base_clone = await _clone_profile_dir_for_session(clone_root)
     clone = _unique_clone_dir(base_clone, clone_suffix) if clone_suffix else _available_clone_dir(base_clone)
     clone_root.mkdir(parents=True, exist_ok=True)
+    # Backstop against unbounded session bloat: before adding another clone,
+    # reclaim the oldest idle auto-clones if storage is over the cap. The clone
+    # we are about to write has no marker yet, so it is never a sweep target.
+    await asyncio.to_thread(_enforce_clone_storage_cap, "pre-clone")
     if _profile_has_running_browser(clone):
         clone = _unique_clone_dir(base_clone, clone_suffix or "busy")
 
@@ -762,6 +877,13 @@ async def app_lifespan(server):
     debug_logger.log_info("server", "startup", "Starting Browser Automation MCP Server...")
     try:
         await browser_manager.start_idle_reaper()
+        # Reclaim any auto-clones that leaked past the cap on a previous run
+        # (e.g. a delete that lost a Windows file-lock race, or a backend that
+        # was killed before close). Fire-and-forget so a large first sweep never
+        # delays server readiness; the local ref keeps the task from being GC'd.
+        _startup_clone_sweep = asyncio.create_task(
+            asyncio.to_thread(_enforce_clone_storage_cap, "startup")
+        )
         yield
     finally:
         debug_logger.log_info("server", "shutdown", "Shutting down Browser Automation MCP Server...")

--- a/src/stealth_chrome_devtools_mcp/embedded/server.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/server.py
@@ -305,6 +305,20 @@ def _profile_ignore_names(directory: str, names: List[str]) -> set:
         "SingletonLock",
         "SingletonSocket",
         "component_crx_cache",
+        # Heavy, regenerable caches — typically ~98% of a Chrome profile by
+        # size. Excluding them turns a multi-GB profile clone into a few-MB
+        # copy of real session state (cookies, logins, Web Data, Local
+        # Storage, Preferences). Chrome rebuilds all of these on next launch.
+        "Cache",
+        "Code Cache",
+        "Service Worker",
+        "blob_storage",
+        "Download Service",
+        "extensions_crx_cache",
+        "optimization_guide_model_store",
+        "optimization_guide_hint_cache_store",
+        "OptGuideOnDeviceModel",
+        "OptGuideOnDeviceClassifierModel",
     }
     ignored = set()
     for name in names:

--- a/src/stealth_chrome_devtools_mcp/embedded/server.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/server.py
@@ -287,6 +287,45 @@ def _profile_has_running_browser(profile_dir: Path) -> bool:
     )
 
 
+# Regenerable Chrome profile subdirectories — caches and on-device model stores
+# that Chrome rebuilds on next launch. Single source of truth: these are both
+# excluded when cloning a profile (_profile_ignore_names) and trimmed from idle
+# profiles under storage pressure (_trim_profile_regenerable), so the clone path
+# and the trim path can never drift apart.
+_REGENERABLE_PROFILE_NAMES = frozenset({
+    "BrowserMetrics",
+    "CertificateRevocation",
+    "Crashpad",
+    "Crash Reports",
+    "DawnCache",
+    "GPUCache",
+    "GrShaderCache",
+    "GraphiteDawnCache",
+    "LOCK",
+    "lockfile",
+    "Safe Browsing",
+    "ShaderCache",
+    "SingletonCookie",
+    "SingletonLock",
+    "SingletonSocket",
+    "component_crx_cache",
+    # Heavy, regenerable caches and on-device AI models — typically ~98% of a
+    # Chrome profile by size (the on-device model alone can be ~4 GB). Excluding
+    # or trimming them leaves only real session state: cookies, logins, Web
+    # Data, Local Storage, Preferences. Chrome rebuilds them all on next launch.
+    "Cache",
+    "Code Cache",
+    "Service Worker",
+    "blob_storage",
+    "Download Service",
+    "extensions_crx_cache",
+    "optimization_guide_model_store",
+    "optimization_guide_hint_cache_store",
+    "OptGuideOnDeviceModel",
+    "OptGuideOnDeviceClassifierModel",
+})
+
+
 def _clone_storage_cap_bytes() -> int:
     """Cap (in bytes) on total auto-clone storage under the clone root.
 
@@ -384,55 +423,176 @@ def _enforce_clone_storage_cap_in(clone_root: Path, cap_bytes: int, reason: str 
     return removed
 
 
-def _enforce_clone_storage_cap(reason: str = "") -> int:
-    """Apply the configured cap to the live clone root (thin runtime wrapper)."""
-    try:
-        return _enforce_clone_storage_cap_in(
-            _clone_root_dir(), _clone_storage_cap_bytes(), reason
-        )
-    except Exception as error:  # never let housekeeping break a spawn/startup
-        debug_logger.log_warning("server", "clone_cap_sweep", f"sweep failed: {error}")
+def _session_storage_cap_bytes() -> int:
+    """Cap (in bytes) on total clone-root storage before idle *named* profiles
+    are trimmed of regenerable data. Default 20 GiB; override with
+    ``STEALTH_MCP_SESSION_STORAGE_CAP_GB`` (a value <= 0 disables the trim).
+    """
+    gb = parse_float_env("STEALTH_MCP_SESSION_STORAGE_CAP_GB", 20.0)
+    if gb <= 0:
         return 0
+    return int(gb * (1024 ** 3))
+
+
+def _clone_is_named(clone_dir: Path) -> bool:
+    """True for user-named/explicit profiles (the persistent ones). They are
+    never deleted, but they *can* be trimmed of regenerable data when idle."""
+    marker = clone_dir / ".stealth_chrome_devtools_mcp_clone.json"
+    if not marker.exists():
+        return False
+    try:
+        data = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    if "auto_clean" in data:
+        return not bool(data["auto_clean"])
+    return str(data.get("source_kind", "")).startswith("explicit")
+
+
+def _trim_profile_regenerable(profile_dir: Path) -> int:
+    """Delete regenerable cache/model subdirectories from an idle profile while
+    preserving every session-state file (cookies, logins, Web Data, Local
+    Storage, Preferences). Returns the number of bytes freed.
+
+    Removes only directories named in ``_REGENERABLE_PROFILE_NAMES`` — the same
+    set the clone path excludes — at the profile root and one level down
+    (``Default/``, ``Profile N/``), which is where Chrome keeps its caches and
+    on-device model stores. Never recurses deeper, so session-state dirs such as
+    ``Local Storage`` and ``IndexedDB`` are always left intact.
+    """
+    freed = 0
+
+    def _trim_level(directory: Path) -> None:
+        nonlocal freed
+        try:
+            children = list(directory.iterdir())
+        except OSError:
+            return
+        for child in children:
+            try:
+                if child.is_dir() and child.name in _REGENERABLE_PROFILE_NAMES:
+                    size = _dir_size_bytes(child)
+                    _rmtree_robust(child)
+                    if not child.exists():
+                        freed += size
+            except OSError:
+                continue
+
+    _trim_level(profile_dir)
+    try:
+        subdirs = [
+            c for c in profile_dir.iterdir()
+            if c.is_dir() and c.name not in _REGENERABLE_PROFILE_NAMES
+        ]
+    except OSError:
+        subdirs = []
+    for sub in subdirs:
+        _trim_level(sub)
+    return freed
+
+
+def _enforce_named_profile_trim_in(clone_root: Path, cap_bytes: int, reason: str = "") -> int:
+    """Trim regenerable data from the largest idle named profiles under
+    ``clone_root`` until total clone-root storage is within ``cap_bytes``.
+    Returns the number of bytes freed.
+
+    Only user-named/explicit profiles are trimmed — auto-clones are the
+    clone-cap sweep's job and unmarked dirs are left alone. In-use profiles are
+    never touched, and only regenerable dirs are removed, so every login
+    survives. ``cap_bytes <= 0`` disables the trim.
+    """
+    if cap_bytes <= 0 or not clone_root.exists():
+        return 0
+
+    sized = []
+    total = 0
+    try:
+        entries = list(clone_root.iterdir())
+    except OSError:
+        return 0
+    for entry in entries:
+        try:
+            if not entry.is_dir():
+                continue
+            size = _dir_size_bytes(entry)
+        except OSError:
+            continue
+        total += size
+        sized.append((size, entry))
+
+    if total <= cap_bytes:
+        return 0
+
+    freed_total = 0
+    for size, entry in sorted(sized, key=lambda item: item[0], reverse=True):  # largest first
+        if total <= cap_bytes:
+            break
+        if not _clone_is_named(entry):
+            continue  # auto-clones -> clone-cap sweep; unmarked -> leave alone
+        if _profile_has_running_browser(entry):
+            continue  # never trim a profile a live browser is using
+        freed = _trim_profile_regenerable(entry)
+        if freed:
+            total -= freed
+            freed_total += freed
+            debug_logger.log_info(
+                "server",
+                "profile_trim",
+                f"trimmed {freed} bytes of regenerable data from {entry.name} reason={reason}",
+            )
+    return freed_total
+
+
+def _enforce_session_storage(reason: str = "") -> None:
+    """Bound clone-root storage: delete idle auto-clones over the clone cap,
+    then trim regenerable data from the largest idle named profiles over the
+    session cap. Best-effort; never raises into a spawn or startup."""
+    try:
+        clone_root = _clone_root_dir()
+        _enforce_clone_storage_cap_in(clone_root, _clone_storage_cap_bytes(), reason)
+        _enforce_named_profile_trim_in(clone_root, _session_storage_cap_bytes(), reason)
+    except Exception as error:
+        debug_logger.log_warning("server", "session_storage_sweep", f"sweep failed: {error}")
+
+
+# Strong refs to in-flight housekeeping sweeps so the event loop cannot GC them
+# mid-run; the done-callback drops each when it finishes.
+_BACKGROUND_SWEEPS: set = set()
+
+
+def _spawn_background_sweep(reason: str = "") -> None:
+    """Kick the storage sweep off the event loop without blocking the caller.
+
+    The clone root and caps are resolved now, at trigger time, and captured for
+    the worker — so the sweep always targets the root that was active when it was
+    triggered (this also keeps it hermetic when tests patch the env to a tmp
+    dir). Deduped to one in-flight sweep, since sizing the clone root is the only
+    real cost and running it concurrently with itself buys nothing.
+    """
+    if _BACKGROUND_SWEEPS:
+        return
+    clone_root = _clone_root_dir()
+    clone_cap = _clone_storage_cap_bytes()
+    session_cap = _session_storage_cap_bytes()
+
+    def _run() -> None:
+        try:
+            _enforce_clone_storage_cap_in(clone_root, clone_cap, reason)
+            _enforce_named_profile_trim_in(clone_root, session_cap, reason)
+        except Exception as error:
+            debug_logger.log_warning("server", "session_storage_sweep", f"sweep failed: {error}")
+
+    task = asyncio.create_task(asyncio.to_thread(_run))
+    _BACKGROUND_SWEEPS.add(task)
+    task.add_done_callback(_BACKGROUND_SWEEPS.discard)
 
 
 def _profile_ignore_names(directory: str, names: List[str]) -> set:
-    volatile_names = {
-        "BrowserMetrics",
-        "CertificateRevocation",
-        "Crashpad",
-        "Crash Reports",
-        "DawnCache",
-        "GPUCache",
-        "GrShaderCache",
-        "GraphiteDawnCache",
-        "LOCK",
-        "lockfile",
-        "Safe Browsing",
-        "ShaderCache",
-        "SingletonCookie",
-        "SingletonLock",
-        "SingletonSocket",
-        "component_crx_cache",
-        # Heavy, regenerable caches — typically ~98% of a Chrome profile by
-        # size. Excluding them turns a multi-GB profile clone into a few-MB
-        # copy of real session state (cookies, logins, Web Data, Local
-        # Storage, Preferences). Chrome rebuilds all of these on next launch.
-        "Cache",
-        "Code Cache",
-        "Service Worker",
-        "blob_storage",
-        "Download Service",
-        "extensions_crx_cache",
-        "optimization_guide_model_store",
-        "optimization_guide_hint_cache_store",
-        "OptGuideOnDeviceModel",
-        "OptGuideOnDeviceClassifierModel",
-    }
     ignored = set()
     for name in names:
         lower = name.lower()
         if (
-            name in volatile_names
+            name in _REGENERABLE_PROFILE_NAMES
             or name.startswith("Singleton")
             or lower.endswith(".tmp")
             or lower.endswith(".lock")
@@ -777,10 +937,12 @@ async def _resolve_profile_selection(
     base_clone = await _clone_profile_dir_for_session(clone_root)
     clone = _unique_clone_dir(base_clone, clone_suffix) if clone_suffix else _available_clone_dir(base_clone)
     clone_root.mkdir(parents=True, exist_ok=True)
-    # Backstop against unbounded session bloat: before adding another clone,
-    # reclaim the oldest idle auto-clones if storage is over the cap. The clone
-    # we are about to write has no marker yet, so it is never a sweep target.
-    await asyncio.to_thread(_enforce_clone_storage_cap, "pre-clone")
+    # Backstop against unbounded session bloat: kick a background sweep (delete
+    # idle auto-clones over the clone cap; trim idle named profiles over the
+    # session cap) before adding another clone. Non-blocking so spawns stay
+    # fast; the clone we are about to write has no marker yet, so it is never a
+    # sweep target.
+    _spawn_background_sweep("pre-clone")
     if _profile_has_running_browser(clone):
         clone = _unique_clone_dir(base_clone, clone_suffix or "busy")
 
@@ -877,13 +1039,10 @@ async def app_lifespan(server):
     debug_logger.log_info("server", "startup", "Starting Browser Automation MCP Server...")
     try:
         await browser_manager.start_idle_reaper()
-        # Reclaim any auto-clones that leaked past the cap on a previous run
-        # (e.g. a delete that lost a Windows file-lock race, or a backend that
-        # was killed before close). Fire-and-forget so a large first sweep never
-        # delays server readiness; the local ref keeps the task from being GC'd.
-        _startup_clone_sweep = asyncio.create_task(
-            asyncio.to_thread(_enforce_clone_storage_cap, "startup")
-        )
+        # Reclaim leaked auto-clones and trim oversized idle named profiles left
+        # by a previous run. Fire-and-forget so a large first sweep never delays
+        # server readiness.
+        _spawn_background_sweep("startup")
         yield
     finally:
         debug_logger.log_info("server", "shutdown", "Shutting down Browser Automation MCP Server...")

--- a/src/stealth_chrome_devtools_mcp/embedded/singleton.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/singleton.py
@@ -18,6 +18,7 @@ import os
 import socket
 import subprocess
 import sys
+import threading
 import time
 from contextlib import contextmanager
 from pathlib import Path
@@ -32,6 +33,11 @@ LOCK_FILE = STATE_DIR / "singleton.lock"
 PORT_FILE = STATE_DIR / "server.port"
 DEFAULT_PORT = 19222
 STARTUP_TIMEOUT = 30
+SERVER_NAME = "stealth-chrome-devtools-mcp"
+# How long the stdio proxy will wait for the backend before later requests
+# (tools/list, tool calls) start failing. The `initialize` handshake itself is
+# answered locally and never waits on this.
+BACKEND_READY_TIMEOUT = 120.0
 
 
 def _ensure_state_dir():
@@ -127,52 +133,226 @@ def _wait_for_server(port: int, timeout: int = STARTUP_TIMEOUT) -> bool:
     return False
 
 
+def _backend_http_url(port: int) -> str:
+    return f"http://127.0.0.1:{port}/mcp/"
+
+
+def _server_version() -> str:
+    try:
+        from importlib.metadata import version
+
+        return version(SERVER_NAME)
+    except Exception:
+        return "0.0.0"
+
+
+def _start_backend_holding_lock(port: int) -> None:
+    """Start the singleton backend exactly once, holding the lock until it is
+    healthy so no other session double-starts it.
+
+    Runs in a daemon thread so it never blocks the stdio handshake. The lock is
+    held for the whole backend cold start: any session that loses the lock race
+    simply proxies to the backend the winner is bringing up.
+    """
+    try:
+        with _exclusive_lock() as got_lock:
+            if not got_lock:
+                return  # another session owns startup; just proxy to it
+            if _find_running_server() is not None:
+                return  # already up
+            _start_server_process(port)
+            _wait_for_server(port)  # keep the lock until the socket is bound
+    except Exception:
+        pass  # best-effort; the proxy still answers initialize and retries
+
+
 def ensure_server_running(port: int = DEFAULT_PORT) -> int | None:
-    """Ensure a singleton HTTP server is running. Returns port or None."""
+    """Ensure the singleton backend is up or coming up, WITHOUT blocking.
+
+    Returns the port to proxy to immediately. Unlike a blocking wait, this never
+    delays the stdio ``initialize`` handshake behind the backend's cold start —
+    the proxy answers ``initialize`` locally and only later requests wait for the
+    backend. That decoupling is what keeps Claude Code's 30s connection timeout
+    from firing under load / on a cold cache.
+    """
     existing = _find_running_server()
     if existing is not None:
         return existing
 
-    with _exclusive_lock() as got_lock:
-        if got_lock:
-            existing = _find_running_server()
-            if existing is not None:
-                return existing
-            _start_server_process(port)
-            if _wait_for_server(port):
-                return port
-            return None
-        else:
-            if _wait_for_server(port):
-                return _find_running_server() or port
-            return None
+    threading.Thread(
+        target=_start_backend_holding_lock, args=(port,), daemon=True
+    ).start()
+    return port
+
+
+async def _await_backend_http(url: str, deadline_seconds: float = BACKEND_READY_TIMEOUT) -> bool:
+    """Poll the backend with a real ``initialize`` until it returns HTTP 200.
+
+    Stronger than a socket probe *and* than "any HTTP response": a freshly bound
+    uvicorn socket can answer (4xx) while FastMCP's MCP session manager is still
+    starting — forwarding to it then fails with ``400`` (the same class of race
+    as the old ``-32000``). Only a 200 to an ``initialize`` proves the MCP layer
+    is genuinely ready to accept the client's session.
+    """
+    import anyio
+    import httpx
+    from mcp.types import DEFAULT_NEGOTIATED_VERSION
+
+    probe = {
+        "jsonrpc": "2.0",
+        "id": 0,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": DEFAULT_NEGOTIATED_VERSION,
+            "capabilities": {},
+            "clientInfo": {"name": "readiness-probe", "version": "0"},
+        },
+    }
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+    }
+    deadline = time.monotonic() + deadline_seconds
+    interval = 0.1
+    async with httpx.AsyncClient(timeout=httpx.Timeout(10.0)) as client:
+        while time.monotonic() < deadline:
+            try:
+                resp = await client.post(url, json=probe, headers=headers)
+                if resp.status_code == 200:
+                    # Terminate the throwaway readiness session so it does not
+                    # linger on the backend (one per proxy start otherwise).
+                    session_id = resp.headers.get("mcp-session-id")
+                    if session_id:
+                        try:
+                            await client.delete(
+                                url, headers={**headers, "mcp-session-id": session_id}
+                            )
+                        except Exception:
+                            pass
+                    return True
+            except Exception:
+                pass
+            await anyio.sleep(interval)
+            interval = min(interval * 1.5, 1.0)
+    return False
+
+
+async def _proxy_streams(client_read, client_write, port: int) -> None:
+    """Answer ``initialize`` locally and instantly, then transparently proxy
+    every other message to/from the singleton HTTP backend once it is ready.
+
+    The transport plumbing (session-id capture, forwarding) is the same proven
+    stdio↔streamable-HTTP pipe used previously; the only additions are the local
+    ``initialize`` answer and swallowing the backend's duplicate ``initialize``
+    response so the client never sees two.
+    """
+    import anyio
+    from mcp.client.streamable_http import streamablehttp_client
+    from mcp.shared.message import SessionMessage
+    from mcp.types import (
+        DEFAULT_NEGOTIATED_VERSION,
+        JSONRPCMessage,
+        JSONRPCRequest,
+        JSONRPCResponse,
+    )
+
+    url = _backend_http_url(port)
+    to_backend_tx, to_backend_rx = anyio.create_memory_object_stream(1024)
+    init_request_id = {"value": None}
+    init_swallowed = {"done": False}
+    backend_initialized = anyio.Event()
+
+    async def pump_client():
+        try:
+            async for msg in client_read:
+                if isinstance(msg, Exception):
+                    continue
+                inner = msg.message.root
+                if isinstance(inner, JSONRPCRequest) and inner.method == "initialize":
+                    params = inner.params or {}
+                    proto = params.get("protocolVersion") or DEFAULT_NEGOTIATED_VERSION
+                    result = {
+                        "protocolVersion": proto,
+                        "capabilities": {"tools": {"listChanged": False}},
+                        "serverInfo": {
+                            "name": SERVER_NAME,
+                            "version": _server_version(),
+                        },
+                    }
+                    response = JSONRPCResponse(jsonrpc="2.0", id=inner.id, result=result)
+                    await client_write.send(
+                        SessionMessage(message=JSONRPCMessage(response))
+                    )
+                    init_request_id["value"] = inner.id
+                # Forward everything (including initialize) so the backend session
+                # initializes with the client's real params. Buffered until the
+                # backend connects.
+                await to_backend_tx.send(msg)
+        finally:
+            await to_backend_tx.aclose()
+
+    async def run_backend():
+        if not await _await_backend_http(url):
+            return  # backend never came up; later requests simply won't answer
+        async with streamablehttp_client(url) as (backend_read, backend_write, _):
+
+            async def to_backend():
+                # Forward the initialize first, then hold every later message
+                # until the backend's initialize response establishes the
+                # streamable-HTTP session id. streamablehttp_client dispatches
+                # requests concurrently and stamps each with the *current*
+                # session id, so sending tools/list before that id exists yields
+                # a 400. The real client gets this sequencing for free by waiting
+                # on the initialize response; we answered it locally, so we must
+                # reproduce the wait here.
+                first = await to_backend_rx.receive()
+                await backend_write.send(first)
+                inner = first.message.root
+                if isinstance(inner, JSONRPCRequest) and inner.method == "initialize":
+                    await backend_initialized.wait()
+                async for msg in to_backend_rx:
+                    await backend_write.send(msg)
+
+            async def from_backend():
+                try:
+                    async for msg in backend_read:
+                        if isinstance(msg, Exception):
+                            continue
+                        inner = msg.message.root
+                        if (
+                            not init_swallowed["done"]
+                            and init_request_id["value"] is not None
+                            and isinstance(inner, JSONRPCResponse)
+                            and inner.id == init_request_id["value"]
+                        ):
+                            init_swallowed["done"] = True
+                            backend_initialized.set()
+                            continue  # client already got a local initialize result
+                        await client_write.send(msg)
+                finally:
+                    # Never leave to_backend blocked if the backend died before
+                    # its initialize response arrived.
+                    backend_initialized.set()
+
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(to_backend)
+                tg.start_soon(from_backend)
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(pump_client)
+        tg.start_soon(run_backend)
 
 
 async def _bridge(port: int):
-    """Bridge MCP stdio ↔ HTTP using the mcp library's transports."""
-    import anyio
-    from mcp.client.streamable_http import streamablehttp_client
+    """Bind real stdio and run the fast-handshake proxy."""
     from mcp.server.stdio import stdio_server
 
-    url = f"http://127.0.0.1:{port}/mcp/"
-
-    async with stdio_server() as (stdio_read, stdio_write):
-        async with streamablehttp_client(url) as (http_read, http_write, _):
-
-            async def forward_requests():
-                async for msg in stdio_read:
-                    await http_write.send(msg)
-
-            async def forward_responses():
-                async for msg in http_read:
-                    await stdio_write.send(msg)
-
-            async with anyio.create_task_group() as tg:
-                tg.start_soon(forward_requests)
-                tg.start_soon(forward_responses)
+    async with stdio_server() as (client_read, client_write):
+        await _proxy_streams(client_read, client_write, port)
 
 
 def run_stdio_proxy(port: int):
     """Run the stdio-to-HTTP proxy (blocking)."""
-    anyio = __import__("anyio")
+    import anyio
+
     anyio.run(_bridge, port)

--- a/tests/test_browser_integration.py
+++ b/tests/test_browser_integration.py
@@ -165,6 +165,40 @@ class TestBrowserSpawnAndClose:
             await close(instance_id=iid)
 
 
+class TestClosePerformance:
+    """close_instance must be fast.
+
+    Regression guard for the teardown-ordering bug where ``close_instance``
+    disconnected the CDP websocket *before* sending the graceful
+    ``Browser.close`` command. nodriver's ``send()`` then silently reconnected
+    and awaited a response that the dying browser never returns — hanging for
+    the full 5s ``wait_for`` budget and pushing every close to 6-8s.
+
+    These are "time-tested" bounds: measured on the fixed path, with margin.
+    """
+
+    DATA_URL = "data:text/html,<h1 id='t'>close-perf</h1>"
+
+    @pytest.mark.asyncio
+    async def test_close_is_fast(self):
+        spawn = _get_fn("spawn_browser")
+        navigate = _get_fn("navigate")
+        close = _get_fn("close_instance")
+
+        result = await spawn(headless=True, **_sandbox_kwargs())
+        iid = result["instance_id"]
+        await navigate(instance_id=iid, url=self.DATA_URL)
+
+        t0 = time.monotonic()
+        await close(instance_id=iid)
+        elapsed = time.monotonic() - t0
+
+        # The old hang made this 6-8s (it blocked the entire 5s wait_for plus
+        # forced cleanup). A correct close sends Browser.close on the live
+        # connection (~1ms) and never reconnects.
+        assert elapsed < 3.0, f"close took {elapsed:.2f}s — teardown hang regressed"
+
+
 class TestNavigateAndScreenshot:
     """Navigate to a data: URL and take a screenshot."""
 

--- a/tests/test_clone_storage_cap.py
+++ b/tests/test_clone_storage_cap.py
@@ -1,0 +1,134 @@
+"""Auto-clone storage must be bounded — leaked clones can never grow without limit.
+
+Background: a clone is only made when the master profile is busy (a second
+concurrent browser). Those clones live under the clone root and are deleted on
+close. But when an on-close delete fails (Windows holding Cache files) or the
+tracking is lost (the singleton backend restarts), the clone is orphaned — and
+nothing swept the clone root and no size cap existed, so leaks accumulated to
+146 GB. The cache-exclusion fix shrank each clone ~60x but left growth unbounded.
+
+These tests pin a size-capped sweep of the clone root that:
+  - reclaims the OLDEST idle auto-clones until total storage is back under a cap,
+  - NEVER deletes user-named/explicit profiles (they persist by design),
+  - NEVER deletes a clone a live browser is currently using,
+  - NEVER deletes unmarked directories it did not create.
+
+Pure filesystem tests: no browser.
+"""
+
+import json
+import os
+
+import server
+from server import _clone_is_auto, _enforce_clone_storage_cap_in
+
+
+MARKER = ".stealth_chrome_devtools_mcp_clone.json"
+
+
+def _make_clone(root, name, *, size_bytes, source_kind="master-snapshot", auto_clean=None):
+    d = root / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "data.bin").write_bytes(b"x" * size_bytes)
+    marker = {
+        "source": "master",
+        "source_kind": source_kind,
+        "created_at": "2026-01-01T00:00:00Z",
+    }
+    if auto_clean is not None:
+        marker["auto_clean"] = auto_clean
+    (d / MARKER).write_text(json.dumps(marker), encoding="utf-8")
+    return d
+
+
+def _set_mtime(path, when):
+    os.utime(path, (when, when))
+
+
+class TestClassification:
+    def test_master_clone_is_auto(self, tmp_path):
+        d = _make_clone(tmp_path, "sess-a", size_bytes=10, source_kind="master-snapshot")
+        assert _clone_is_auto(d) is True
+
+    def test_live_master_fallback_clone_is_auto(self, tmp_path):
+        d = _make_clone(tmp_path, "sess-b", size_bytes=10, source_kind="live-master-fallback")
+        assert _clone_is_auto(d) is True
+
+    def test_explicit_named_profile_is_not_auto(self, tmp_path):
+        d = _make_clone(tmp_path, "github", size_bytes=10, source_kind="explicit-master")
+        assert _clone_is_auto(d) is False
+
+    def test_unmarked_dir_is_not_auto(self, tmp_path):
+        d = tmp_path / "mystery"
+        d.mkdir()
+        assert _clone_is_auto(d) is False
+
+    def test_explicit_auto_clean_flag_overrides_source_kind(self, tmp_path):
+        # A future explicit marker pinned auto_clean=False must win even if the
+        # source_kind heuristic would have called it an auto-clone.
+        d = _make_clone(tmp_path, "weird", size_bytes=10, source_kind="master-snapshot", auto_clean=False)
+        assert _clone_is_auto(d) is False
+
+
+class TestCapSweep:
+    def test_under_cap_is_noop(self, tmp_path):
+        _make_clone(tmp_path, "a", size_bytes=1000)
+        removed = _enforce_clone_storage_cap_in(tmp_path, cap_bytes=10_000)
+        assert removed == 0
+        assert (tmp_path / "a").exists()
+
+    def test_cap_zero_disables_sweep(self, tmp_path):
+        _make_clone(tmp_path, "a", size_bytes=10_000)
+        removed = _enforce_clone_storage_cap_in(tmp_path, cap_bytes=0)
+        assert removed == 0
+        assert (tmp_path / "a").exists()
+
+    def test_oldest_idle_autoclones_removed_until_under_cap(self, tmp_path):
+        old = _make_clone(tmp_path, "old", size_bytes=4096)
+        mid = _make_clone(tmp_path, "mid", size_bytes=4096)
+        new = _make_clone(tmp_path, "new", size_bytes=4096)
+        _set_mtime(old, 1_000)
+        _set_mtime(mid, 2_000)
+        _set_mtime(new, 3_000)
+
+        # ~12.3 KB total, cap 6 KB -> the two oldest must go, newest survives.
+        removed = _enforce_clone_storage_cap_in(tmp_path, cap_bytes=6000)
+
+        assert removed == 2
+        assert not old.exists()
+        assert not mid.exists()
+        assert new.exists()
+
+    def test_named_profiles_never_deleted_even_when_oldest_and_huge(self, tmp_path):
+        named = _make_clone(tmp_path, "github", size_bytes=20_000, source_kind="explicit-master")
+        _set_mtime(named, 1)
+        removed = _enforce_clone_storage_cap_in(tmp_path, cap_bytes=1000)
+        assert removed == 0
+        assert named.exists()
+
+    def test_running_clone_never_deleted(self, tmp_path, monkeypatch):
+        old_running = _make_clone(tmp_path, "old-running", size_bytes=8000)
+        newer_idle = _make_clone(tmp_path, "newer-idle", size_bytes=8000)
+        _set_mtime(old_running, 1_000)
+        _set_mtime(newer_idle, 2_000)
+
+        monkeypatch.setattr(
+            server,
+            "_profile_has_running_browser",
+            lambda p: str(p).endswith("old-running"),
+        )
+
+        # ~16 KB total, cap 6 KB. Oldest is the live one (protected), so the
+        # idle one is reclaimed and the sweep stops without killing the session.
+        removed = _enforce_clone_storage_cap_in(tmp_path, cap_bytes=6000)
+        assert removed == 1
+        assert old_running.exists()
+        assert not newer_idle.exists()
+
+    def test_unmarked_dirs_never_deleted(self, tmp_path):
+        mystery = tmp_path / "not-ours"
+        mystery.mkdir()
+        (mystery / "big.bin").write_bytes(b"x" * 50_000)
+        removed = _enforce_clone_storage_cap_in(tmp_path, cap_bytes=1000)
+        assert removed == 0
+        assert mystery.exists()

--- a/tests/test_profile_clone_excludes_cache.py
+++ b/tests/test_profile_clone_excludes_cache.py
@@ -1,0 +1,91 @@
+"""Profile clone must exclude regenerable cache dirs (huge, worthless to copy).
+
+A real Chrome profile is ~98% cache (Cache, Code Cache, Service Worker,
+optimization-guide ML model stores, Safe Browsing). Cloning those makes
+spawn_browser take ~40s on a 5.4 GB profile. Only ~88 MB of session state
+(cookies, logins, Web Data, Local Storage, Preferences) actually matters.
+
+These tests pin the behavior: cache dirs are skipped, session state is kept.
+No browser required.
+"""
+
+from server import _profile_ignore_names, _copy_profile_delta
+
+
+CACHE_DIRS_THAT_MUST_BE_SKIPPED = [
+    "Cache",
+    "Code Cache",
+    "Service Worker",
+    "optimization_guide_model_store",
+    "OptGuideOnDeviceModel",
+    "OptGuideOnDeviceClassifierModel",
+    "Safe Browsing",
+]
+
+SESSION_STATE_THAT_MUST_BE_KEPT = [
+    "Default",
+    "Cookies",
+    "Login Data",
+    "Web Data",
+    "Local Storage",
+    "Preferences",
+    "Network",
+]
+
+
+class TestIgnoreNamesExcludesCache:
+    def test_heavy_cache_dirs_are_ignored(self):
+        ignored = _profile_ignore_names("/fake", CACHE_DIRS_THAT_MUST_BE_SKIPPED)
+        for name in CACHE_DIRS_THAT_MUST_BE_SKIPPED:
+            assert name in ignored, f"cache dir {name!r} should be excluded from clone"
+
+    def test_session_state_names_are_kept(self):
+        ignored = _profile_ignore_names("/fake", SESSION_STATE_THAT_MUST_BE_KEPT)
+        assert ignored == set(), f"session state must never be excluded, got {ignored}"
+
+
+class TestCloneSkipsCacheKeepsState:
+    def test_copy_skips_cache_trees_but_keeps_session_state(self, tmp_path):
+        src = tmp_path / "src"
+        dst = tmp_path / "dst"
+
+        # ── heavy, regenerable caches that must NOT be cloned ──
+        for rel in (
+            "Default/Cache/Cache_Data/data_0",
+            "Default/Code Cache/js/blob",
+            "Default/Service Worker/CacheStorage/big",
+            "optimization_guide_model_store/model.bin",
+            "Default/Safe Browsing/store",
+        ):
+            f = src / rel
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_bytes(b"x" * 4096)
+
+        # ── essential session state that MUST be cloned ──
+        for rel in (
+            "Default/Cookies",
+            "Default/Network/Cookies",
+            "Default/Login Data",
+            "Default/Web Data",
+            "Default/Preferences",
+        ):
+            f = src / rel
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_bytes(b"keep")
+
+        dst.mkdir()
+        _copy_profile_delta(src, dst)
+
+        # caches excluded
+        assert not (dst / "Default" / "Cache").exists()
+        assert not (dst / "Default" / "Code Cache").exists()
+        assert not (dst / "Default" / "Service Worker").exists()
+        assert not (dst / "optimization_guide_model_store").exists()
+        assert not (dst / "Default" / "Safe Browsing").exists()
+
+        # session state preserved
+        assert (dst / "Default" / "Cookies").read_bytes() == b"keep"
+        assert (dst / "Default" / "Network" / "Cookies").read_bytes() == b"keep"
+        assert (dst / "Default" / "Login Data").exists()
+        assert (dst / "Default" / "Web Data").exists()
+        assert (dst / "Default" / "Preferences").exists()

--- a/tests/test_profile_trim.py
+++ b/tests/test_profile_trim.py
@@ -1,0 +1,133 @@
+"""Idle named profiles must be trimmable down to their real session state.
+
+Evidence from a real "persistent" profile: 5.3 GB total, of which a single
+on-device AI model (OptGuideOnDeviceModel) was 4 GB and Cache/Code Cache/Service
+Worker most of the rest — while the logins that make it worth keeping (Cookies,
+Login Data, Web Data, Preferences, Local Storage) were ~40 MB. So when sessions/
+storage exceeds the cap, the largest idle NAMED profiles are trimmed of their
+regenerable dirs — using the SAME name set the clone path excludes — and every
+login is preserved. Auto-clones, unmarked dirs, and in-use profiles are untouched.
+
+Pure filesystem tests: no browser.
+"""
+
+import json
+
+import server
+from server import (
+    _clone_is_named,
+    _enforce_named_profile_trim_in,
+    _trim_profile_regenerable,
+)
+
+
+MARKER = ".stealth_chrome_devtools_mcp_clone.json"
+
+
+def _write(path, data=b"x"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+
+
+def _named_profile(root, name, *, model_mb=0):
+    d = root / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / MARKER).write_text(
+        json.dumps({"source_kind": "explicit-master", "auto_clean": False}), encoding="utf-8"
+    )
+    # regenerable — profile-root model store + Default/ caches
+    if model_mb:
+        _write(d / "OptGuideOnDeviceModel" / "model.bin", b"x" * (model_mb * 1024 * 1024))
+    _write(d / "Default" / "Cache" / "data_0", b"x" * 4096)
+    _write(d / "Default" / "Code Cache" / "js" / "blob", b"x" * 4096)
+    _write(d / "Default" / "Service Worker" / "CacheStorage" / "big", b"x" * 4096)
+    # session state — MUST survive a trim
+    _write(d / "Default" / "Cookies", b"COOKIES")
+    _write(d / "Default" / "Login Data", b"LOGINS")
+    _write(d / "Default" / "Local Storage" / "leveldb" / "000003.log", b"LOCALSTATE")
+    _write(d / "Default" / "Preferences", b"PREFS")
+    return d
+
+
+def _auto_clone(root, name, *, mb=1):
+    d = root / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / MARKER).write_text(
+        json.dumps({"source_kind": "master-snapshot", "auto_clean": True}), encoding="utf-8"
+    )
+    _write(d / "Default" / "Cache" / "data", b"x" * (mb * 1024 * 1024))
+    return d
+
+
+class TestClassifyNamed:
+    def test_named_marker_is_named(self, tmp_path):
+        assert _clone_is_named(_named_profile(tmp_path, "github")) is True
+
+    def test_auto_clone_is_not_named(self, tmp_path):
+        assert _clone_is_named(_auto_clone(tmp_path, "sess")) is False
+
+    def test_unmarked_is_not_named(self, tmp_path):
+        d = tmp_path / "mystery"
+        d.mkdir()
+        assert _clone_is_named(d) is False
+
+
+class TestTrimProfile:
+    def test_trims_regenerable_keeps_all_session_state(self, tmp_path):
+        d = _named_profile(tmp_path, "github", model_mb=8)
+
+        freed = _trim_profile_regenerable(d)
+
+        # regenerable gone (root model store + Default caches)
+        assert not (d / "OptGuideOnDeviceModel").exists()
+        assert not (d / "Default" / "Cache").exists()
+        assert not (d / "Default" / "Code Cache").exists()
+        assert not (d / "Default" / "Service Worker").exists()
+        # session state preserved exactly
+        assert (d / "Default" / "Cookies").read_bytes() == b"COOKIES"
+        assert (d / "Default" / "Login Data").read_bytes() == b"LOGINS"
+        assert (d / "Default" / "Local Storage" / "leveldb" / "000003.log").read_bytes() == b"LOCALSTATE"
+        assert (d / "Default" / "Preferences").read_bytes() == b"PREFS"
+        assert freed > 8 * 1024 * 1024  # at least the model
+
+
+class TestNamedProfileTrimCap:
+    def test_under_cap_is_noop(self, tmp_path):
+        _named_profile(tmp_path, "a", model_mb=1)
+        assert _enforce_named_profile_trim_in(tmp_path, cap_bytes=10 ** 9) == 0
+        assert (tmp_path / "a" / "OptGuideOnDeviceModel").exists()
+
+    def test_cap_zero_disables(self, tmp_path):
+        _named_profile(tmp_path, "a", model_mb=20)
+        assert _enforce_named_profile_trim_in(tmp_path, cap_bytes=0) == 0
+        assert (tmp_path / "a" / "OptGuideOnDeviceModel").exists()
+
+    def test_trims_largest_until_under_cap(self, tmp_path):
+        big = _named_profile(tmp_path, "big", model_mb=20)
+        small = _named_profile(tmp_path, "small", model_mb=2)
+
+        # ~22 MB total, cap 12 MB → trimming the largest (big) drops under it;
+        # the small one is left fully intact (model still present).
+        freed = _enforce_named_profile_trim_in(tmp_path, cap_bytes=12 * 1024 * 1024)
+
+        assert freed > 0
+        assert not (big / "OptGuideOnDeviceModel").exists()
+        assert (big / "Default" / "Cookies").read_bytes() == b"COOKIES"  # logins kept
+        assert (small / "OptGuideOnDeviceModel").exists()                # untouched
+
+    def test_never_trims_auto_clones(self, tmp_path):
+        a = _auto_clone(tmp_path, "sess-auto", mb=50)
+        assert _enforce_named_profile_trim_in(tmp_path, cap_bytes=1024 * 1024) == 0
+        assert (a / "Default" / "Cache").exists()  # left for the clone-cap sweep
+
+    def test_never_trims_unmarked(self, tmp_path):
+        d = tmp_path / "not-ours"
+        _write(d / "OptGuideOnDeviceModel" / "model.bin", b"x" * (50 * 1024 * 1024))
+        assert _enforce_named_profile_trim_in(tmp_path, cap_bytes=1024 * 1024) == 0
+        assert (d / "OptGuideOnDeviceModel").exists()
+
+    def test_never_trims_running_profile(self, tmp_path, monkeypatch):
+        d = _named_profile(tmp_path, "github", model_mb=50)
+        monkeypatch.setattr(server, "_profile_has_running_browser", lambda p: True)
+        assert _enforce_named_profile_trim_in(tmp_path, cap_bytes=1024) == 0
+        assert (d / "OptGuideOnDeviceModel").exists()

--- a/tests/test_singleton_fast_handshake.py
+++ b/tests/test_singleton_fast_handshake.py
@@ -1,0 +1,197 @@
+"""The stdio proxy must answer `initialize` locally and instantly.
+
+This is the fix for the recurring "MCP server disconnected / connection timed
+out after 30000ms" failure: under load (or a cold file cache) the backend's
+heavy import can exceed Claude Code's 30s connection timeout. By answering the
+`initialize` handshake in the proxy — without waiting for the backend — the
+connection is always established immediately, and only later requests
+(tools/list, tool calls) wait for the backend to finish starting.
+
+These are pure in-memory tests: no browser, no backend, no real stdio.
+"""
+
+import socket
+
+import anyio
+import pytest
+
+from mcp.shared.message import SessionMessage
+from mcp.types import JSONRPCMessage, JSONRPCRequest, JSONRPCResponse
+
+from singleton import _proxy_streams
+
+
+def _free_port() -> int:
+    """A port with nothing listening — so the proxy's backend never answers."""
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _initialize_msg(req_id, protocol_version=None):
+    params = {"capabilities": {}, "clientInfo": {"name": "test", "version": "1"}}
+    if protocol_version is not None:
+        params["protocolVersion"] = protocol_version
+    req = JSONRPCRequest(jsonrpc="2.0", id=req_id, method="initialize", params=params)
+    return SessionMessage(message=JSONRPCMessage(req))
+
+
+async def _drive_initialize(protocol_version):
+    """Run the proxy against a dead port, send initialize, return its response."""
+    client_to_proxy_tx, client_to_proxy_rx = anyio.create_memory_object_stream(10)
+    proxy_to_client_tx, proxy_to_client_rx = anyio.create_memory_object_stream(10)
+    port = _free_port()  # nothing is listening here
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(_proxy_streams, client_to_proxy_rx, proxy_to_client_tx, port)
+
+        await client_to_proxy_tx.send(_initialize_msg(1, protocol_version))
+
+        # The whole point: a reply arrives fast despite no backend being up.
+        with anyio.fail_after(5):
+            reply = await proxy_to_client_rx.receive()
+
+        tg.cancel_scope.cancel()  # stop the background backend-retry loop
+
+    return reply.message.root
+
+
+class TestFastHandshake:
+    @pytest.mark.asyncio
+    async def test_initialize_answered_without_backend(self):
+        inner = await _drive_initialize("2025-03-26")
+
+        assert isinstance(inner, JSONRPCResponse)
+        assert inner.id == 1
+        # echoes the client's requested protocol version
+        assert inner.result["protocolVersion"] == "2025-03-26"
+        # advertises tools (the real list is fetched later from the backend)
+        assert "tools" in inner.result["capabilities"]
+        assert inner.result["serverInfo"]["name"] == "stealth-chrome-devtools-mcp"
+
+    @pytest.mark.asyncio
+    async def test_initialize_falls_back_to_default_version(self):
+        from mcp.types import DEFAULT_NEGOTIATED_VERSION
+
+        inner = await _drive_initialize(None)  # client omits protocolVersion
+
+        assert isinstance(inner, JSONRPCResponse)
+        assert inner.result["protocolVersion"] == DEFAULT_NEGOTIATED_VERSION
+
+
+class TestEnsureServerRunningNonBlocking:
+    """ensure_server_running must NOT block on the backend cold start — that
+    blocking wait was what let Claude Code's 30s connection timeout fire."""
+
+    def test_returns_existing_without_starting(self):
+        import singleton
+        from unittest.mock import patch
+
+        with patch.object(singleton, "_find_running_server", return_value=12345):
+            with patch.object(singleton.threading, "Thread") as thread_cls:
+                port = singleton.ensure_server_running(port=19222)
+
+        assert port == 12345
+        thread_cls.assert_not_called()  # already up → no startup thread
+
+    def test_does_not_block_on_cold_start(self):
+        import time
+        import singleton
+        from unittest.mock import patch
+
+        # Simulate a backend that takes "forever" to come up. The old code
+        # blocked here for up to 30s; the new code must return immediately.
+        def slow_start(port):
+            time.sleep(5)
+
+        with patch.object(singleton, "_find_running_server", return_value=None):
+            with patch.object(singleton, "_start_backend_holding_lock", slow_start):
+                t0 = time.monotonic()
+                port = singleton.ensure_server_running(port=19222)
+                elapsed = time.monotonic() - t0
+
+        assert port == 19222
+        assert elapsed < 0.5, f"ensure_server_running blocked {elapsed:.2f}s on startup"
+
+
+def _initialized_notification():
+    from mcp.types import JSONRPCNotification
+
+    note = JSONRPCNotification(jsonrpc="2.0", method="notifications/initialized", params={})
+    return SessionMessage(message=JSONRPCMessage(note))
+
+
+def _tools_list_msg(req_id):
+    req = JSONRPCRequest(jsonrpc="2.0", id=req_id, method="tools/list", params={})
+    return SessionMessage(message=JSONRPCMessage(req))
+
+
+@pytest.mark.integration
+class TestFastHandshakeEndToEnd:
+    """End-to-end against a real backend: local initialize, then a forwarded
+    tools/list that returns the real tool catalog — and the backend's duplicate
+    initialize response must be swallowed (client sees exactly one)."""
+
+    @pytest.mark.asyncio
+    async def test_initialize_local_then_tools_list_forwarded(self, tmp_path):
+        import os
+        import subprocess
+        import sys
+
+        port = _free_port()
+        env = dict(os.environ)
+        env["STEALTH_MCP_BROWSER_SESSION_ROOT"] = str(tmp_path / "sessions")
+        env["STEALTH_BROWSER_DEBUG"] = "false"
+
+        backend = subprocess.Popen(
+            [
+                sys.executable, "-m", "stealth_chrome_devtools_mcp",
+                "--transport", "http", "--port", str(port), "--host", "127.0.0.1",
+            ],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, stdin=subprocess.DEVNULL,
+            env=env,
+        )
+        try:
+            c2p_tx, c2p_rx = anyio.create_memory_object_stream(50)
+            p2c_tx, p2c_rx = anyio.create_memory_object_stream(50)
+
+            replies = []
+            async with anyio.create_task_group() as tg:
+                tg.start_soon(_proxy_streams, c2p_rx, p2c_tx, port)
+
+                # Full client handshake + first real request.
+                await c2p_tx.send(_initialize_msg(1, "2025-03-26"))
+                await c2p_tx.send(_initialized_notification())
+                await c2p_tx.send(_tools_list_msg(2))
+
+                # initialize answers locally & instantly (no backend wait).
+                with anyio.fail_after(5):
+                    first = await p2c_rx.receive()
+                replies.append(first.message.root)
+
+                # tools/list waits for the backend cold start, then returns.
+                with anyio.fail_after(90):
+                    second = await p2c_rx.receive()
+                replies.append(second.message.root)
+
+                tg.cancel_scope.cancel()
+
+            init_reply, tools_reply = replies
+            # exactly one initialize response (id=1) — backend's dup swallowed
+            assert isinstance(init_reply, JSONRPCResponse)
+            assert init_reply.id == 1
+            assert init_reply.result["serverInfo"]["name"] == "stealth-chrome-devtools-mcp"
+            # tools/list (id=2) came from the real backend with real tools
+            assert isinstance(tools_reply, JSONRPCResponse)
+            assert tools_reply.id == 2
+            assert len(tools_reply.result["tools"]) > 0
+            tool_names = {t["name"] for t in tools_reply.result["tools"]}
+            assert "spawn_browser" in tool_names
+        finally:
+            backend.terminate()
+            try:
+                backend.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                backend.kill()


### PR DESCRIPTION
## Summary

Server-side fixes for the sluggishness, the intermittent **`MCP server disconnected (connection timed out after 30000ms)`** failures, and unbounded **session-storage bloat**. All help every user out of the box — no configuration, no raised timeouts.

| Problem | Before | After |
|---|---|---|
| MCP disconnect under load / cold cache | 30s timeout → session dropped | `initialize` answered in **ms** |
| `close_instance` | 6–8s | **~1.0s** |
| `spawn_browser` profile clone (5.4 GB master) | ~40s | **2.6s** |
| Cloned profile size | 5,485 MB | **89 MB** |
| close-time process scan (Windows) | ~1.6s | ~0.26s |
| **`sessions/` auto-clone growth** | **unbounded → 146 GB observed** | **capped (default 10 GB), oldest idle clones reclaimed** |
| **named-profile bloat** (regenerable cache/model) | **5 GB+/profile, unbounded** | **trimmed to session state over a cap, logins kept** |

## 1. Startup disconnect (the universal fix)

**Root cause:** the stdio launcher blocked in `ensure_server_running()` until the backend's HTTP socket bound — but the backend runs its full ~13s heavy import *before* binding. Under load / on a cold cache that exceeds Claude Code's **30s connection timeout**, so the session is dropped before `initialize` is ever answered. The socket-only health check also reported "ready" too early, producing the secondary `-32000` / `400` errors.

**Fix (`singleton.py`):** the proxy answers `initialize` **locally and instantly**, decoupled from backend cold start; backend startup moves to a daemon thread that still holds the singleton lock (single-start preserved); readiness is probed at the MCP layer (a real `initialize` → `200`) instead of socket-only; and the client's session sequencing is reproduced so a locally-answered handshake can't let `tools/list` race ahead of the backend session.

## 2. `close_instance` 6–8s → ~1s

**Root cause (`browser_manager.py`):** teardown disconnected the CDP websocket *before* sending the graceful `Browser.close`, so nodriver's `send()` silently reconnected and awaited a reply the dying browser never sends — hanging the entire 5s `wait_for`. **Fix:** send `Browser.close` on the live connection first, then disconnect, both bounded. Plus `process_cleanup.py` reads psutil `cmdline` lazily for browser-named processes only (~1.6s → ~0.26s on Windows).

## 3. Profile clone 40s/5.4 GB → 2.6s/89 MB

**Fix (`server.py`):** exclude regenerable Chrome caches (`Cache`, `Code Cache`, `Service Worker`, optimization-guide model stores, …) from the profile clone. Chrome rebuilds them on next launch; only real session state is copied. This is per-clone **size**.

## 4. Auto-clone storage is now bounded (the 146 GB)

**Root cause:** a clone is only made when the master profile is busy (a second concurrent browser); normal single-browser use makes **zero** clones (it reuses `master/`). Those clones live under the clone root and *are* deleted on close — **but** when an on-close delete fails (Windows holding `Cache` files) or tracking is lost (the long-lived singleton backend restarts), the clone is orphaned. Nothing swept the clone root (the startup sweep only covered the system *temp* dir) and there was **no size cap**, so leaks accumulated to 146 GB. Fix #3 makes that grow ~60× slower but still unbounded.

**Fix (`server.py`):** a size-capped sweep of the clone root that deletes the **oldest idle** auto-clones once total auto-clone storage exceeds a cap (`STEALTH_MCP_CLONE_STORAGE_CAP_GB`, default **10 GB**, `0` disables). Invariants:
- named/explicit profiles and unmarked dirs are **never** touched (the "unless the user manually creates them" carve-out),
- a clone a **live browser** is using is never deleted,
- **oldest-first** eviction, so the freshest sessions survive.

The clone marker now records an explicit `auto_clean` flag to distinguish disposable clones from user-named profiles (older markers fall back to the `explicit-*` source-kind heuristic). Runs **on startup** and **before each new clone** via a single deduped, non-blocking background sweep, so a large first sweep never delays readiness or a spawn.

## 5. Named profiles no longer bloat unbounded

**Root cause:** a read-only preview of a real machine showed the actual footprint is user-named/persistent profiles — and a "persistent" profile is ~98% regenerable: a single on-device AI model (`OptGuideOnDeviceModel`) was **4 GB** of one **5.3 GB** profile, with `Cache`/`Code Cache`/`Service Worker` most of the rest; the logins that make it worth keeping were ~40 MB. The cache-exclusion (fix #3) only trims at *clone* time, so a profile you actually browse with rebuilds all of that.

**Fix (`server.py`):** generalize the clone-time cache-exclusion into a **trim on idle profiles**. The regenerable-name set is now one shared constant (`_REGENERABLE_PROFILE_NAMES`) used by both the clone-exclusion and the trim, so they can't drift. When `sessions/` exceeds `STEALTH_MCP_SESSION_STORAGE_CAP_GB` (default **20 GB**, `0` disables), the largest **idle named** profiles are trimmed of their cache/model dirs while **every login is preserved** (Chrome rebuilds the rest on launch). Auto-clones, unmarked dirs, in-use profiles, and `master` (the hot clone source, outside `sessions/`) are never trimmed.

## Test plan

- **`tests/test_singleton_fast_handshake.py`** — `initialize` answered with no backend; non-blocking `ensure_server_running`; e2e local-initialize → forwarded `tools/list` with the backend's duplicate initialize swallowed.
- **`tests/test_browser_integration.py`** — `TestClosePerformance` guards `close_instance < 3s`.
- **`tests/test_profile_clone_excludes_cache.py`** — cache trees skipped, session state preserved.
- **`tests/test_clone_storage_cap.py`** — classification (auto vs named vs unmarked), oldest-first eviction down to the cap, and the invariants (named/running/unmarked never deleted, `cap=0` disables).
- **`tests/test_profile_trim.py`** — trim removes regenerable dirs and keeps all session state; the cap trims largest-first down to target; auto-clones, unmarked dirs, in-use profiles, and `cap=0` are never trimmed.

Full suite green locally: **231 unit + 15 integration passed**.

> Note: these take effect when the MCP server restarts (next session / reconnect) — a running backend keeps the old code until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

