### PR TITLE
release v1.2.0: fix stdio proxy process leak (+ ops CLI, perf)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ uv run pytest
 uv run pytest -v --tb=short
 ```
 
-**95 tests** covering stealth arg filtering, profile resolution, orphan recovery, and full browser integration.
+**256 tests** covering stealth arg filtering, profile resolution, orphan recovery, storage-cap sweeps, the ops CLI, and full browser integration.
 
 ## Environment Variables
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "stealth-chrome-devtools-mcp"
-version = "1.1.0"
+version = "1.2.0"
 description = "Undetectable browser automation for AI agents via the Model Context Protocol."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/stealth_chrome_devtools_mcp/embedded/singleton.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/singleton.py
@@ -354,7 +354,17 @@ async def _bridge(port: int):
     from mcp.server.stdio import stdio_server
 
     async with stdio_server() as (client_read, client_write):
-        await _proxy_streams(client_read, client_write, port)
+        try:
+            await _proxy_streams(client_read, client_write, port)
+        finally:
+            # The client disconnected. mcp's stdio_server holds its __aexit__
+            # open until its stdout-writer task finishes, and that task only
+            # ends when the write stream is closed. Without this the process
+            # hangs after every disconnect instead of exiting — one stranded
+            # entrypoint per disconnect. Closing both streams lets stdio_server
+            # tear down so the entrypoint returns and the process exits.
+            await client_write.aclose()
+            await client_read.aclose()
 
 
 def run_stdio_proxy(port: int):

--- a/src/stealth_chrome_devtools_mcp/embedded/singleton.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/singleton.py
@@ -339,8 +339,14 @@ async def _proxy_streams(client_read, client_write, port: int) -> None:
                 tg.start_soon(from_backend)
 
     async with anyio.create_task_group() as tg:
-        tg.start_soon(pump_client)
         tg.start_soon(run_backend)
+        # Drive the client pump in the main task. When the client (Claude Code)
+        # disconnects, stdin hits EOF and pump_client returns — at which point we
+        # cancel everything. Otherwise run_backend's from_backend loop stays
+        # parked on the still-open backend stream forever and the proxy process
+        # never exits, leaking one stranded process per disconnect.
+        await pump_client()
+        tg.cancel_scope.cancel()
 
 
 async def _bridge(port: int):

--- a/tests/test_browser_integration.py
+++ b/tests/test_browser_integration.py
@@ -199,6 +199,70 @@ class TestClosePerformance:
         assert elapsed < 3.0, f"close took {elapsed:.2f}s — teardown hang regressed"
 
 
+class TestCloseKillsProcessTree:
+    """close_instance must kill the WHOLE Chrome process tree, not just root.
+
+    The shipped bug: Chrome's renderer/GPU/utility/crashpad children do not
+    carry ``--user-data-dir`` on Windows, so the profile-cmdline match that
+    close relied on never enumerated them. Only the root ``chrome.exe`` was
+    killed; the ~15 children orphaned — one leaked tree per spawn. The old
+    "fast teardown" test passed precisely *because* close didn't wait for or
+    ensure the children's death.
+
+    This captures the live descendant PIDs before close and asserts every one
+    is gone after. On Linux the children die with the parent regardless (which
+    is why CI never caught it); on Windows this fails on the old root-only kill.
+    """
+
+    DATA_URL = "data:text/html,<h1 id='t'>tree</h1>"
+
+    @pytest.mark.asyncio
+    async def test_close_kills_entire_chrome_tree(self):
+        import psutil
+        import process_cleanup as pc_mod
+
+        spawn = _get_fn("spawn_browser")
+        navigate = _get_fn("navigate")
+        close = _get_fn("close_instance")
+
+        result = await spawn(headless=True, user_data_dir="tree-kill-test", **_sandbox_kwargs())
+        iid = result["instance_id"]
+        # Navigate so a renderer child definitely exists.
+        await navigate(instance_id=iid, url=self.DATA_URL)
+
+        metadata = pc_mod.process_cleanup.browser_processes.get(iid) or {}
+        root_pid = metadata.get("pid")
+        if not isinstance(root_pid, int) or not psutil.pid_exists(root_pid):
+            pytest.skip("no tracked root pid to inspect")
+
+        try:
+            descendants = psutil.Process(root_pid).children(recursive=True)
+        except psutil.NoSuchProcess:
+            descendants = []
+        tree = [root_pid, *[p.pid for p in descendants]]
+
+        try:
+            await close(instance_id=iid)
+
+            # Give the OS a beat to reap the tree.
+            deadline = time.monotonic() + 8.0
+            while time.monotonic() < deadline and any(psutil.pid_exists(p) for p in tree):
+                await asyncio.sleep(0.2)
+
+            survivors = [p for p in tree if psutil.pid_exists(p)]
+            assert survivors == [], (
+                f"close leaked {len(survivors)}/{len(tree)} chrome process(es): "
+                f"{survivors} (root={root_pid}, {len(descendants)} children captured)"
+            )
+        finally:
+            # Safety net: never let a failed assertion leak a real Chrome tree.
+            for p in tree:
+                try:
+                    psutil.Process(p).kill()
+                except psutil.Error:
+                    pass
+
+
 class TestNavigateAndScreenshot:
     """Navigate to a data: URL and take a screenshot."""
 

--- a/tests/test_singleton_fast_handshake.py
+++ b/tests/test_singleton_fast_handshake.py
@@ -267,3 +267,87 @@ class TestProxyExitsOnClientDisconnect:
                 backend.wait(timeout=10)
             except subprocess.TimeoutExpired:
                 backend.kill()
+
+
+@pytest.mark.integration
+class TestEntrypointExitsOnDisconnect:
+    """The REAL entrypoint process must exit when the client disconnects.
+
+    This is the end-to-end guard the isolated ``_proxy_streams`` test above could
+    not provide. The leak had TWO causes: ``_proxy_streams`` not tearing down the
+    backend side, AND mcp's ``stdio_server`` holding its teardown open until the
+    write stream is closed. The unit test only covered the first and passed while
+    the real entrypoint still hung. This runs ``python -m
+    stealth_chrome_devtools_mcp``, does the handshake, closes stdin, and asserts
+    the process exits — the hang it guards against is not platform-specific.
+    """
+
+    def test_stdio_entrypoint_exits_when_stdin_closes(self, tmp_path):
+        import json
+        import os
+        import queue
+        import subprocess
+        import sys
+        import threading
+
+        import psutil
+
+        port = _free_port()
+        env = dict(os.environ)
+        env["STEALTH_MCP_BROWSER_SESSION_ROOT"] = str(tmp_path / "sessions")
+        env["STEALTH_MCP_NO_AUTO_RECOVERY"] = "1"
+
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "stealth_chrome_devtools_mcp",
+             "--singleton-port", str(port)],
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            text=True, bufsize=1, env=env,
+        )
+        spawned = []
+        try:
+            answers = queue.Queue()
+
+            def _reader():
+                try:
+                    for line in proc.stdout:
+                        answers.put(line)
+                finally:
+                    answers.put(None)
+
+            threading.Thread(target=_reader, daemon=True).start()
+
+            init = {
+                "jsonrpc": "2.0", "id": 1, "method": "initialize",
+                "params": {"protocolVersion": "2025-03-26", "capabilities": {},
+                           "clientInfo": {"name": "entrypoint-test", "version": "1"}},
+            }
+            proc.stdin.write(json.dumps(init) + "\n")
+            proc.stdin.flush()
+
+            # The proxy answers initialize locally and instantly.
+            reply = answers.get(timeout=30)
+            assert reply and "serverInfo" in reply, f"no initialize answer: {reply!r}"
+
+            # Capture the singleton backend it started so we can reap it after.
+            try:
+                spawned = psutil.Process(proc.pid).children(recursive=True)
+            except psutil.Error:
+                spawned = []
+
+            proc.stdin.close()  # client disconnects: stdin hits EOF
+
+            try:
+                proc.wait(timeout=15)
+            except subprocess.TimeoutExpired:
+                pytest.fail(
+                    "stdio entrypoint did not exit within 15s of client disconnect "
+                    "— the proxy process leak regressed"
+                )
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+            for child in spawned:
+                try:
+                    child.kill()
+                except psutil.Error:
+                    pass

--- a/tests/test_singleton_fast_handshake.py
+++ b/tests/test_singleton_fast_handshake.py
@@ -195,3 +195,75 @@ class TestFastHandshakeEndToEnd:
                 backend.wait(timeout=10)
             except subprocess.TimeoutExpired:
                 backend.kill()
+
+
+@pytest.mark.integration
+class TestProxyExitsOnClientDisconnect:
+    """The stdio proxy MUST exit when the client (Claude Code) disconnects.
+
+    The leak that made the server unusable: when stdin hits EOF, ``pump_client``
+    ends but ``run_backend``'s ``from_backend`` loop keeps reading the still-open
+    backend stream forever, so the proxy process never returns. Over days of
+    Claude Code restarts/reconnects these pile up (we measured 250 leaked stealth
+    python processes on one machine) until handles/memory are exhausted and a
+    fresh spawn wedges for hours. Closing the client stream must tear the proxy
+    down and return promptly.
+    """
+
+    @pytest.mark.asyncio
+    async def test_proxy_returns_when_client_stream_closes(self, tmp_path):
+        import os
+        import subprocess
+        import sys
+
+        port = _free_port()
+        env = dict(os.environ)
+        env["STEALTH_MCP_BROWSER_SESSION_ROOT"] = str(tmp_path / "sessions")
+        env["STEALTH_BROWSER_DEBUG"] = "false"
+
+        backend = subprocess.Popen(
+            [
+                sys.executable, "-m", "stealth_chrome_devtools_mcp",
+                "--transport", "http", "--port", str(port), "--host", "127.0.0.1",
+            ],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, stdin=subprocess.DEVNULL,
+            env=env,
+        )
+        try:
+            c2p_tx, c2p_rx = anyio.create_memory_object_stream(50)
+            p2c_tx, p2c_rx = anyio.create_memory_object_stream(50)
+            proxy_returned = anyio.Event()
+
+            async with anyio.create_task_group() as tg:
+
+                async def run_proxy():
+                    await _proxy_streams(c2p_rx, p2c_tx, port)
+                    proxy_returned.set()
+
+                tg.start_soon(run_proxy)
+
+                # A real handshake so the backend stream is genuinely live and
+                # from_backend is parked on it (the exact leak condition).
+                await c2p_tx.send(_initialize_msg(1, "2025-03-26"))
+                await c2p_tx.send(_initialized_notification())
+                await c2p_tx.send(_tools_list_msg(2))
+                with anyio.fail_after(90):
+                    await p2c_rx.receive()  # local initialize answer
+                    await p2c_rx.receive()  # tools/list from the real backend
+
+                # The client (Claude Code) disconnects: stdin closes -> EOF.
+                await c2p_tx.aclose()
+
+                # The proxy must notice the dead client and return. On the old
+                # code it parks on the live backend stream forever and this times
+                # out — that is the leaked process.
+                with anyio.fail_after(10):
+                    await proxy_returned.wait()
+
+                tg.cancel_scope.cancel()
+        finally:
+            backend.terminate()
+            try:
+                backend.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                backend.kill()

--- a/uv.lock
+++ b/uv.lock
@@ -1452,7 +1452,7 @@ wheels = [
 
 [[package]]
 name = "stealth-chrome-devtools-mcp"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Version bump: 1.1.0 -> 1.2.0

Release PR for the perf/reliability, storage-bounding, and CLI work just merged to `main`.

### 🔴 Critical fix: stdio proxy/entrypoint process leak (the unusable bug)

When Claude Code disconnected, the stdio entrypoint never exited, so a stranded
process leaked on every disconnect/reconnect. Over days these piled up
(**250 leaked stealth python processes** measured on one machine) until
handles/memory were exhausted and a fresh `spawn_browser` could wedge for hours.

**Two causes, both fixed:**
1. `_proxy_streams` stayed parked on the backend stream forever after the client
   left — now the client pump drives the main task and cancels the rest on
   disconnect.
2. mcp's `stdio_server` holds its teardown open until its stdout-writer task
   ends, which only happens when the write stream is closed — `_bridge` now
   closes the client streams so the entrypoint returns and the process exits.

Local end-to-end validation (running the real `python -m
stealth_chrome_devtools_mcp`) is what caught that fix #1 alone was insufficient —
the unit test passed while the real entrypoint still hung.

**Guards (both run in the CI integration job):**
- `test_stdio_entrypoint_exits_when_stdin_closes` — runs the REAL entrypoint,
  handshakes, closes stdin, asserts exit within 15s. Verified it hangs (fails)
  with the fix removed; passes with it.
- `test_proxy_returns_when_client_stream_closes` — covers the `_proxy_streams` layer.
- `TestCloseKillsProcessTree` — locks in that `close_instance` reaps the whole Chrome tree.

### What shipped since 1.1.0

**#11 - perf: startup, teardown, profile clones**
- Fix startup disconnects in multi-session environments (fast-handshake proxy)
- Teardown 6-8s -> ~1s; clone 40s -> ~2.6s (regenerable caches excluded)
- **Bounded disk** - `STEALTH_MCP_CLONE_STORAGE_CAP_GB` (default 10) reclaims oldest **idle** auto-clones; `STEALTH_MCP_SESSION_STORAGE_CAP_GB` (default 20) trims regenerable cache/model dirs from idle named profiles while **keeping every login**. In-use profiles are never touched.

**#12 - feat: `stealth-chrome-devtools` ops CLI**
- `status` / `profiles` / `cleanup` (dry-run unless `--apply`) / `doctor` / `serve`
- Read-only commands import with `STEALTH_MCP_NO_AUTO_RECOVERY=1`, so running the CLI never disturbs a live server's browsers
- `cleanup` uses the same selectors as the live sweep, so the preview matches `--apply`

### Housekeeping
- Corrects the stale README test count (95 -> 256).

### Release
Publishing is gated on pushing a `v1.2.0` tag (CI verifies the tag matches `pyproject.toml`). This PR only bumps the version - no publish happens on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
