### PR TITLE
audit(stage-3) plan 7/12 — M9: byte-cap response-body store + capture opt-in (F-605)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,13 @@ STEALTH_MCP_SESSION_STORAGE_CAP_GB=20.0
 #STEALTH_MCP_LOG_DIR=
 # Minimum level recorded by the M3 file logger (DEBUG/INFO/WARNING/ERROR/CRITICAL).
 STEALTH_MCP_LOG_LEVEL=INFO
+# Capture response bodies (metadata is always captured). OFF by default (F-605):
+# get_response_content still live-refetches; search/export bodies stay empty until on.
+STEALTH_MCP_NETWORK_CAPTURE_BODIES=false
+# Per-body cap in bytes; a larger body is stored metadata-only. 0 = no cap. (5 MiB)
+STEALTH_MCP_NETWORK_BODY_MAX_BYTES=5242880
+# Total response-body store cap in bytes; oldest bodies evicted first. 0 = no cap. (128 MiB)
+STEALTH_MCP_NETWORK_BODY_STORE_MAX_BYTES=134217728
 
 # -- Legacy-named config (no prefix; names preserved exactly) ---------------
 # Real timeout (seconds) for the synchronous kill phase of close_instance.

--- a/src/stealth_chrome_devtools_mcp/embedded/network_interceptor.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/network_interceptor.py
@@ -3,6 +3,7 @@
 import asyncio
 import base64
 import json
+from collections import deque
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -12,6 +13,8 @@ from debug_logger import debug_logger
 from models import NetworkRequest, NetworkResponse
 from nodriver import Tab
 
+from stealth_chrome_devtools_mcp.settings import get_settings
+
 
 class NetworkInterceptor:
     """Intercepts and manages network traffic for browser instances."""
@@ -20,8 +23,12 @@ class NetworkInterceptor:
         self._requests: dict[str, NetworkRequest] = {}
         self._responses: dict[str, NetworkResponse] = {}
         self._instance_requests: dict[str, list[str]] = {}
-        self._instance_filters: dict[str, dict[str, list[str]]] = {}
+        self._instance_filters: dict[str, dict[str, Any]] = {}
         self._lock = asyncio.Lock()
+        # Byte-bounded body store (F-605): running total of stored response-body
+        # bytes, plus the FIFO capture order used for oldest-first eviction.
+        self._body_bytes: int = 0
+        self._body_order: deque[str] = deque()
 
     async def setup_interception(
         self, tab: Tab, instance_id: str, block_resources: list[str] | None = None
@@ -175,8 +182,15 @@ class NetworkInterceptor:
             request_id = event.request_id
             response = event.response
 
+            async with self._lock:
+                capture_bodies = self._instance_filters.get(instance_id, {}).get(
+                    "capture_bodies"
+                )
+            if capture_bodies is None:
+                capture_bodies = get_settings().network_capture_bodies
+
             body = None
-            if tab:
+            if capture_bodies and tab:
                 try:
                     result = await tab.send(
                         uc.cdp.network.get_response_body(request_id=request_id)
@@ -209,7 +223,7 @@ class NetworkInterceptor:
                 body=body,
             )
             async with self._lock:
-                self._responses[request_id] = network_response
+                self._store_response(request_id, network_response)
         except Exception as e:
             debug_logger.log_warning(
                 "network_interceptor",
@@ -217,11 +231,63 @@ class NetworkInterceptor:
                 f"Failed to capture response for {instance_id}: {e}",
             )
 
+    def _store_response(self, request_id: str, response: NetworkResponse) -> None:
+        """Insert a response into the byte-bounded body store (F-605).
+
+        The single write chokepoint for the body store; callers (``_on_response``,
+        ``import_from_json``) MUST already hold ``self._lock``. Both caps are
+        resolved from Settings at call time and treat 0 as "no cap":
+
+        * per-body (``network_body_max_bytes``): a body larger than the cap is
+          dropped to ``None`` (its metadata is still stored).
+        * total store (``network_body_store_max_bytes``): once the running byte
+          total exceeds the cap, oldest-captured bodies are evicted FIFO — their
+          ``.body`` nulled, metadata kept — until back under the cap.
+        """
+        settings = get_settings()
+        max_body = settings.network_body_max_bytes
+        max_store = settings.network_body_store_max_bytes
+
+        # Overwrite: drop the previously-counted bytes for this request_id first.
+        prior = self._responses.get(request_id)
+        if prior is not None and prior.body is not None:
+            self._body_bytes -= len(prior.body)
+
+        if response.body is not None and max_body and len(response.body) > max_body:
+            debug_logger.log_debug(
+                "network_interceptor",
+                "_store_response",
+                f"response body for {request_id} ({len(response.body)} bytes) "
+                f"exceeds per-body cap {max_body}; storing metadata only",
+            )
+            response.body = None
+
+        self._responses[request_id] = response
+        if response.body is not None:
+            self._body_bytes += len(response.body)
+            self._body_order.append(request_id)
+
+        while max_store and self._body_bytes > max_store and self._body_order:
+            oldest_id = self._body_order.popleft()
+            victim = self._responses.get(oldest_id)
+            if victim is None or victim.body is None:
+                continue  # already cleared or evicted; skip its stale order entry
+            evicted = len(victim.body)
+            self._body_bytes -= evicted
+            debug_logger.log_debug(
+                "network_interceptor",
+                "_store_response",
+                f"evicted oldest response body {oldest_id} ({evicted} bytes) "
+                f"to stay under store cap {max_store}",
+            )
+            victim.body = None
+
     async def set_capture_filters(
         self,
         instance_id: str,
         include_types: list[str] | None = None,
         exclude_types: list[str] | None = None,
+        capture_bodies: bool | None = None,
     ):
         """
         Set resource type filters for network capture.
@@ -230,24 +296,45 @@ class NetworkInterceptor:
         include_types: Optional[List[str]] - Only capture these types
         (Document, Stylesheet, Image, Media, Font, Script, XHR, Fetch, etc).
         exclude_types: Optional[List[str]] - Exclude these types from capture.
+        capture_bodies: Optional[bool] - Enable/disable response-body capture for
+        this instance (overrides the STEALTH_MCP_NETWORK_CAPTURE_BODIES default).
+
+        Each argument is merged into the existing entry; passing None leaves that
+        field unchanged (a capture_bodies-only update keeps include/exclude).
         """
         async with self._lock:
-            self._instance_filters[instance_id] = {
-                "include": include_types or [],
-                "exclude": exclude_types or [],
-            }
-
-    async def get_capture_filters(self, instance_id: str) -> dict[str, list[str]]:
-        """
-        Get current capture filters.
-
-        instance_id: str - The browser instance identifier.
-        Returns: Dict[str, List[str]] - Current filters.
-        """
-        async with self._lock:
-            return self._instance_filters.get(
+            entry = self._instance_filters.setdefault(
                 instance_id, {"include": [], "exclude": []}
             )
+            if include_types is not None:
+                entry["include"] = include_types
+            if exclude_types is not None:
+                entry["exclude"] = exclude_types
+            if capture_bodies is not None:
+                entry["capture_bodies"] = capture_bodies
+
+    async def get_capture_filters(self, instance_id: str) -> dict[str, Any]:
+        """
+        Get current capture filters plus resolved body-capture state and store stats.
+
+        instance_id: str - The browser instance identifier.
+        Returns: Dict[str, Any] - include/exclude lists, the resolved
+        capture_bodies flag, and body-store byte usage vs the configured caps.
+        """
+        async with self._lock:
+            entry = self._instance_filters.get(instance_id, {})
+            settings = get_settings()
+            capture_bodies = entry.get("capture_bodies")
+            if capture_bodies is None:
+                capture_bodies = settings.network_capture_bodies
+            return {
+                "include": entry.get("include", []),
+                "exclude": entry.get("exclude", []),
+                "capture_bodies": capture_bodies,
+                "body_store_bytes": self._body_bytes,
+                "body_store_max_bytes": settings.network_body_store_max_bytes,
+                "body_max_bytes": settings.network_body_max_bytes,
+            }
 
     async def search_requests(  # noqa: PLR0913  PERMANENT(function interface)
         self,
@@ -530,7 +617,7 @@ class NetworkInterceptor:
                     else None,
                     timestamp=datetime.fromisoformat(resp_data["timestamp"]),
                 )
-                self._responses[resp.request_id] = resp
+                self._store_response(resp.request_id, resp)
 
             return True
 
@@ -664,6 +751,8 @@ class NetworkInterceptor:
             if instance_id in self._instance_requests:
                 for req_id in self._instance_requests[instance_id]:
                     self._requests.pop(req_id, None)
-                    self._responses.pop(req_id, None)
+                    removed = self._responses.pop(req_id, None)
+                    if removed is not None and removed.body is not None:
+                        self._body_bytes -= len(removed.body)
                 del self._instance_requests[instance_id]
             self._instance_filters.pop(instance_id, None)

--- a/src/stealth_chrome_devtools_mcp/embedded/server.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/server.py
@@ -1376,6 +1376,14 @@ async def spawn_browser(
             creating one as a deliberate, space-consuming action. Do not invent names.
         sandbox (Optional[Any]): Enable browser sandbox. Accepts bool, string ('true'/'false'), int (1/0), or None for auto-detect.
 
+    Network interception captures request/response metadata by default, but
+    response *bodies* are NOT stored unless capture is enabled — via
+    set_network_capture_filters(capture_bodies=True) or
+    STEALTH_MCP_NETWORK_CAPTURE_BODIES=1 (F-605, off by default). When on, the
+    body store is byte-bounded (STEALTH_MCP_NETWORK_BODY_MAX_BYTES per body,
+    STEALTH_MCP_NETWORK_BODY_STORE_MAX_BYTES total). get_response_content
+    live-refetches a body on demand regardless of this setting.
+
     Returns:
         Dict[str, Any]: Instance information including instance_id.
     """
@@ -2199,10 +2207,23 @@ async def get_request_details(request_id: str) -> dict[str, Any] | None:
     return None
 
 
+# Surfaced by the body-consuming tools when a body is absent because capture is
+# off, so an empty body doesn't read as a broken tool (F-605, off-by-default).
+_CAPTURE_OFF_NOTE = (
+    "response-body capture is off; enable via "
+    "set_network_capture_filters(capture_bodies=True) or "
+    "STEALTH_MCP_NETWORK_CAPTURE_BODIES=1"
+)
+
+
 @section_tool("network-debugging")
 async def get_response_details(request_id: str) -> dict[str, Any] | None:
     """
     Get response details for a network request.
+
+    Response bodies are only stored when capture is enabled (off by default);
+    status/headers/content-type metadata is always captured. When the body is
+    absent because capture is off, a ``capture_note`` explains how to enable it.
 
     Args:
         request_id (str): Network request ID.
@@ -2212,7 +2233,10 @@ async def get_response_details(request_id: str) -> dict[str, Any] | None:
     """
     response = await network_interceptor.get_response(request_id)
     if response:
-        return response.dict()
+        result = response.dict()
+        if response.body is None and not get_settings().network_capture_bodies:
+            result["capture_note"] = _CAPTURE_OFF_NOTE
+        return result
     return None
 
 
@@ -2220,6 +2244,10 @@ async def get_response_details(request_id: str) -> dict[str, Any] | None:
 async def get_response_content(instance_id: str, request_id: str) -> str | None:
     """
     Get response body content.
+
+    Live-refetches the body from CDP on demand, so it works even when
+    response-body capture is off (the default) and independent of the stored-body
+    cap. CDP evicts bodies from its own buffer quickly, so fetch soon after load.
 
     Args:
         instance_id (str): Browser instance ID.
@@ -2271,9 +2299,10 @@ async def search_network_requests(
         offset (int): Starting index for pagination.
 
     Returns:
-        Dict[str, Any]: Paginated results with metadata.
+        Dict[str, Any]: Paginated results with metadata. Includes a ``capture_note``
+        when body capture is off (response_contains matching is unavailable then).
     """
-    return await network_interceptor.search_requests(
+    result = await network_interceptor.search_requests(
         instance_id,
         url_pattern,
         method,
@@ -2284,10 +2313,14 @@ async def search_network_requests(
         limit,
         offset,
     )
+    filters = await network_interceptor.get_capture_filters(instance_id)
+    if not filters.get("capture_bodies"):
+        result["capture_note"] = _CAPTURE_OFF_NOTE
+    return result
 
 
 @section_tool("network-debugging")
-async def export_network_data(instance_id: str, filepath: str) -> bool:
+async def export_network_data(instance_id: str, filepath: str) -> dict[str, Any]:
     """
     Export network data to JSON file.
 
@@ -2296,9 +2329,15 @@ async def export_network_data(instance_id: str, filepath: str) -> bool:
         filepath (str): Path to save JSON file.
 
     Returns:
-        bool: True if successful.
+        Dict[str, Any]: ``{"success": bool}``, plus a ``capture_note`` when body
+        capture is off (exported responses have no bodies until it is enabled).
     """
-    return await network_interceptor.export_to_json(instance_id, filepath)
+    success = await network_interceptor.export_to_json(instance_id, filepath)
+    result: dict[str, Any] = {"success": success}
+    filters = await network_interceptor.get_capture_filters(instance_id)
+    if not filters.get("capture_bodies"):
+        result["capture_note"] = _CAPTURE_OFF_NOTE
+    return result
 
 
 @section_tool("network-debugging")
@@ -2321,6 +2360,7 @@ async def set_network_capture_filters(
     instance_id: str,
     include_types: list[str] | None = None,
     exclude_types: list[str] | None = None,
+    capture_bodies: bool | None = None,
 ) -> bool:
     """
     Set resource type filters for network capture to reduce memory usage.
@@ -2329,6 +2369,9 @@ async def set_network_capture_filters(
         instance_id (str): Browser instance ID.
         include_types (Optional[List[str]]): Only capture these types (e.g., ['XHR', 'Fetch', 'Document']).
         exclude_types (Optional[List[str]]): Exclude these types (e.g., ['Image', 'Stylesheet', 'Font', 'Script']).
+        capture_bodies (Optional[bool]): Enable/disable response-body capture for this
+            instance (default off; overrides STEALTH_MCP_NETWORK_CAPTURE_BODIES). Each
+            argument is merged — passing only capture_bodies keeps include/exclude.
 
     Common resource types: Document, Stylesheet, Image, Media, Font, Script, XHR, Fetch, WebSocket, Manifest, Other
 
@@ -2336,21 +2379,23 @@ async def set_network_capture_filters(
         bool: True if successful.
     """
     await network_interceptor.set_capture_filters(
-        instance_id, include_types, exclude_types
+        instance_id, include_types, exclude_types, capture_bodies
     )
     return True
 
 
 @section_tool("network-debugging")
-async def get_network_capture_filters(instance_id: str) -> dict[str, list[str]]:
+async def get_network_capture_filters(instance_id: str) -> dict[str, Any]:
     """
-    Get current network capture filters.
+    Get current network capture filters plus resolved body-capture state.
 
     Args:
         instance_id (str): Browser instance ID.
 
     Returns:
-        Dict[str, List[str]]: Current filters with 'include' and 'exclude' lists.
+        Dict[str, Any]: 'include'/'exclude' lists, the resolved 'capture_bodies'
+        flag, and body-store usage ('body_store_bytes', 'body_store_max_bytes',
+        'body_max_bytes').
     """
     return await network_interceptor.get_capture_filters(instance_id)
 

--- a/src/stealth_chrome_devtools_mcp/settings.py
+++ b/src/stealth_chrome_devtools_mcp/settings.py
@@ -62,6 +62,13 @@ class Settings(BaseSettings):
     # logging setup must never be the reason the server won't boot.
     log_level: str = "INFO"
 
+    # -- Response-body capture (F-605) ---------------------------------------
+    # Body capture is OFF by default (metadata is always captured); when on, the
+    # response-body store is byte-bounded. 0 on either byte cap = unbounded.
+    network_capture_bodies: bool = False
+    network_body_max_bytes: int = Field(5 * 1024 * 1024, ge=0)
+    network_body_store_max_bytes: int = Field(128 * 1024 * 1024, ge=0)
+
     # -- Legacy unprefixed config (names preserved verbatim via alias) -------
     # 0 = idle reaping disabled (never auto-close): the correct default for a
     # persistent server. The old server.py forced BROWSER_IDLE_TIMEOUT=0 via an

--- a/tests/test_network_interceptor.py
+++ b/tests/test_network_interceptor.py
@@ -7,6 +7,9 @@ filter logic that the MCP network tools call. These are the filters an agent
 relies on to find the one request that matters among thousands.
 """
 
+import base64
+import json
+
 from models import NetworkRequest, NetworkResponse
 from network_interceptor import NetworkInterceptor
 
@@ -75,20 +78,54 @@ def _fixture():
     return ni
 
 
+class _SpyTab:
+    """Minimal async CDP tab double for ``_on_response``: counts body-fetch
+    sends and either returns a ``(body, base64_encoded)`` tuple or raises."""
+
+    def __init__(self, body=None, raises=None):
+        self._body = body
+        self._raises = raises
+        self.send_count = 0
+
+    async def send(self, cmd):
+        self.send_count += 1
+        close = getattr(cmd, "close", None)
+        if close:
+            close()  # close the un-driven CDP command generator (no warning)
+        if self._raises is not None:
+            raise self._raises
+        return self._body
+
+
+class _FakeResponse:
+    def __init__(self, status=200, headers=None, mime_type="application/json"):
+        self.status = status
+        self.headers = headers or {}
+        self.mime_type = mime_type
+
+
+class _FakeEvent:
+    def __init__(self, request_id, response):
+        self.request_id = request_id
+        self.response = response
+
+
 class TestCaptureFilters:
     async def test_default_filters_empty(self):
         ni = NetworkInterceptor()
-        assert await ni.get_capture_filters("i1") == {"include": [], "exclude": []}
+        filters = await ni.get_capture_filters("i1")
+        assert filters["include"] == []
+        assert filters["exclude"] == []
+        assert filters["capture_bodies"] is False  # off by default
 
     async def test_set_and_get_filters(self):
         ni = NetworkInterceptor()
         await ni.set_capture_filters(
             "i1", include_types=["XHR"], exclude_types=["Image"]
         )
-        assert await ni.get_capture_filters("i1") == {
-            "include": ["XHR"],
-            "exclude": ["Image"],
-        }
+        filters = await ni.get_capture_filters("i1")
+        assert filters["include"] == ["XHR"]
+        assert filters["exclude"] == ["Image"]
 
 
 class TestSearchRequests:
@@ -156,3 +193,178 @@ class TestListAndGet:
         ni = _fixture()
         assert (await ni.get_response("r2")).status == 401
         assert await ni.get_response("nope") is None
+
+
+class TestBodyStoreByteCaps:
+    """M9-1 (F-605): the response-body store is byte-bounded at its single
+    write chokepoint ``_store_response``. Caps are resolved from Settings at
+    call time; the autouse ``_reset_settings_cache`` fixture makes
+    ``monkeypatch.setenv`` visible. 0 on either cap = unbounded.
+    """
+
+    def test_over_per_body_cap_drops_body_keeps_metadata(self, monkeypatch):
+        monkeypatch.setenv("STEALTH_MCP_NETWORK_BODY_MAX_BYTES", "100")
+        ni = NetworkInterceptor()
+        ni._store_response("r1", _resp("r1", status=200, body=b"x" * 200))
+        stored = ni._responses["r1"]
+        assert stored.body is None  # over per-body cap -> body dropped
+        assert stored.status == 200  # metadata retained
+        assert ni._body_bytes == 0  # nothing counted
+        assert "r1" not in ni._body_order  # not tracked for eviction
+
+    def test_total_store_cap_evicts_oldest_fifo(self, monkeypatch):
+        monkeypatch.setenv("STEALTH_MCP_NETWORK_BODY_STORE_MAX_BYTES", "250")
+        monkeypatch.setenv("STEALTH_MCP_NETWORK_BODY_MAX_BYTES", "0")  # no per-body cap
+        ni = NetworkInterceptor()
+        ni._store_response("r1", _resp("r1", body=b"a" * 100))
+        ni._store_response("r2", _resp("r2", body=b"b" * 100))
+        ni._store_response("r3", _resp("r3", body=b"c" * 100))  # 300 > 250 -> evict
+        assert ni._body_bytes <= 250
+        assert ni._body_bytes == 200
+        assert ni._responses["r1"].body is None  # oldest evicted first (FIFO)
+        assert ni._responses["r2"].body == b"b" * 100
+        assert ni._responses["r3"].body == b"c" * 100
+
+    def test_overwrite_same_request_id_does_not_double_count(self, monkeypatch):
+        monkeypatch.setenv("STEALTH_MCP_NETWORK_BODY_MAX_BYTES", "0")
+        monkeypatch.setenv("STEALTH_MCP_NETWORK_BODY_STORE_MAX_BYTES", "0")
+        ni = NetworkInterceptor()
+        ni._store_response("r1", _resp("r1", body=b"x" * 100))
+        assert ni._body_bytes == 100
+        ni._store_response("r1", _resp("r1", body=b"y" * 30))  # overwrite
+        assert ni._body_bytes == 30  # prior 100 subtracted, not summed to 130
+        assert ni._responses["r1"].body == b"y" * 30
+
+    def test_cap_zero_is_unbounded(self, monkeypatch):
+        monkeypatch.setenv("STEALTH_MCP_NETWORK_BODY_MAX_BYTES", "0")
+        monkeypatch.setenv("STEALTH_MCP_NETWORK_BODY_STORE_MAX_BYTES", "0")
+        ni = NetworkInterceptor()
+        for i in range(5):
+            ni._store_response(f"r{i}", _resp(f"r{i}", body=b"z" * 1_000_000))
+        assert ni._body_bytes == 5_000_000  # nothing dropped or evicted
+        assert all(ni._responses[f"r{i}"].body is not None for i in range(5))
+
+    async def test_import_from_json_is_capped(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("STEALTH_MCP_NETWORK_BODY_STORE_MAX_BYTES", "250")
+        monkeypatch.setenv("STEALTH_MCP_NETWORK_BODY_MAX_BYTES", "0")
+        requests, responses = [], []
+        for i in range(3):
+            rid = f"r{i}"
+            requests.append(
+                {
+                    "request_id": rid,
+                    "url": f"https://x/{i}",
+                    "method": "GET",
+                    "headers": {},
+                    "cookies": {},
+                    "post_data": None,
+                    "resource_type": "XHR",
+                    "timestamp": "2026-01-01T00:00:00",
+                }
+            )
+            responses.append(
+                {
+                    "request_id": rid,
+                    "status": 200,
+                    "headers": {},
+                    "content_type": "application/json",
+                    "body": base64.b64encode(b"q" * 100).decode("utf-8"),
+                    "timestamp": "2026-01-01T00:00:00",
+                }
+            )
+        fp = tmp_path / "net.json"
+        fp.write_text(json.dumps({"requests": requests, "responses": responses}))
+        ni = NetworkInterceptor()
+        await ni.import_from_json("i1", str(fp))
+        assert ni._body_bytes <= 250
+        assert ni._responses["r0"].body is None  # oldest imported evicted first
+        assert ni._responses["r2"].body is not None
+
+    async def test_clear_instance_data_returns_body_bytes_to_zero(self, monkeypatch):
+        monkeypatch.setenv("STEALTH_MCP_NETWORK_BODY_MAX_BYTES", "0")
+        monkeypatch.setenv("STEALTH_MCP_NETWORK_BODY_STORE_MAX_BYTES", "0")
+        ni = NetworkInterceptor()
+        ni._instance_requests["i1"] = []
+        for i in range(3):
+            rid = f"r{i}"
+            ni._instance_requests["i1"].append(rid)
+            ni._store_response(rid, _resp(rid, body=b"m" * 100))
+        assert ni._body_bytes == 300
+        await ni.clear_instance_data("i1")
+        assert ni._body_bytes == 0
+        assert ni._responses == {}
+
+
+class TestCaptureOptIn:
+    """M9-2 (F-605): response-body capture is opt-in / off-by-default.
+    ``_on_response`` gates the CDP body fetch on the resolved capture flag —
+    the per-instance filter if set, else ``network_capture_bodies``."""
+
+    async def test_default_off_stores_metadata_and_skips_body_fetch(self):
+        ni = NetworkInterceptor()
+        tab = _SpyTab(body=("hello", False))
+        await ni._on_response(_FakeEvent("r1", _FakeResponse(status=200)), "i1", tab)
+        stored = await ni.get_response("r1")
+        assert stored is not None
+        assert stored.status == 200  # metadata captured
+        assert stored.body is None  # body not captured
+        assert tab.send_count == 0  # CDP body fetch never attempted
+
+    async def test_per_instance_enable_fetches_and_stores_body(self):
+        ni = NetworkInterceptor()
+        await ni.set_capture_filters("i1", capture_bodies=True)
+        tab = _SpyTab(body=("hello", False))
+        await ni._on_response(_FakeEvent("r1", _FakeResponse()), "i1", tab)
+        stored = await ni.get_response("r1")
+        assert tab.send_count == 1
+        assert stored.body == b"hello"
+        assert ni._body_bytes == len(b"hello")
+
+    async def test_global_env_enable_fetches_body(self, monkeypatch):
+        monkeypatch.setenv("STEALTH_MCP_NETWORK_CAPTURE_BODIES", "1")
+        ni = NetworkInterceptor()
+        tab = _SpyTab(body=("data", False))
+        await ni._on_response(_FakeEvent("r1", _FakeResponse()), "i1", tab)
+        assert tab.send_count == 1
+        assert (await ni.get_response("r1")).body == b"data"
+
+    async def test_capture_bodies_only_update_preserves_include_exclude(self):
+        ni = NetworkInterceptor()
+        await ni.set_capture_filters(
+            "i1", include_types=["XHR"], exclude_types=["Image"]
+        )
+        await ni.set_capture_filters("i1", capture_bodies=True)  # merge, not clobber
+        filters = await ni.get_capture_filters("i1")
+        assert filters["include"] == ["XHR"]
+        assert filters["exclude"] == ["Image"]
+        assert filters["capture_bodies"] is True
+
+    async def test_get_capture_filters_reports_flag_and_store_stats(self, monkeypatch):
+        monkeypatch.setenv("STEALTH_MCP_NETWORK_BODY_STORE_MAX_BYTES", "1000")
+        monkeypatch.setenv("STEALTH_MCP_NETWORK_BODY_MAX_BYTES", "500")
+        ni = NetworkInterceptor()
+        ni._store_response("r1", _resp("r1", body=b"a" * 42))
+        filters = await ni.get_capture_filters("i1")
+        assert filters["capture_bodies"] is False  # resolved global default
+        assert filters["body_store_bytes"] == 42
+        assert filters["body_store_max_bytes"] == 1000
+        assert filters["body_max_bytes"] == 500
+
+    async def test_m10a_7b_debug_log_survives_when_body_fetch_raises(self, monkeypatch):
+        # Carry-through pin: with capture ON, a failing body fetch still emits the
+        # M10a-7b DEBUG record (the log line survived M9's _on_response rewrite).
+        import network_interceptor as ni_mod
+
+        calls = []
+        monkeypatch.setattr(
+            ni_mod.debug_logger,
+            "log_debug",
+            lambda *a, **k: calls.append(a),
+        )
+        ni = NetworkInterceptor()
+        await ni.set_capture_filters("i1", capture_bodies=True)
+        tab = _SpyTab(raises=ValueError("boom"))
+        await ni._on_response(_FakeEvent("r1", _FakeResponse()), "i1", tab)
+        assert tab.send_count == 1
+        assert any("boom" in str(a) for a in calls), "expected M10a-7b debug log"
+        assert (await ni.get_response("r1")).body is None  # metadata still stored

--- a/tests/test_server_network_tools.py
+++ b/tests/test_server_network_tools.py
@@ -1,0 +1,78 @@
+"""Tool-layer pins for M9-2 (F-605): the network tools surface capture state.
+
+Hermetic — the module-global ``network_interceptor`` singleton is swapped for a
+fresh, synthetically-seeded one and the ``@section_tool`` functions are invoked
+through their FastMCP ``.fn`` (the real tool body, minus the transport layer).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make embedded/ importable the same way the real entrypoint / conftest does.
+EMBEDDED_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "stealth_chrome_devtools_mcp"
+    / "embedded"
+)
+if str(EMBEDDED_DIR) not in sys.path:
+    sys.path.insert(0, str(EMBEDDED_DIR))
+
+import server
+from models import NetworkResponse
+from network_interceptor import NetworkInterceptor
+
+
+@pytest.fixture()
+def fresh_interceptor(monkeypatch):
+    """Swap the server's shared interceptor for an empty one per test."""
+    ni = NetworkInterceptor()
+    monkeypatch.setattr(server, "network_interceptor", ni)
+    return ni
+
+
+class TestCaptureNote:
+    async def test_get_response_details_notes_capture_off(self, fresh_interceptor):
+        fresh_interceptor._responses["r1"] = NetworkResponse(
+            request_id="r1", status=200, body=None
+        )
+        result = await server.get_response_details.fn(request_id="r1")
+        assert result["status"] == 200  # metadata still surfaced
+        assert "capture" in result["capture_note"].lower()
+
+    async def test_get_response_details_no_note_when_capture_on(
+        self, fresh_interceptor, monkeypatch
+    ):
+        monkeypatch.setenv("STEALTH_MCP_NETWORK_CAPTURE_BODIES", "1")
+        fresh_interceptor._responses["r1"] = NetworkResponse(
+            request_id="r1", status=200, body=None
+        )
+        result = await server.get_response_details.fn(request_id="r1")
+        assert "capture_note" not in result
+
+    async def test_search_network_requests_notes_capture_off(self, fresh_interceptor):
+        result = await server.search_network_requests.fn(instance_id="i1")
+        assert "capture_note" in result
+
+    async def test_search_no_note_when_capture_on(self, fresh_interceptor):
+        await fresh_interceptor.set_capture_filters("i1", capture_bodies=True)
+        result = await server.search_network_requests.fn(instance_id="i1")
+        assert "capture_note" not in result
+
+    async def test_export_notes_capture_off(self, fresh_interceptor, tmp_path):
+        fp = tmp_path / "net.json"
+        result = await server.export_network_data.fn(instance_id="i1", filepath=str(fp))
+        assert result["success"] is True
+        assert "capture_note" in result
+
+
+class TestCaptureBodiesRoundTrip:
+    async def test_set_and_get_capture_bodies_round_trips(self, fresh_interceptor):
+        await server.set_network_capture_filters.fn(
+            instance_id="i1", include_types=["XHR"], capture_bodies=True
+        )
+        filters = await server.get_network_capture_filters.fn(instance_id="i1")
+        assert filters["capture_bodies"] is True
+        assert filters["include"] == ["XHR"]

--- a/tests/test_silent_excepts_log_7b.py
+++ b/tests/test_silent_excepts_log_7b.py
@@ -67,6 +67,9 @@ class TestNetworkInterceptorSilentExcepts:
         from network_interceptor import NetworkInterceptor
 
         ni = NetworkInterceptor()
+        # Body capture is opt-in (M9-2/F-605); enable it so _on_response actually
+        # attempts the fetch that this test forces to fail.
+        await ni.set_capture_filters("inst-1", capture_bodies=True)
         tab = MagicMock()
         tab.send = AsyncMock(side_effect=ValueError("preflight body-fail"))
 


### PR DESCRIPTION
## What

Executes approved `audit/stage2/plan_M9.md` — the one order-of-magnitude memory item in the audit (**F-605, High**: the network response-body store grew unbounded; `set_capture_filters` couldn't bound it because `_on_response` applied no filter).

**M9-1 — byte-cap the store (kills the OOM on its own).** New `_store_response()` chokepoint (called under `self._lock` by both write sites: `_on_response`, `import_from_json`): per-body cap (default 5 MiB — over-limit bodies stored metadata-only) + total-store cap (default 128 MiB — FIFO eviction of oldest bodies, metadata kept), overwrite-safe accounting, `clear_instance_data` decrements exactly. `0` = no cap.

**M9-2 — capture opt-in, off by default.** `_on_response` skips the CDP body fetch entirely unless enabled per-instance (`set_network_capture_filters(capture_bodies=True)`, merge semantics — include/exclude preserved) or globally (`STEALTH_MCP_NETWORK_CAPTURE_BODIES=1`). Metadata capture stays on; `get_response_content` still live-refetches (store-independent). `get_network_capture_filters` reports the resolved flag + store stats; body-consuming tools emit a `capture_note` when capture is off.

**M9-3 — observability + docs.** Skip/evict DEBUG logs via `debug_logger` (durable per M3); no new silent excepts (M10a-8 guard green); docstrings updated.

## Plan deviations (adjudicated by orchestrator)

1. **`env_utils` → pydantic `Settings`** (mandated pre-launch): plan says parse knobs via `env_utils` — that module was never created; env parsing was consolidated into `settings.py` (F-720/F-763). The 3 knobs are Settings fields, resolved at call time (works with the autouse `get_settings.cache_clear()` fixture). `.env.example` documents them (required by `test_env_example_documents_every_field`).
2. **`export_network_data` return `bool` → `{"success": bool, capture_note?}`**: the plan-required `capture_note` needs a carrier; bool has none. Breaking changes are free per plan §4 (0 users); tool-schema snapshot guard unaffected.
3. **`test_silent_excepts_log_7b.py`**: one-line precondition (`capture_bodies=True`) so the forced-failure body fetch is actually attempted under the new default — the M10a-7b DEBUG log line itself is untouched, and a new carry-through pin covers it independently.

Committed as one commit (units' hunks interleave in the same files); unit breakdown above.

## Known minor edge (documented, not blocking)

`get_response_details` has no `instance_id` param, so its `capture_note` checks the global flag only — a per-instance-enabled instance whose body was evicted could get a note wrongly implying capture is off. Narrow; candidate follow-up.

## New-finding candidates (noticed by executor, NOT fixed — no drive-bys)

- `_body_order` deque accumulates stale ids over very long sessions (correct + memory-safe — eviction skips them; same residual class as plan §7's metadata-count growth).
- `response.dict()` is Pydantic-v2-deprecated (pre-existing idiom in `get_response_details`/`get_request_details`).
- `_on_response(..., tab: Tab = None)` should be `Tab | None` (pre-existing ty warning).

## Verification

- Unit suite: **612 passed, 0 failed** (594 baseline + 18 new pins: 6 byte-cap, 6 opt-in incl. spy-tab zero-CDP-sends + M10a-7b carry-through, 6 tool-layer capture-note/round-trip)
- All pre-commit gates green (ruff format/check, ty, vulture, suppression owners, file budgets — server.py 4401/4425, no bump needed)
- Findings: **F-605 CLOSED**; F-606/F-609 explicitly OUT (different files, per plan §8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjzHHNR3fNZuv3uhc8itY7