### PR TITLE
feat: add stealth-chrome-devtools ops CLI (cleanup, profiles, status, doctor, serve)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,27 @@ All optional. Defaults work for normal use.
 | `STEALTH_CHROME_PROFILE_KEY` | unset | Force a stable clone key |
 | `STEALTH_BROWSER_DEBUG` | `false` | Enable debug logging |
 
+## CLI
+
+Installs a `stealth-chrome-devtools` ops command for managing the server and its
+disk usage. (This is for *ops* — to drive a browser, use the MCP server or its
+HTTP backend.)
+
+```bash
+stealth-chrome-devtools status       # backend running? session root + caps
+stealth-chrome-devtools profiles     # list profiles with size / role / in-use
+stealth-chrome-devtools cleanup      # preview reclaimable disk (DRY RUN)
+stealth-chrome-devtools cleanup --apply               # actually reclaim
+stealth-chrome-devtools cleanup --session-cap-gb 12   # preview at a tighter cap
+stealth-chrome-devtools doctor       # check Chrome / environment
+stealth-chrome-devtools serve --http --port 19222     # start the server
+```
+
+`cleanup` deletes idle auto-clones over the clone cap and trims idle named
+profiles down to their session state — **logins kept** — over the session cap. It
+is a **dry run unless you pass `--apply`**, never touches in-use profiles, and
+uses the same selectors as the automatic sweep, so the preview matches `--apply`.
+
 ## Preparing the Master Profile
 
 1. Start the MCP server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ Issues = "https://github.com/DevinoSolutions/stealth-chrome-devtools-mcp/issues"
 
 [project.scripts]
 stealth-chrome-devtools-mcp = "stealth_chrome_devtools_mcp.server:main"
+stealth-chrome-devtools = "stealth_chrome_devtools_mcp.cli:main"
 
 [project.optional-dependencies]
 transpiler = [

--- a/src/stealth_chrome_devtools_mcp/cli.py
+++ b/src/stealth_chrome_devtools_mcp/cli.py
@@ -1,0 +1,273 @@
+"""``stealth-chrome-devtools`` — an ops CLI for the stealth browser MCP server.
+
+A thin management layer over the *same* backend the MCP server uses: inspect the
+singleton, list profiles, reclaim disk (the storage sweep), check the
+environment, or start the server. It never reimplements browser logic — to drive
+a browser, use the MCP server (or its HTTP backend) directly.
+
+Read-only commands (``status``, ``profiles``, ``cleanup`` without ``--apply``,
+``doctor``) import the package with ``STEALTH_MCP_NO_AUTO_RECOVERY=1`` so merely
+running the CLI never kills a running server's browsers or touches its profiles.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+EMBEDDED_DIR = Path(__file__).with_name("embedded")
+
+
+def _ensure_embedded_on_path() -> None:
+    path = str(EMBEDDED_DIR)
+    if path not in sys.path:
+        sys.path.insert(0, path)
+
+
+def _server():
+    """Import the embedded server module, reusing its profile/storage helpers.
+
+    Forces read-only import semantics: no orphan-process recovery, no atexit
+    teardown handlers — so the CLI never disturbs a running backend.
+    """
+    os.environ.setdefault("STEALTH_MCP_NO_AUTO_RECOVERY", "1")
+    _ensure_embedded_on_path()
+    import server  # noqa: E402  (path set up just above)
+
+    return server
+
+
+def _human(num: int) -> str:
+    value = float(num)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if value < 1024 or unit == "TB":
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{value:.1f} TB"
+
+
+def _role(server, path: Path) -> str:
+    if server._clone_is_auto(path):
+        return "auto-clone"
+    if server._clone_is_named(path):
+        return "named"
+    return "unmarked"
+
+
+def _collect_profiles(server) -> list[dict]:
+    """Every profile under the session root with size, role, and in-use flag."""
+    rows: list[dict] = []
+
+    def _row(path: Path, role: str) -> dict:
+        return {
+            "name": path.name,
+            "path": path,
+            "role": role,
+            "size": server._dir_size_bytes(path),
+            "in_use": server._profile_has_running_browser(path),
+        }
+
+    master = server._master_profile_dir()
+    snapshot = server._master_snapshot_dir()
+    if master.exists():
+        rows.append(_row(master, "master"))
+    if snapshot.exists():
+        rows.append(_row(snapshot, "snapshot"))
+
+    clone_root = server._clone_root_dir()
+    if clone_root.exists():
+        for child in sorted(clone_root.iterdir()):
+            if child.is_dir():
+                rows.append(_row(child, _role(server, child)))
+    return rows
+
+
+def _gb_to_bytes(gb: float | None, fallback: int) -> int:
+    if gb is None:
+        return fallback
+    return 0 if gb <= 0 else int(gb * (1024 ** 3))
+
+
+# ── commands ────────────────────────────────────────────────────────────────
+
+def _cmd_status(_args) -> int:
+    server = _server()
+    import singleton
+
+    port = singleton._find_running_server()
+    root = server._default_session_root()
+    print(f"backend     : {'running on port ' + str(port) if port else 'not running'}")
+    print(f"version     : {singleton._server_version()}")
+    print(f"session root: {root}  (exists: {root.exists()})")
+    print(f"clone cap   : {_human(server._clone_storage_cap_bytes())}  [STEALTH_MCP_CLONE_STORAGE_CAP_GB]")
+    print(f"session cap : {_human(server._session_storage_cap_bytes())}  [STEALTH_MCP_SESSION_STORAGE_CAP_GB]")
+    return 0
+
+
+def _cmd_profiles(_args) -> int:
+    server = _server()
+    rows = _collect_profiles(server)
+    if not rows:
+        print("no profiles found.")
+        return 0
+    for row in sorted(rows, key=lambda r: r["size"], reverse=True):
+        print(
+            f"  {row['name'][:44]:44s} {row['role']:11s} "
+            f"{_human(row['size']):>10s}  in_use={row['in_use']}"
+        )
+    print(f"  {'total':44s} {'':11s} {_human(sum(r['size'] for r in rows)):>10s}")
+    return 0
+
+
+def _cmd_cleanup(args) -> int:
+    server = _server()
+    clone_root = server._clone_root_dir()
+    clone_cap = _gb_to_bytes(args.clone_cap_gb, server._clone_storage_cap_bytes())
+    session_cap = _gb_to_bytes(args.session_cap_gb, server._session_storage_cap_bytes())
+
+    # Same selectors the live sweep uses — dry-run and apply can't disagree.
+    to_delete = server._idle_autoclones_over_cap(clone_root, clone_cap)
+    to_trim = server._named_profiles_over_session_cap(clone_root, session_cap)
+    delete_bytes = sum(server._dir_size_bytes(p) for p in to_delete)
+    trim_bytes = sum(server._regenerable_size(p) for p in to_trim)
+
+    print(f"clone root  : {clone_root}")
+    print(f"caps        : clone {_human(clone_cap)} | session {_human(session_cap)}")
+    if not to_delete and not to_trim:
+        print("nothing to reclaim - storage is within caps.")
+        return 0
+
+    if to_delete:
+        print(f"\ndelete {len(to_delete)} idle auto-clone(s) - frees {_human(delete_bytes)}:")
+        for path in to_delete:
+            print(f"   - {path.name[:50]:50s} {_human(server._dir_size_bytes(path)):>10s}")
+    if to_trim:
+        print(f"\ntrim {len(to_trim)} idle named profile(s) - frees ~{_human(trim_bytes)} (logins kept):")
+        for path in to_trim:
+            print(f"   - {path.name[:50]:50s} ~{_human(server._regenerable_size(path)):>10s}")
+    print(f"\ntotal reclaimable: ~{_human(delete_bytes + trim_bytes)}")
+
+    if not args.apply:
+        print("\n(dry run - nothing deleted. Re-run with --apply to reclaim.)")
+        return 0
+
+    removed = server._enforce_clone_storage_cap_in(clone_root, clone_cap, "cli")
+    freed = server._enforce_named_profile_trim_in(clone_root, session_cap, "cli")
+    print(f"\napplied: deleted {removed} auto-clone(s); trimmed {_human(freed)} from named profiles.")
+    return 0
+
+
+def _cmd_doctor(_args) -> int:
+    import platform
+
+    server = _server()
+    import singleton
+
+    ok = True
+    print(f"python      : {platform.python_version()}")
+    print(f"platform    : {platform.platform()}")
+    root = server._default_session_root()
+    print(f"session root: {root}  (exists: {root.exists()})")
+    port = singleton._find_running_server()
+    print(f"backend     : {'running on port ' + str(port) if port else 'not running'}")
+
+    chrome = _find_chrome()
+    print(f"chrome      : {chrome or 'NOT FOUND — install Google Chrome'}")
+    if not chrome:
+        ok = False
+    return 0 if ok else 1
+
+
+def _find_chrome() -> str | None:
+    import shutil
+
+    for name in ("google-chrome", "google-chrome-stable", "chrome", "chromium", "chromium-browser"):
+        found = shutil.which(name)
+        if found:
+            return found
+    candidates = [
+        r"C:\Program Files\Google\Chrome\Application\chrome.exe",
+        r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe",
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    ]
+    for candidate in candidates:
+        if Path(candidate).exists():
+            return candidate
+    return None
+
+
+def _cmd_serve(args) -> int:
+    # Delegate to the same entrypoint as `stealth-chrome-devtools-mcp` so server
+    # lifecycle (incl. orphan recovery) behaves exactly as normal.
+    from stealth_chrome_devtools_mcp import server as shim
+
+    if args.http:
+        sys.argv = [
+            "stealth-chrome-devtools-mcp",
+            "--transport", "http",
+            "--port", str(args.port),
+            "--host", args.host,
+        ]
+    else:
+        sys.argv = ["stealth-chrome-devtools-mcp", "--transport", "stdio"]
+    shim.main()
+    return 0
+
+
+_DISPATCH = {
+    "status": _cmd_status,
+    "profiles": _cmd_profiles,
+    "cleanup": _cmd_cleanup,
+    "doctor": _cmd_doctor,
+    "serve": _cmd_serve,
+}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="stealth-chrome-devtools",
+        description="Ops CLI for the stealth Chrome DevTools MCP server "
+        "(inspect, reclaim disk, start). For browser automation, use the MCP server.",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    sub.add_parser("status", help="show backend state, session root, and storage caps")
+    sub.add_parser("profiles", help="list profiles with size, role, and in-use flag")
+
+    clean = sub.add_parser(
+        "cleanup",
+        help="reclaim disk: delete idle auto-clones over the clone cap and trim "
+        "idle named profiles over the session cap (dry run unless --apply)",
+    )
+    clean.add_argument("--apply", action="store_true", help="actually reclaim (default: dry run)")
+    clean.add_argument(
+        "--session-cap-gb", type=float, default=None, dest="session_cap_gb",
+        help="override the named-profile trim cap for this run (GB; 0 disables)",
+    )
+    clean.add_argument(
+        "--clone-cap-gb", type=float, default=None, dest="clone_cap_gb",
+        help="override the auto-clone delete cap for this run (GB; 0 disables)",
+    )
+
+    sub.add_parser("doctor", help="check Python, platform, session root, backend, and Chrome")
+
+    serve = sub.add_parser("serve", help="start the MCP server (stdio by default, or --http)")
+    serve.add_argument("--http", action="store_true", help="serve over HTTP instead of stdio")
+    serve.add_argument("--port", type=int, default=19222, help="HTTP port (default 19222)")
+    serve.add_argument("--host", default="127.0.0.1", help="HTTP host (default 127.0.0.1)")
+    return parser
+
+
+def main(argv=None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not args.command:
+        parser.print_help()
+        return 1
+    return _DISPATCH[args.command](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/stealth_chrome_devtools_mcp/embedded/process_cleanup.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/process_cleanup.py
@@ -45,6 +45,12 @@ class ProcessCleanup:
         # Record server start time so recovery never kills processes spawned
         # during the current session (create_time >= _init_time).
         self._init_time = time.time()
+        # Read-only tooling (the `stealth-chrome-devtools` CLI) imports this
+        # package to reuse profile helpers without taking over process
+        # lifecycle. Honor an opt-out so importing never kills the running
+        # server's browsers, deletes their profiles, or wipes PID tracking.
+        if os.getenv("STEALTH_MCP_NO_AUTO_RECOVERY", "").strip().lower() in {"1", "true", "yes", "on"}:
+            return
         self._setup_cleanup_handlers()
         self._recover_orphaned_processes()
 

--- a/src/stealth_chrome_devtools_mcp/embedded/server.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/server.py
@@ -371,26 +371,23 @@ def _clone_is_auto(clone_dir: Path) -> bool:
     return not str(data.get("source_kind", "")).startswith("explicit")
 
 
-def _enforce_clone_storage_cap_in(clone_root: Path, cap_bytes: int, reason: str = "") -> int:
-    """Reclaim the oldest idle auto-clones until total auto-clone storage under
-    ``clone_root`` is within ``cap_bytes``. Returns the number of dirs removed.
+def _idle_autoclones_over_cap(clone_root: Path, cap_bytes: int) -> List[Path]:
+    """Oldest-first idle auto-clones whose removal brings total auto-clone
+    storage within ``cap_bytes``. Read-only — selection only, no deletion.
 
-    Safety invariants (this is the backstop that turns "grows slower" into
-    "provably bounded"):
-      * Named/explicit profiles and unmarked directories are never touched.
-      * A clone a live browser is currently using is never deleted.
-      * Deletion is oldest-first (by mtime), so the freshest sessions survive.
-    ``cap_bytes <= 0`` disables the sweep.
+    Named/explicit profiles, unmarked dirs, and clones a live browser is using
+    are never selected. ``cap_bytes <= 0`` selects nothing. Shared by the live
+    sweep and the CLI's dry-run so the two can never disagree.
     """
     if cap_bytes <= 0 or not clone_root.exists():
-        return 0
+        return []
 
-    autos = []  # (mtime, size, path, is_running)
+    autos = []  # (mtime, size, path)
     total = 0
     try:
         entries = list(clone_root.iterdir())
     except OSError:
-        return 0
+        return []
     for entry in entries:
         try:
             if not entry.is_dir() or not _clone_is_auto(entry):
@@ -400,20 +397,32 @@ def _enforce_clone_storage_cap_in(clone_root: Path, cap_bytes: int, reason: str 
         except OSError:
             continue
         total += size
-        autos.append((mtime, size, entry, _profile_has_running_browser(entry)))
+        autos.append((mtime, size, entry))
 
     if total <= cap_bytes:
-        return 0
+        return []
 
-    removed = 0
-    for _mtime, size, entry, is_running in sorted(autos, key=lambda item: item[0]):
+    victims: List[Path] = []
+    for _mtime, size, entry in sorted(autos, key=lambda item: item[0]):
         if total <= cap_bytes:
             break
-        if is_running:
+        if _profile_has_running_browser(entry):
             continue  # never evict a live session to satisfy the cap
+        victims.append(entry)
+        total -= size
+    return victims
+
+
+def _enforce_clone_storage_cap_in(clone_root: Path, cap_bytes: int, reason: str = "") -> int:
+    """Delete the oldest idle auto-clones until total auto-clone storage under
+    ``clone_root`` is within ``cap_bytes``. Returns the number of dirs removed.
+    Selection (and its safety invariants) lives in ``_idle_autoclones_over_cap``.
+    """
+    removed = 0
+    for entry in _idle_autoclones_over_cap(clone_root, cap_bytes):
+        size = _dir_size_bytes(entry)
         _rmtree_robust(entry)
         if not entry.exists():
-            total -= size
             removed += 1
             debug_logger.log_info(
                 "server",
@@ -449,21 +458,15 @@ def _clone_is_named(clone_dir: Path) -> bool:
     return str(data.get("source_kind", "")).startswith("explicit")
 
 
-def _trim_profile_regenerable(profile_dir: Path) -> int:
-    """Delete regenerable cache/model subdirectories from an idle profile while
-    preserving every session-state file (cookies, logins, Web Data, Local
-    Storage, Preferences). Returns the number of bytes freed.
-
-    Removes only directories named in ``_REGENERABLE_PROFILE_NAMES`` — the same
-    set the clone path excludes — at the profile root and one level down
+def _regenerable_dirs_in_profile(profile_dir: Path) -> List[Path]:
+    """Regenerable cache/model directories in a profile — those named in
+    ``_REGENERABLE_PROFILE_NAMES``, at the profile root and one level down
     (``Default/``, ``Profile N/``), which is where Chrome keeps its caches and
     on-device model stores. Never recurses deeper, so session-state dirs such as
-    ``Local Storage`` and ``IndexedDB`` are always left intact.
-    """
-    freed = 0
+    ``Local Storage`` and ``IndexedDB`` are never included."""
+    found: List[Path] = []
 
-    def _trim_level(directory: Path) -> None:
-        nonlocal freed
+    def _scan(directory: Path) -> None:
         try:
             children = list(directory.iterdir())
         except OSError:
@@ -471,14 +474,11 @@ def _trim_profile_regenerable(profile_dir: Path) -> int:
         for child in children:
             try:
                 if child.is_dir() and child.name in _REGENERABLE_PROFILE_NAMES:
-                    size = _dir_size_bytes(child)
-                    _rmtree_robust(child)
-                    if not child.exists():
-                        freed += size
+                    found.append(child)
             except OSError:
                 continue
 
-    _trim_level(profile_dir)
+    _scan(profile_dir)
     try:
         subdirs = [
             c for c in profile_dir.iterdir()
@@ -487,29 +487,46 @@ def _trim_profile_regenerable(profile_dir: Path) -> int:
     except OSError:
         subdirs = []
     for sub in subdirs:
-        _trim_level(sub)
+        _scan(sub)
+    return found
+
+
+def _regenerable_size(profile_dir: Path) -> int:
+    """Bytes a trim of ``profile_dir`` would reclaim (read-only)."""
+    return sum(_dir_size_bytes(d) for d in _regenerable_dirs_in_profile(profile_dir))
+
+
+def _trim_profile_regenerable(profile_dir: Path) -> int:
+    """Delete the regenerable cache/model dirs from a profile (see
+    ``_regenerable_dirs_in_profile``) while preserving every session-state file
+    (cookies, logins, Web Data, Local Storage, Preferences). Returns bytes freed.
+    """
+    freed = 0
+    for directory in _regenerable_dirs_in_profile(profile_dir):
+        size = _dir_size_bytes(directory)
+        _rmtree_robust(directory)
+        if not directory.exists():
+            freed += size
     return freed
 
 
-def _enforce_named_profile_trim_in(clone_root: Path, cap_bytes: int, reason: str = "") -> int:
-    """Trim regenerable data from the largest idle named profiles under
-    ``clone_root`` until total clone-root storage is within ``cap_bytes``.
-    Returns the number of bytes freed.
+def _named_profiles_over_session_cap(clone_root: Path, cap_bytes: int) -> List[Path]:
+    """Largest-first idle named profiles whose trim brings total clone-root
+    storage within ``cap_bytes``. Read-only — selection only.
 
-    Only user-named/explicit profiles are trimmed — auto-clones are the
-    clone-cap sweep's job and unmarked dirs are left alone. In-use profiles are
-    never touched, and only regenerable dirs are removed, so every login
-    survives. ``cap_bytes <= 0`` disables the trim.
+    Auto-clones (the clone-cap sweep's job), unmarked dirs, and in-use profiles
+    are never selected. ``cap_bytes <= 0`` selects nothing. Shared by the live
+    sweep and the CLI's dry-run.
     """
     if cap_bytes <= 0 or not clone_root.exists():
-        return 0
+        return []
 
-    sized = []
+    sized = []  # (size, path)
     total = 0
     try:
         entries = list(clone_root.iterdir())
     except OSError:
-        return 0
+        return []
     for entry in entries:
         try:
             if not entry.is_dir():
@@ -521,19 +538,28 @@ def _enforce_named_profile_trim_in(clone_root: Path, cap_bytes: int, reason: str
         sized.append((size, entry))
 
     if total <= cap_bytes:
-        return 0
+        return []
 
-    freed_total = 0
-    for size, entry in sorted(sized, key=lambda item: item[0], reverse=True):  # largest first
+    victims: List[Path] = []
+    for _size, entry in sorted(sized, key=lambda item: item[0], reverse=True):  # largest first
         if total <= cap_bytes:
             break
-        if not _clone_is_named(entry):
-            continue  # auto-clones -> clone-cap sweep; unmarked -> leave alone
-        if _profile_has_running_browser(entry):
-            continue  # never trim a profile a live browser is using
+        if not _clone_is_named(entry) or _profile_has_running_browser(entry):
+            continue  # autos -> clone-cap sweep; unmarked/in-use -> leave alone
+        victims.append(entry)
+        total -= _regenerable_size(entry)  # a trim frees ~the regenerable portion
+    return victims
+
+
+def _enforce_named_profile_trim_in(clone_root: Path, cap_bytes: int, reason: str = "") -> int:
+    """Trim regenerable data from the largest idle named profiles until total
+    clone-root storage is within ``cap_bytes``. Returns bytes freed. Selection
+    (and its safety invariants) lives in ``_named_profiles_over_session_cap``.
+    """
+    freed_total = 0
+    for entry in _named_profiles_over_session_cap(clone_root, cap_bytes):
         freed = _trim_profile_regenerable(entry)
         if freed:
-            total -= freed
             freed_total += freed
             debug_logger.log_info(
                 "server",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,112 @@
+"""The ops CLI must be a faithful, safe front-end to the storage sweep.
+
+`cleanup` defaults to a dry run that mutates nothing; `--apply` reclaims using
+the exact same selectors as the live sweep (so preview and apply agree), trims
+named profiles down to their session state, and never deletes named profiles or
+touches in-use ones. Pure filesystem tests (the `tmp_session_root` fixture points
+every profile helper at a tmp dir); no browser.
+"""
+
+import json
+
+import stealth_chrome_devtools_mcp.cli as cli
+
+
+MARKER = ".stealth_chrome_devtools_mcp_clone.json"
+
+
+def _write(path, data=b"x"):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+
+
+def _named(sessions, name, *, model_mb):
+    d = sessions / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / MARKER).write_text(
+        json.dumps({"source_kind": "explicit-master", "auto_clean": False}), encoding="utf-8"
+    )
+    _write(d / "OptGuideOnDeviceModel" / "model.bin", b"x" * (model_mb * 1024 * 1024))
+    _write(d / "Default" / "Cache" / "data", b"x" * 4096)
+    _write(d / "Default" / "Cookies", b"COOKIES")
+    _write(d / "Default" / "Login Data", b"LOGINS")
+    return d
+
+
+def _auto(sessions, name, *, mb):
+    d = sessions / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / MARKER).write_text(
+        json.dumps({"source_kind": "master-snapshot", "auto_clean": True}), encoding="utf-8"
+    )
+    _write(d / "Default" / "Cache" / "data", b"x" * (mb * 1024 * 1024))
+    return d
+
+
+class TestParser:
+    def test_no_command_prints_help_and_returns_1(self, capsys):
+        assert cli.main([]) == 1
+        assert "usage" in capsys.readouterr().out.lower()
+
+    def test_serve_args_parse(self):
+        args = cli.build_parser().parse_args(["serve", "--http", "--port", "20001"])
+        assert args.command == "serve" and args.http and args.port == 20001
+
+
+class TestStatusProfiles:
+    def test_status_runs(self, tmp_session_root, capsys):
+        assert cli.main(["status"]) == 0
+        assert "session root" in capsys.readouterr().out.lower()
+
+    def test_profiles_lists_roles(self, tmp_session_root, capsys):
+        sessions = tmp_session_root["sessions"]
+        _named(sessions, "github-session", model_mb=2)
+        _auto(sessions, "sess-auto", mb=1)
+
+        assert cli.main(["profiles"]) == 0
+        out = capsys.readouterr().out
+        assert "github-session" in out and "named" in out
+        assert "sess-auto" in out and "auto-clone" in out
+
+
+class TestCleanup:
+    def test_dry_run_reports_plan_and_mutates_nothing(self, tmp_session_root, capsys):
+        sessions = tmp_session_root["sessions"]
+        named = _named(sessions, "github-session", model_mb=4)
+        auto = _auto(sessions, "sess-auto", mb=4)
+
+        # Tiny caps so both the auto-clone and the named profile are over.
+        rc = cli.main(["cleanup", "--clone-cap-gb", "0.001", "--session-cap-gb", "0.001"])
+        out = capsys.readouterr().out.lower()
+
+        assert rc == 0
+        assert "dry run" in out
+        # nothing was touched
+        assert (auto / "Default" / "Cache").exists()
+        assert (named / "OptGuideOnDeviceModel").exists()
+        assert (named / "Default" / "Cookies").read_bytes() == b"COOKIES"
+
+    def test_apply_deletes_autoclones_and_trims_named(self, tmp_session_root, capsys):
+        sessions = tmp_session_root["sessions"]
+        named = _named(sessions, "github-session", model_mb=4)
+        auto = _auto(sessions, "sess-auto", mb=4)
+
+        rc = cli.main(
+            ["cleanup", "--apply", "--clone-cap-gb", "0.001", "--session-cap-gb", "0.001"]
+        )
+        out = capsys.readouterr().out.lower()
+
+        assert rc == 0
+        assert "applied" in out
+        assert not auto.exists()                                  # auto-clone deleted
+        assert not (named / "OptGuideOnDeviceModel").exists()     # named trimmed
+        assert (named / "Default" / "Cookies").read_bytes() == b"COOKIES"  # logins kept
+
+    def test_within_caps_reclaims_nothing(self, tmp_session_root, capsys):
+        sessions = tmp_session_root["sessions"]
+        _named(sessions, "github-session", model_mb=1)
+
+        rc = cli.main(["cleanup"])  # default caps (10/20 GB) — way over the tiny data
+        out = capsys.readouterr().out.lower()
+        assert rc == 0
+        assert "within caps" in out


### PR DESCRIPTION
## Summary

Adds a `stealth-chrome-devtools` **ops CLI** — a thin management layer over the same backend the MCP server uses. It's for *ops* (inspect, reclaim disk, start), **not** browser driving — that stays on the MCP server / HTTP backend. This productizes the storage sweep from #11 into an on-demand, previewable command.

> **Stacked on #11** (`perf/spawn-and-timeouts`) — `cleanup` reuses the storage functions added there. GitHub retargets this PR to `main` automatically when #11 merges.

## Commands

```
stealth-chrome-devtools status       # backend running? session root + caps
stealth-chrome-devtools profiles     # list profiles: size / role / in-use
stealth-chrome-devtools cleanup      # preview reclaimable disk (DRY RUN)
stealth-chrome-devtools cleanup --apply               # actually reclaim
stealth-chrome-devtools cleanup --session-cap-gb 12   # preview at a tighter cap
stealth-chrome-devtools doctor       # Python / platform / session root / backend / Chrome
stealth-chrome-devtools serve --http --port 19222     # start the server
```

## Live on a real machine

```
$ stealth-chrome-devtools status
backend     : running on port 19222
version     : 1.1.0
session root: C:\stealth-mcp-browser-sessions  (exists: True)
clone cap   : 10.0 GB  [STEALTH_MCP_CLONE_STORAGE_CAP_GB]
session cap : 20.0 GB  [STEALTH_MCP_SESSION_STORAGE_CAP_GB]

$ stealth-chrome-devtools cleanup --session-cap-gb 12
clone root  : C:\stealth-mcp-browser-sessions\sessions
caps        : clone 10.0 GB | session 12.0 GB

trim 1 idle named profile(s) - frees ~5.2 GB (logins kept):
   - github-session                                     ~    5.2 GB

total reclaimable: ~5.2 GB

(dry run - nothing deleted. Re-run with --apply to reclaim.)
```

## Design

- **No logic fork.** `cleanup`'s dry-run *and* `--apply` call the same victim-selectors as the automatic sweep, so the preview always matches what apply does. To enable that, the sweep's selection is factored into read-only selectors (`_idle_autoclones_over_cap`, `_named_profiles_over_session_cap`) plus `_regenerable_size`; the enforce functions now call them. Behavior is unchanged (existing storage tests pass).
- **Safe import.** A read-only command must never disturb a running server. `process_cleanup` honors `STEALTH_MCP_NO_AUTO_RECOVERY=1` to skip orphan-process recovery + atexit teardown on import; the CLI sets it for every command except `serve`. Verified live: after running the CLI, the backend on port 19222 was still up.
- **Dry run by default.** `cleanup` mutates nothing without `--apply`; in-use profiles are never touched.
- Thin layer only — it never reimplements browser logic.

## Test plan

`tests/test_cli.py`: dry-run reports the plan and mutates nothing; `--apply` deletes idle auto-clones and trims named profiles (cookies preserved); within-caps is a no-op; `profiles` / `status` / parser. Full suite green locally: **238 unit + integration**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
