### PR TITLE
plan_E2E: fixture web app + deterministic all-tool E2E suite (94-tool coverage manifest)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,13 @@
 """Shared fixtures for stealth-chrome-devtools-mcp test suite."""
 
+import functools
 import json
 import os
 import shutil
 import sys
 import tempfile
+import threading
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from unittest.mock import patch
 
@@ -180,3 +183,81 @@ def patched_server(monkeypatch):
         return server
 
     return _patch
+
+
+# ---------------------------------------------------------------------------
+# plan_E2E — self-contained fixture web app served over a local HTTP server.
+# Session-scoped so the E2E integration suite (and the hermetic smoke test)
+# share one ephemeral-port server. Serves tests/fixture_app plus the four
+# deterministic API routes from plan_E2E §2.2. No external network; the port is
+# ephemeral and threaded through base_url, so it never appears in fixture files.
+# ---------------------------------------------------------------------------
+
+FIXTURE_APP_DIR = Path(__file__).resolve().parent / "fixture_app"
+
+
+class _FixtureHandler(SimpleHTTPRequestHandler):
+    """Static file server for tests/fixture_app + the plan_E2E §2.2 API routes."""
+
+    def log_message(self, *args, **kwargs):
+        """Silence per-request stderr logging (keeps test output clean)."""
+
+    def _send_json(self, payload, status=200, extra_headers=None):
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        for key, value in (extra_headers or {}).items():
+            self.send_header(key, value)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):  # noqa: N802  stdlib override, PERMANENT(interface)
+        if self.path == "/api/json":
+            self._send_json({"ok": True, "value": 42, "source": "fixture"})
+            return
+        if self.path == "/api/set-cookie":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Set-Cookie", "fixture_cookie=server-set; Path=/")
+            self.end_headers()
+            self.wfile.write(b"cookie set")
+            return
+        if self.path == "/redirect":
+            self.send_response(302)
+            self.send_header("Location", "/api/json")
+            self.end_headers()
+            return
+        super().do_GET()
+
+    def do_POST(self):  # noqa: N802  stdlib override, PERMANENT(interface)
+        if self.path == "/api/echo":
+            length = int(self.headers.get("Content-Length") or 0)
+            raw = self.rfile.read(length).decode("utf-8", "replace") if length else ""
+            reflected = {key.lower(): value for key, value in self.headers.items()}
+            self._send_json({"body": raw, "headers": reflected})
+            return
+        self.send_response(404)
+        self.end_headers()
+
+
+@pytest.fixture(scope="session")
+def fixture_app_server():
+    """Yield the base_url of a session-scoped HTTP server for the fixture app.
+
+    Binds an ephemeral 127.0.0.1 port, serves ``tests/fixture_app`` plus the
+    §2.2 JSON/cookie/redirect routes on a daemon thread, and shuts the server
+    down on teardown. Hermetic: importing it costs nothing until a test requests
+    it, and it never touches the network or a fixed port.
+    """
+    handler = functools.partial(_FixtureHandler, directory=str(FIXTURE_APP_DIR))
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    host, port = httpd.server_address
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        thread.join(timeout=5)

--- a/tests/e2e_helpers.py
+++ b/tests/e2e_helpers.py
@@ -1,0 +1,156 @@
+"""Shared harness for the plan_E2E integration suite (real headless Chrome).
+
+ONE home for the mechanism the three ``test_e2e_*.py`` modules reuse when they
+drive a real browser through the MCP's own tools: the importlib load of
+``embedded/server.py``, the FastMCP ``.fn`` unwrap, the Chrome-availability skip
+guard, sandbox kwargs for root/container/CI, a once-per-session warmup, and a
+few JS / action-log / cookie readers. Test LOGIC never lives here — only
+reusable mechanism (this mirrors ``tests/fakes.py`` for the hermetic tier).
+
+Conventions copied verbatim from ``tests/test_browser_integration.py`` so the
+E2E files stay consistent with the existing integration suite.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# ── Load embedded/server.py as a module (it uses bare internal imports). ──
+_spec = importlib.util.spec_from_file_location(
+    "server",
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "stealth_chrome_devtools_mcp"
+    / "embedded"
+    / "server.py",
+)
+_server_mod = importlib.util.module_from_spec(_spec)
+sys.modules.setdefault("server", _server_mod)
+try:
+    _spec.loader.exec_module(_server_mod)
+except Exception:
+    _server_mod = None
+
+server_mod = _server_mod
+
+
+def unwrap(fn):
+    """A FunctionTool wraps the original coroutine as ``.fn`` (no-op if raw)."""
+    return getattr(fn, "fn", fn)
+
+
+# ── Chrome-availability guard (identical policy to the integration suite). ──
+_can_run = False
+_needs_no_sandbox = False
+try:
+    from platform_utils import (
+        check_browser_executable,
+        is_running_as_root,
+        is_running_in_container,
+    )
+
+    _can_run = _server_mod is not None and check_browser_executable() is not None
+    _needs_no_sandbox = (
+        is_running_as_root()
+        or is_running_in_container()
+        or os.environ.get("CI") == "true"
+    )
+except Exception:
+    pass
+
+CAN_RUN = _can_run
+
+
+def integration_pytestmark():
+    """Module-level ``pytestmark``: integration, plus skip when Chrome is absent."""
+    if not _can_run:
+        return [
+            pytest.mark.integration,
+            pytest.mark.skip("Chrome not available or server failed to load"),
+        ]
+    return pytest.mark.integration
+
+
+def get_fn(name):
+    """Return an unwrapped ``server`` tool coroutine by name (skips if missing)."""
+    fn = getattr(_server_mod, name, None)
+    if fn is None:
+        pytest.skip(f"server.{name} not found")
+    return unwrap(fn)
+
+
+def sandbox_kwargs() -> dict:
+    """``{'sandbox': False}`` under root/container/CI, else ``{}``."""
+    return {"sandbox": False} if _needs_no_sandbox else {}
+
+
+# ── Warmup: the first Chrome launch on CI is slow / flaky. Run once per session
+# (the guard makes every later call a no-op), driven by a tiny autouse fixture
+# each E2E module declares — keeps this file logic-only and dodges an unused
+# fixture-import lint. ──
+_warmed_up = False
+
+
+async def warmup_once() -> None:
+    global _warmed_up
+    if _warmed_up or not _can_run:
+        return
+    _warmed_up = True
+    spawn = get_fn("spawn_browser")
+    close = get_fn("close_instance")
+    try:
+        result = await spawn(
+            headless=True, user_data_dir="e2e-warmup", **sandbox_kwargs()
+        )
+        await close(instance_id=result["instance_id"])
+    except Exception:
+        pass  # warmup failure is non-fatal
+
+
+# ── Small readers shared across E2E modules. ──
+async def eval_js(iid: str, expression: str) -> Any:
+    """Evaluate a non-blocking JS expression via ``execute_script``; return result.
+
+    Asserts the tool reported success, so a page/JS error surfaces immediately
+    rather than as a confusing downstream ``None``.
+    """
+    execute = get_fn("execute_script")
+    r = await execute(instance_id=iid, script=expression)
+    assert isinstance(r, dict) and r.get("success") is True, r
+    return r.get("result")
+
+
+async def read_actions(iid: str) -> list[str]:
+    """Return the in-page action log ``window.__actions`` as a Python list."""
+    raw = await eval_js(iid, "JSON.stringify(window.__actions)")
+    return json.loads(raw) if raw else []
+
+
+async def wait_for_js(
+    iid: str,
+    expression: str,
+    expected: Any,
+    timeout: float = 5.0,
+    interval: float = 0.1,
+) -> Any:
+    """Poll a JS expression until it equals ``expected`` or the deadline passes.
+
+    Bounded deadline + fixed interval (no sleep-then-assert), per plan §2.6. On
+    timeout the last observed value is returned so the caller's assert shows the
+    real mismatch.
+    """
+    deadline = time.monotonic() + timeout
+    last = await eval_js(iid, expression)
+    while last != expected and time.monotonic() < deadline:
+        await asyncio.sleep(interval)
+        last = await eval_js(iid, expression)
+    return last

--- a/tests/e2e_helpers.py
+++ b/tests/e2e_helpers.py
@@ -116,6 +116,31 @@ async def warmup_once() -> None:
         pass  # warmup failure is non-fatal
 
 
+async def navigate_and_settle(iid: str, url: str, timeout: float = 10.0):
+    """Navigate, then block until the DOM is queryable — returns the nav result.
+
+    After navigation, nodriver's cached document node is transiently stale, so the
+    FIRST DOM-node-path tool call (``tab.select``/``select_all``) can fail on slow
+    CI: ``click_element`` raises ``ProtocolException`` (-32000, "Could not find
+    node with given id") and ``query_elements`` swallows the same exception into an
+    empty list (the finding-#8 class). One successful ``body`` select refreshes the
+    cached document, making subsequent node-path calls stable — so we settle it
+    ONCE here per navigation (a workaround pending the src fix). ``query_elements``
+    is the safe probe PRECISELY because it swallows the exception (returns [] rather
+    than raising), so the poll can retry until the document is fresh. The real
+    navigate result is returned unchanged so callers can still assert on it.
+    """
+    navigate = get_fn("navigate")
+    query_elements = get_fn("query_elements")
+    result = await navigate(instance_id=iid, url=url)
+    deadline = time.monotonic() + timeout
+    body = await query_elements(instance_id=iid, selector="body")
+    while not (isinstance(body, list) and body) and time.monotonic() < deadline:
+        await asyncio.sleep(0.25)
+        body = await query_elements(instance_id=iid, selector="body")
+    return result
+
+
 # ── Small readers shared across E2E modules. ──
 async def eval_js(iid: str, expression: str) -> Any:
     """Evaluate a non-blocking JS expression via ``execute_script``; return result.

--- a/tests/fixture_app/app.js
+++ b/tests/fixture_app/app.js
@@ -1,0 +1,147 @@
+/* Single JS home for the fixture app (plan_E2E STEP 1).
+ *
+ * Every page includes this via <script src="app.js">. It defines the action
+ * log and the global hook surface immediately (so cdp-functions / dynamic-hook
+ * tests see them right after load), then wires whichever fixture elements are
+ * present once the DOM is ready. No external URLs; the only timer is the
+ * bounded 200ms reveal used as a wait_for_element target.
+ */
+
+(function () {
+  "use strict";
+
+  // --- Action log: proof that "the right action was performed". Each entry is
+  // "<kind>:<id>" plus ":<detail>" when a detail is supplied. ---
+  window.__actions = [];
+  window.logAction = function logAction(kind, id, detail) {
+    var entry = kind + ":" + id;
+    if (detail !== undefined && detail !== null) {
+      entry += ":" + detail;
+    }
+    window.__actions.push(entry);
+    var pre = document.getElementById("action-log");
+    if (pre) {
+      pre.textContent = window.__actions.join("\n");
+    }
+  };
+
+  // --- Global function + hookable API surface (cdp-functions / hooks tests). ---
+  window.calcTotal = function calcTotal(a, b) {
+    return a + b;
+  };
+  window.appAPI = {
+    getUser: function () {
+      return { id: 7, name: "Fixture User", role: "tester" };
+    },
+    setFlag: function (v) {
+      window.__flag = v;
+      return v;
+    },
+    version: "1.0-fixture",
+  };
+  // Same-origin fetch trigger reused by network + dynamic-hook interception.
+  window.triggerFetch = function triggerFetch(path) {
+    return fetch(path).then(function (r) {
+      return r.status;
+    });
+  };
+
+  function on(id, event, handler) {
+    var el = document.getElementById(id);
+    if (el) {
+      el.addEventListener(event, handler);
+    }
+    return el;
+  }
+
+  function wire() {
+    // Counter button increments #counter-value.
+    on("btn-counter", "click", function () {
+      var v = document.getElementById("counter-value");
+      if (v) {
+        v.textContent = String(parseInt(v.textContent, 10) + 1);
+      }
+      window.logAction("click", "btn-counter");
+    });
+
+    // Select / checkbox / radios log the chosen value as detail.
+    on("select-single", "change", function (e) {
+      window.logAction("change", "select-single", e.target.value);
+    });
+    on("check-me", "change", function (e) {
+      window.logAction("change", "check-me", e.target.checked ? "on" : "off");
+    });
+    var radios = document.querySelectorAll("input[name='flavor']");
+    for (var i = 0; i < radios.length; i++) {
+      radios[i].addEventListener("change", function (e) {
+        window.logAction("change", "flavor", e.target.value);
+      });
+    }
+
+    // Text + textarea log their natural events (value is the primary assert).
+    on("text-input", "keydown", function () {
+      window.logAction("keydown", "text-input");
+    });
+    on("textarea-input", "input", function () {
+      window.logAction("input", "textarea-input");
+    });
+
+    // Form submit stays on-page.
+    var form = document.getElementById("hook-form");
+    if (form) {
+      form.addEventListener("submit", function (e) {
+        e.preventDefault();
+        window.logAction("submit", "hook-form");
+      });
+    }
+
+    // Bounded reveal: 200ms after the click #delayed-el becomes visible.
+    on("reveal-btn", "click", function () {
+      window.logAction("click", "reveal-btn");
+      setTimeout(function () {
+        var el = document.getElementById("delayed-el");
+        if (el) {
+          el.classList.remove("hidden");
+        }
+      }, 200);
+    });
+
+    // Network trigger buttons (same-origin, document-relative paths).
+    on("fetch-json-btn", "click", function () {
+      window.logAction("click", "fetch-json-btn");
+      window.triggerFetch("api/json");
+    });
+    on("post-echo-btn", "click", function () {
+      window.logAction("click", "post-echo-btn");
+      fetch("api/echo", { method: "POST", body: "fixture-payload" });
+    });
+
+    // Cookie / storage setters.
+    on("set-client-cookie-btn", "click", function () {
+      document.cookie = "client_cookie=from-js; path=/";
+      window.logAction("click", "set-client-cookie-btn");
+    });
+    on("set-local-storage-btn", "click", function () {
+      window.localStorage.setItem("fixture_key", "fixture-value");
+      window.logAction("click", "set-local-storage-btn");
+    });
+
+    // extract.html styled card: one click + one mouseover listener so
+    // extract_element_events has real addEventListener listeners to find.
+    var card = document.getElementById("styled-card");
+    if (card) {
+      card.addEventListener("click", function () {
+        window.logAction("click", "styled-card");
+      });
+      card.addEventListener("mouseover", function () {
+        window.logAction("mouseover", "styled-card");
+      });
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", wire);
+  } else {
+    wire();
+  }
+})();

--- a/tests/fixture_app/cookies.html
+++ b/tests/fixture_app/cookies.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>fixture-cookies-page</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <h1 id="page-title">COOKIES</h1>
+    <p id="sentinel">fixture-cookies-page</p>
+
+    <button id="set-client-cookie-btn">Set client cookie</button>
+    <button id="set-local-storage-btn">Set localStorage</button>
+
+    <pre id="action-log"></pre>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/tests/fixture_app/extract.html
+++ b/tests/fixture_app/extract.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>fixture-extract-page</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <h1 id="page-title">EXTRACT</h1>
+    <p id="sentinel">fixture-extract-page</p>
+
+    <div id="styled-card" data-role="fixture-card" data-level="top">
+      <img
+        id="card-img"
+        alt="fixture pixel"
+        src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+      />
+      <div class="level-1">
+        <div class="level-2">
+          <div class="level-3">
+            <span id="deep-text">DEEP-FIXTURE-TEXT</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <pre id="action-log"></pre>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/tests/fixture_app/hooks.html
+++ b/tests/fixture_app/hooks.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>fixture-hooks-page</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <h1 id="page-title">HOOKS</h1>
+    <p id="sentinel">fixture-hooks-page</p>
+
+    <button id="fetch-json-btn">Fetch JSON</button>
+    <p id="calc-note">calcTotal and appAPI are defined in app.js</p>
+
+    <pre id="action-log"></pre>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/tests/fixture_app/index.html
+++ b/tests/fixture_app/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>fixture-index-page</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <h1 id="page-title">FIXTURE HUB</h1>
+    <p id="sentinel">fixture-index-page</p>
+    <nav>
+      <a href="interact.html" id="nav-interact">Interact</a>
+      <a href="extract.html" id="nav-extract">Extract</a>
+      <a href="network.html" id="nav-network">Network</a>
+      <a href="cookies.html" id="nav-cookies">Cookies</a>
+      <a href="hooks.html" id="nav-hooks">Hooks</a>
+    </nav>
+    <pre id="action-log"></pre>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/tests/fixture_app/interact.html
+++ b/tests/fixture_app/interact.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>fixture-interact-page</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <h1 id="page-title">INTERACT</h1>
+    <p id="sentinel">fixture-interact-page</p>
+
+    <button id="btn-counter">Increment</button>
+    <span id="counter-value">0</span>
+
+    <select id="select-single">
+      <option value="alpha">alpha</option>
+      <option value="beta">beta</option>
+      <option value="gamma">gamma</option>
+    </select>
+
+    <label><input type="checkbox" id="check-me" /> check me</label>
+
+    <fieldset id="flavor-group">
+      <label><input type="radio" name="flavor" value="vanilla" /> vanilla</label>
+      <label><input type="radio" name="flavor" value="chocolate" /> chocolate</label>
+      <label><input type="radio" name="flavor" value="strawberry" /> strawberry</label>
+    </fieldset>
+
+    <input type="text" id="text-input" value="" />
+    <textarea id="textarea-input"></textarea>
+
+    <input type="file" id="single-file" />
+    <input type="file" id="multi-file" multiple />
+
+    <form id="hook-form">
+      <input type="text" id="form-name" name="name" />
+      <button type="submit" id="form-submit">Submit</button>
+    </form>
+
+    <button id="reveal-btn">Reveal</button>
+    <div id="delayed-el" class="hidden">DELAYED-VISIBLE</div>
+
+    <div id="scroll-spacer"></div>
+    <div id="scroll-bottom">SCROLL-BOTTOM-MARKER</div>
+
+    <pre id="action-log"></pre>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/tests/fixture_app/network.html
+++ b/tests/fixture_app/network.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>fixture-network-page</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <h1 id="page-title">NETWORK</h1>
+    <p id="sentinel">fixture-network-page</p>
+
+    <button id="fetch-json-btn">Fetch JSON</button>
+    <button id="post-echo-btn">Post Echo</button>
+
+    <pre id="action-log"></pre>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/tests/fixture_app/styles.css
+++ b/tests/fixture_app/styles.css
@@ -1,0 +1,63 @@
+/* Shared fixture stylesheet (plan_E2E STEP 1).
+ *
+ * Ground-truth styles for #styled-card live here so extract_element_styles
+ * (include_css_rules) and extract_related_files have a real linked stylesheet
+ * to analyze. Every pinned value is repeated verbatim in the E2E asserts, so a
+ * fixture edit surfaces as a test diff. No external URLs; no timing coupling.
+ */
+
+body {
+  font-family: monospace;
+  margin: 0;
+  padding: 16px;
+}
+
+nav a {
+  display: inline-block;
+  margin-right: 8px;
+}
+
+#action-log {
+  border: 1px solid rgb(200, 200, 200);
+  min-height: 20px;
+  white-space: pre-wrap;
+}
+
+/* Ground-truth extraction/cloning component. Pinned computed values:
+ *   color            rgb(17, 34, 51)
+ *   background-color rgb(250, 235, 215)
+ *   padding          12px
+ *   border           2px solid rgb(68, 85, 102)
+ * The animation is PAUSED so computed styles never vary mid-test, while
+ * extract_element_animations still sees a named animation.
+ */
+#styled-card {
+  color: rgb(17, 34, 51);
+  background-color: rgb(250, 235, 215);
+  padding: 12px;
+  border: 2px solid rgb(68, 85, 102);
+  background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==");
+  animation: fixture-pulse 2s infinite;
+  animation-play-state: paused;
+}
+
+#styled-card::before {
+  content: "FIXTURE-BEFORE";
+}
+
+@keyframes fixture-pulse {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0.5;
+  }
+}
+
+.hidden {
+  display: none;
+}
+
+#scroll-spacer {
+  height: 3000px;
+}

--- a/tests/test_e2e_data_tools.py
+++ b/tests/test_e2e_data_tools.py
@@ -1,0 +1,388 @@
+"""plan_E2E STEP 3 — data-tool E2E against the fixture app (real headless Chrome).
+
+Covers network-debugging (10), element-extraction (9), progressive-cloning (10),
+and file-extraction (9). Extraction/clone output is Chrome-version-volatile, so
+tests assert invariant keys + fixture-pinned exact values (a substring of the
+JSON blob), never live-Chrome goldens. Network assertions filter by our URL
+substrings only — never total request counts (Chrome emits background noise).
+
+Determinism per plan §2.6: bounded polling only, the fixture animation is paused,
+every URL is base_url-relative, and every spawn closes in ``finally``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from e2e_helpers import (
+    get_fn,
+    integration_pytestmark,
+    sandbox_kwargs,
+    warmup_once,
+)
+
+pytestmark = integration_pytestmark()
+
+CLONE_OUTPUT_DIR = Path(os.environ["STEALTH_MCP_CLONE_OUTPUT_DIR"]).resolve()
+
+
+@pytest.fixture(autouse=True)
+async def _warmup():
+    await warmup_once()
+    yield
+
+
+async def _find_request(iid: str, url_substr: str, timeout: float = 10.0):
+    """Bounded-poll list_network_requests for a request whose URL contains
+    ``url_substr``. Returns the request dict or None on timeout."""
+    list_requests = get_fn("list_network_requests")
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        reqs = await list_requests(instance_id=iid)
+        if isinstance(reqs, list):
+            for r in reqs:
+                if url_substr in (r.get("url") or ""):
+                    return r
+        await asyncio.sleep(0.25)
+    return None
+
+
+async def _poll_response_details(rid: str, timeout: float = 10.0):
+    """Bounded-poll get_response_details until it returns a non-None dict.
+
+    Eventual-consistency contract: with body capture on, ``_on_response`` awaits
+    the CDP get_response_body fetch BEFORE storing the response record, so a
+    request can surface via ``_find_request`` a short window before its response
+    metadata exists (reported as a finding). Same deadline/interval style as
+    ``_find_request``."""
+    get_response_details = get_fn("get_response_details")
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        details = await get_response_details(request_id=rid)
+        if isinstance(details, dict):
+            return details
+        await asyncio.sleep(0.25)
+    return None
+
+
+def _first_existing_path(result) -> Path | None:
+    """Pull the first string value that names an existing file out of a tool
+    result dict (the to-file tools report their path under file_path/filepath/
+    path; this stays robust to which key)."""
+    if not isinstance(result, dict):
+        return None
+    for value in result.values():
+        if isinstance(value, str) and value.endswith(".json") and Path(value).exists():
+            return Path(value)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# network-debugging (10): capture opt-in, request/response, export/import, headers
+# ---------------------------------------------------------------------------
+
+
+async def test_network_debugging_flow(fixture_app_server, tmp_path):
+    base = fixture_app_server
+    spawn = get_fn("spawn_browser")
+    navigate = get_fn("navigate")
+    click = get_fn("click_element")
+    set_filters = get_fn("set_network_capture_filters")
+    get_filters = get_fn("get_network_capture_filters")
+    get_request_details = get_fn("get_request_details")
+    get_response_content = get_fn("get_response_content")
+    search = get_fn("search_network_requests")
+    export = get_fn("export_network_data")
+    import_data = get_fn("import_network_data")
+    modify_headers = get_fn("modify_headers")
+    close = get_fn("close_instance")
+
+    result = await spawn(headless=True, **sandbox_kwargs())
+    iid = result["instance_id"]
+    try:
+        await navigate(instance_id=iid, url=f"{base}/network.html")
+
+        # M9 opt-in: body capture is OFF by default; enable it for this instance.
+        assert await set_filters(instance_id=iid, capture_bodies=True) is True
+        filters = await get_filters(instance_id=iid)
+        assert filters.get("capture_bodies") is True
+
+        # Trigger a same-origin fetch to /api/json and wait for it to be captured.
+        assert await click(instance_id=iid, selector="#fetch-json-btn")
+        req = await _find_request(iid, "/api/json")
+        assert req is not None, "fetch to /api/json was not captured"
+        rid = req["request_id"]
+
+        assert isinstance(await get_request_details(request_id=rid), dict)
+        # Response metadata lands behind the body CDP fetch when capture is on, so
+        # poll for the response record before asserting it (eventual consistency).
+        assert isinstance(await _poll_response_details(rid), dict), (
+            "response details never became available"
+        )
+
+        # Response body parses to the fixture ground truth (value == 42).
+        body = await get_response_content(instance_id=iid, request_id=rid)
+        assert body is not None
+        assert json.loads(body)["value"] == 42
+
+        # search filters by our URL substring only (never a total count).
+        hits = await search(instance_id=iid, url_pattern="/api/json")
+        assert "/api/json" in json.dumps(hits, default=str)
+
+        # export to tmp_path, then import the same file back.
+        exported = await export(instance_id=iid, filepath=str(tmp_path / "net.json"))
+        assert exported.get("success") is True
+        assert (tmp_path / "net.json").exists()
+        assert await import_data(instance_id=iid, filepath=str(tmp_path / "net.json"))
+
+        # modify_headers -> trigger a POST to /api/echo, which reflects request
+        # headers (lowercased). Proves whether the injected header propagates.
+        assert (
+            await modify_headers(instance_id=iid, headers={"X-Fixture-Injected": "yes"})
+            is True
+        )
+        assert await click(instance_id=iid, selector="#post-echo-btn")
+        echo = await _find_request(iid, "/api/echo")
+        assert echo is not None, "POST to /api/echo was not captured"
+        # Same eventual-consistency window: wait for the response record before
+        # reading its content.
+        assert isinstance(await _poll_response_details(echo["request_id"]), dict)
+        echo_body = await get_response_content(
+            instance_id=iid, request_id=echo["request_id"]
+        )
+        reflected = json.loads(echo_body)
+        assert reflected["body"] == "fixture-payload"
+        assert reflected["headers"].get("x-fixture-injected") == "yes"
+    finally:
+        await close(instance_id=iid)
+
+
+# ---------------------------------------------------------------------------
+# element-extraction (9): ground-truth styles/structure/assets/animations
+# ---------------------------------------------------------------------------
+
+
+async def test_element_extraction_ground_truth(fixture_app_server):
+    base = fixture_app_server
+    spawn = get_fn("spawn_browser")
+    navigate = get_fn("navigate")
+    extract_styles = get_fn("extract_element_styles")
+    extract_structure = get_fn("extract_element_structure")
+    extract_events = get_fn("extract_element_events")
+    extract_animations = get_fn("extract_element_animations")
+    extract_assets = get_fn("extract_element_assets")
+    extract_styles_cdp = get_fn("extract_element_styles_cdp")
+    extract_related = get_fn("extract_related_files")
+    extract_complete_cdp = get_fn("extract_complete_element_cdp")
+    close = get_fn("close_instance")
+
+    result = await spawn(headless=True, **sandbox_kwargs())
+    iid = result["instance_id"]
+    try:
+        await navigate(instance_id=iid, url=f"{base}/extract.html")
+
+        styles = await extract_styles(instance_id=iid, selector="#styled-card")
+        styles_blob = json.dumps(styles, default=str)
+        assert "rgb(17, 34, 51)" in styles_blob  # color ground truth
+        assert "12px" in styles_blob  # padding ground truth
+
+        structure = await extract_structure(
+            instance_id=iid, selector="#styled-card", include_children=True
+        )
+        structure_blob = json.dumps(structure, default=str)
+        assert "styled-card" in structure_blob
+        # Nested >=3 levels deep is represented somewhere in the tree.
+        assert "level-3" in structure_blob or "deep-text" in structure_blob
+
+        events = await extract_events(instance_id=iid, selector="#styled-card")
+        assert isinstance(events, dict)
+
+        animations = await extract_animations(instance_id=iid, selector="#styled-card")
+        assert "fixture-pulse" in json.dumps(animations, default=str)
+
+        assets = await extract_assets(instance_id=iid, selector="#styled-card")
+        assert "data:image/png" in json.dumps(assets, default=str)
+
+        styles_cdp = await extract_styles_cdp(instance_id=iid, selector="#styled-card")
+        assert "rgb(17, 34, 51)" in json.dumps(styles_cdp, default=str)
+
+        related = await extract_related(instance_id=iid)
+        assert "styles.css" in json.dumps(related, default=str)
+
+        complete_cdp = await extract_complete_cdp(
+            instance_id=iid, selector="#styled-card"
+        )
+        assert isinstance(complete_cdp, dict)
+    finally:
+        await close(instance_id=iid)
+
+
+@pytest.mark.characterization
+async def test_clone_element_complete_current_shape(fixture_app_server):
+    """PINS clone_element_complete current output (known M5b selector-forwarding
+    gap: the tool does not forward ``selector`` to its 4 JS sub-extractors). We
+    pin the observable shape so the M5b fix surfaces as a deliberate test update.
+    """
+    base = fixture_app_server
+    spawn = get_fn("spawn_browser")
+    navigate = get_fn("navigate")
+    clone_complete = get_fn("clone_element_complete")
+    close = get_fn("close_instance")
+
+    result = await spawn(headless=True, **sandbox_kwargs())
+    iid = result["instance_id"]
+    try:
+        await navigate(instance_id=iid, url=f"{base}/extract.html")
+        complete = await clone_complete(instance_id=iid, selector="#styled-card")
+        # Current behavior: returns a dict (never raises for a present element).
+        assert isinstance(complete, dict)
+    finally:
+        await close(instance_id=iid)
+
+
+# ---------------------------------------------------------------------------
+# progressive-cloning (10): one clone, every expand_*, then list + clear
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.characterization
+async def test_progressive_cloning_walk(fixture_app_server):
+    """PINS the progressive-clone tier's CURRENT real-Chrome behavior: every
+    expansion comes back EMPTY.
+
+    Finding — progressive tier returns empty expansions under real Chrome:
+    ``comprehensive_element_cloner.extract_complete_element``'s live output shape
+    matches NEITHER shape the progressive readers try (``element.computed_styles``
+    nor a top-level ``styles`` map — see progressive_element_cloner.py:112-161 and
+    the shape-hedging OR at :71-74), so every expand_* reader falls through to its
+    empty default even though #styled-card verifiably has rgb styles, 2 listeners,
+    a ::before, a paused animation, and a 3-level child tree. The fakes-tier
+    goldens (tests/goldens/progressive_expand_*.json) pin the intended NON-empty
+    shape; live Chrome never produces it. Route M5b.
+
+    ``expand_children`` is the lone non-empty reader, but it iterates the KEYS of
+    a dict (``full_data["children"]``) rather than a child list, so we pin only the
+    list/consistency invariants — not the garbage values, which nodriver
+    serialization can shift. The list/clear lifecycle tools work and stay asserted
+    for real.
+    """
+    base = fixture_app_server
+    spawn = get_fn("spawn_browser")
+    navigate = get_fn("navigate")
+    clone_progressive = get_fn("clone_element_progressive")
+    expand_styles = get_fn("expand_styles")
+    expand_events = get_fn("expand_events")
+    expand_children = get_fn("expand_children")
+    expand_css_rules = get_fn("expand_css_rules")
+    expand_pseudo = get_fn("expand_pseudo_elements")
+    expand_animations = get_fn("expand_animations")
+    list_stored = get_fn("list_stored_elements")
+    clear_stored = get_fn("clear_stored_element")
+    clear_all = get_fn("clear_all_elements")
+    close = get_fn("close_instance")
+
+    result = await spawn(headless=True, **sandbox_kwargs())
+    iid = result["instance_id"]
+    try:
+        await navigate(instance_id=iid, url=f"{base}/extract.html")
+
+        base_clone = await clone_progressive(instance_id=iid, selector="#styled-card")
+        assert "element_id" in base_clone
+        assert base_clone["selector"] == "#styled-card"
+        element_id = base_clone["element_id"]
+        # Quirk: the base summary reports zero styles for an element that has them.
+        assert base_clone["base"]["summary"]["styles_count"] == 0
+
+        # Every typed expansion is empty under real Chrome (the finding).
+        styles = await expand_styles(element_id=element_id)
+        assert styles["styles"] == {}
+        assert styles["total_available"] == 0
+
+        assert (await expand_events(element_id=element_id))["event_listeners"] == []
+
+        assert (await expand_css_rules(element_id=element_id))["css_rules"] == []
+
+        # ::before exists in the fixture, yet the reader returns no pseudo-elements.
+        assert (await expand_pseudo(element_id=element_id))["pseudo_elements"] == {}
+
+        # fixture-pulse exists in the fixture, yet the reader returns no animations.
+        assert (await expand_animations(element_id=element_id))["animations"] == {}
+
+        # expand_children is non-empty but reads dict KEYS as "children"; pin only
+        # the list/consistency invariants, not the serialization-volatile values.
+        children = await expand_children(element_id=element_id)
+        assert isinstance(children["children"], list)
+        assert children["total_available"] == children["returned_count"]
+
+        # list + clear lifecycle works correctly (asserted for real, not pinned).
+        stored = await list_stored()
+        assert element_id in json.dumps(stored, default=str)
+
+        assert (await clear_stored(element_id=element_id)).get("success") is True
+        assert (await clear_all()).get("success") is True
+    finally:
+        await close(instance_id=iid)
+
+
+# ---------------------------------------------------------------------------
+# file-extraction (9): every to-file tool lands under the redirected dir, then
+# list + cleanup
+# ---------------------------------------------------------------------------
+
+
+async def test_file_extraction_walk(fixture_app_server):
+    base = fixture_app_server
+    spawn = get_fn("spawn_browser")
+    navigate = get_fn("navigate")
+    clone_to_file = get_fn("clone_element_to_file")
+    complete_to_file = get_fn("extract_complete_element_to_file")
+    styles_to_file = get_fn("extract_element_styles_to_file")
+    structure_to_file = get_fn("extract_element_structure_to_file")
+    events_to_file = get_fn("extract_element_events_to_file")
+    animations_to_file = get_fn("extract_element_animations_to_file")
+    assets_to_file = get_fn("extract_element_assets_to_file")
+    list_clone_files = get_fn("list_clone_files")
+    cleanup_clone_files = get_fn("cleanup_clone_files")
+    close = get_fn("close_instance")
+
+    result = await spawn(headless=True, **sandbox_kwargs())
+    iid = result["instance_id"]
+    try:
+        await navigate(instance_id=iid, url=f"{base}/extract.html")
+
+        results = [
+            await clone_to_file(instance_id=iid, selector="#styled-card"),
+            await complete_to_file(instance_id=iid, selector="#styled-card"),
+            await styles_to_file(instance_id=iid, selector="#styled-card"),
+            await structure_to_file(instance_id=iid, selector="#styled-card"),
+            await events_to_file(instance_id=iid, selector="#styled-card"),
+            await animations_to_file(instance_id=iid, selector="#styled-card"),
+            await assets_to_file(instance_id=iid, selector="#styled-card"),
+        ]
+
+        created = []
+        for res in results:
+            path = _first_existing_path(res)
+            assert path is not None, f"no output file in result: {res}"
+            # Landed under the conftest-redirected clone-output dir (pathlib, not
+            # a string-prefix compare — Windows/Linux safe).
+            assert CLONE_OUTPUT_DIR in path.resolve().parents
+            created.append(path)
+
+        listed = await list_clone_files()
+        assert isinstance(listed, list)
+        assert len(listed) >= len(created)
+
+        # max_age_hours=0 -> every file (ctime in the past) is eligible.
+        cleaned = await cleanup_clone_files(max_age_hours=0)
+        assert cleaned["deleted_count"] >= 1
+        for path in created:
+            assert not path.exists()
+    finally:
+        await close(instance_id=iid)

--- a/tests/test_e2e_data_tools.py
+++ b/tests/test_e2e_data_tools.py
@@ -23,6 +23,7 @@ import pytest
 from e2e_helpers import (
     get_fn,
     integration_pytestmark,
+    navigate_and_settle,
     sandbox_kwargs,
     warmup_once,
 )
@@ -91,7 +92,6 @@ def _first_existing_path(result) -> Path | None:
 async def test_network_debugging_flow(fixture_app_server, tmp_path):
     base = fixture_app_server
     spawn = get_fn("spawn_browser")
-    navigate = get_fn("navigate")
     click = get_fn("click_element")
     set_filters = get_fn("set_network_capture_filters")
     get_filters = get_fn("get_network_capture_filters")
@@ -106,7 +106,7 @@ async def test_network_debugging_flow(fixture_app_server, tmp_path):
     result = await spawn(headless=True, **sandbox_kwargs())
     iid = result["instance_id"]
     try:
-        await navigate(instance_id=iid, url=f"{base}/network.html")
+        await navigate_and_settle(iid, f"{base}/network.html")
 
         # M9 opt-in: body capture is OFF by default; enable it for this instance.
         assert await set_filters(instance_id=iid, capture_bodies=True) is True
@@ -171,7 +171,6 @@ async def test_network_debugging_flow(fixture_app_server, tmp_path):
 async def test_element_extraction_ground_truth(fixture_app_server):
     base = fixture_app_server
     spawn = get_fn("spawn_browser")
-    navigate = get_fn("navigate")
     extract_styles = get_fn("extract_element_styles")
     extract_structure = get_fn("extract_element_structure")
     extract_events = get_fn("extract_element_events")
@@ -185,7 +184,7 @@ async def test_element_extraction_ground_truth(fixture_app_server):
     result = await spawn(headless=True, **sandbox_kwargs())
     iid = result["instance_id"]
     try:
-        await navigate(instance_id=iid, url=f"{base}/extract.html")
+        await navigate_and_settle(iid, f"{base}/extract.html")
 
         styles = await extract_styles(instance_id=iid, selector="#styled-card")
         styles_blob = json.dumps(styles, default=str)
@@ -231,14 +230,13 @@ async def test_clone_element_complete_current_shape(fixture_app_server):
     """
     base = fixture_app_server
     spawn = get_fn("spawn_browser")
-    navigate = get_fn("navigate")
     clone_complete = get_fn("clone_element_complete")
     close = get_fn("close_instance")
 
     result = await spawn(headless=True, **sandbox_kwargs())
     iid = result["instance_id"]
     try:
-        await navigate(instance_id=iid, url=f"{base}/extract.html")
+        await navigate_and_settle(iid, f"{base}/extract.html")
         complete = await clone_complete(instance_id=iid, selector="#styled-card")
         # Current behavior: returns a dict (never raises for a present element).
         assert isinstance(complete, dict)
@@ -274,7 +272,6 @@ async def test_progressive_cloning_walk(fixture_app_server):
     """
     base = fixture_app_server
     spawn = get_fn("spawn_browser")
-    navigate = get_fn("navigate")
     clone_progressive = get_fn("clone_element_progressive")
     expand_styles = get_fn("expand_styles")
     expand_events = get_fn("expand_events")
@@ -290,7 +287,7 @@ async def test_progressive_cloning_walk(fixture_app_server):
     result = await spawn(headless=True, **sandbox_kwargs())
     iid = result["instance_id"]
     try:
-        await navigate(instance_id=iid, url=f"{base}/extract.html")
+        await navigate_and_settle(iid, f"{base}/extract.html")
 
         base_clone = await clone_progressive(instance_id=iid, selector="#styled-card")
         assert "element_id" in base_clone
@@ -339,7 +336,6 @@ async def test_progressive_cloning_walk(fixture_app_server):
 async def test_file_extraction_walk(fixture_app_server):
     base = fixture_app_server
     spawn = get_fn("spawn_browser")
-    navigate = get_fn("navigate")
     clone_to_file = get_fn("clone_element_to_file")
     complete_to_file = get_fn("extract_complete_element_to_file")
     styles_to_file = get_fn("extract_element_styles_to_file")
@@ -354,7 +350,7 @@ async def test_file_extraction_walk(fixture_app_server):
     result = await spawn(headless=True, **sandbox_kwargs())
     iid = result["instance_id"]
     try:
-        await navigate(instance_id=iid, url=f"{base}/extract.html")
+        await navigate_and_settle(iid, f"{base}/extract.html")
 
         results = [
             await clone_to_file(instance_id=iid, selector="#styled-card"),

--- a/tests/test_e2e_functions_hooks.py
+++ b/tests/test_e2e_functions_hooks.py
@@ -16,6 +16,7 @@ import pytest
 from e2e_helpers import (
     CAN_RUN,
     get_fn,
+    navigate_and_settle,
     sandbox_kwargs,
     server_mod,
     warmup_once,
@@ -63,13 +64,12 @@ async def test_cdp_functions_walk(fixture_app_server):
     await warmup_once()
     base = fixture_app_server
     spawn = get_fn("spawn_browser")
-    navigate = get_fn("navigate")
     close = get_fn("close_instance")
 
     result = await spawn(headless=True, **sandbox_kwargs())
     iid = result["instance_id"]
     try:
-        await navigate(instance_id=iid, url=f"{base}/hooks.html")
+        await navigate_and_settle(iid, f"{base}/hooks.html")
 
         commands = await get_fn("list_cdp_commands")()
         assert isinstance(commands, list) and len(commands) > 0
@@ -169,13 +169,12 @@ async def test_execute_cdp_command_rejects_domain_qualified_name(fixture_app_ser
     await warmup_once()
     base = fixture_app_server
     spawn = get_fn("spawn_browser")
-    navigate = get_fn("navigate")
     close = get_fn("close_instance")
 
     result = await spawn(headless=True, **sandbox_kwargs())
     iid = result["instance_id"]
     try:
-        await navigate(instance_id=iid, url=f"{base}/hooks.html")
+        await navigate_and_settle(iid, f"{base}/hooks.html")
         cdp = await get_fn("execute_cdp_command")(
             instance_id=iid,
             command="Runtime.evaluate",
@@ -197,7 +196,6 @@ async def test_dynamic_hooks_lifecycle(fixture_app_server):
     await warmup_once()
     base = fixture_app_server
     spawn = get_fn("spawn_browser")
-    navigate = get_fn("navigate")
     create_simple = get_fn("create_simple_dynamic_hook")
     create_full = get_fn("create_dynamic_hook")
     list_hooks = get_fn("list_dynamic_hooks")
@@ -208,7 +206,7 @@ async def test_dynamic_hooks_lifecycle(fixture_app_server):
     result = await spawn(headless=True, **sandbox_kwargs())
     iid = result["instance_id"]
     try:
-        await navigate(instance_id=iid, url=f"{base}/hooks.html")
+        await navigate_and_settle(iid, f"{base}/hooks.html")
 
         created = await create_simple(
             name="fixture-hook",

--- a/tests/test_e2e_functions_hooks.py
+++ b/tests/test_e2e_functions_hooks.py
@@ -1,0 +1,429 @@
+"""plan_E2E STEP 4 — cdp-functions, dynamic-hooks, debugging + coverage manifest.
+
+The three browser-driven walks (cdp-functions 13, dynamic-hooks 5 async, debug 5)
+are ``@integration_test`` — integration-marked and skipped when Chrome is absent.
+The sync hook-doc tools (5) and the coverage manifest are hermetic and run in the
+unit job: the manifest is a tripwire that breaks if a 95th tool is added without
+deciding its E2E story (same philosophy as the F-108 count pin).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from e2e_helpers import (
+    CAN_RUN,
+    get_fn,
+    sandbox_kwargs,
+    server_mod,
+    warmup_once,
+)
+
+
+def integration_test(fn):
+    """Mark a test integration + skip it when Chrome / the server is unavailable
+    (a per-test guard, since this module also holds hermetic tests)."""
+    fn = pytest.mark.integration(fn)
+    if not CAN_RUN:
+        fn = pytest.mark.skip("Chrome not available or server failed to load")(fn)
+    return fn
+
+
+def _find_hook_id(listing, name):
+    """Recursively find the hook_id of the hook named ``name`` in a list_hooks
+    result (robust to whether hooks sit under 'hooks'/'dynamic_hooks'/etc.)."""
+
+    def walk(obj):
+        if isinstance(obj, dict):
+            if obj.get("name") == name and "hook_id" in obj:
+                return obj["hook_id"]
+            for value in obj.values():
+                found = walk(value)
+                if found:
+                    return found
+        elif isinstance(obj, list):
+            for item in obj:
+                found = walk(item)
+                if found:
+                    return found
+        return None
+
+    return walk(listing)
+
+
+# ---------------------------------------------------------------------------
+# cdp-functions: 13 tools driven against hooks.html
+# ---------------------------------------------------------------------------
+
+
+@integration_test
+async def test_cdp_functions_walk(fixture_app_server):
+    await warmup_once()
+    base = fixture_app_server
+    spawn = get_fn("spawn_browser")
+    navigate = get_fn("navigate")
+    close = get_fn("close_instance")
+
+    result = await spawn(headless=True, **sandbox_kwargs())
+    iid = result["instance_id"]
+    try:
+        await navigate(instance_id=iid, url=f"{base}/hooks.html")
+
+        commands = await get_fn("list_cdp_commands")()
+        assert isinstance(commands, list) and len(commands) > 0
+
+        assert isinstance(await get_fn("get_execution_contexts")(instance_id=iid), list)
+
+        # execute_cdp_command is Runtime-only: it resolves the command via
+        # getattr(uc.cdp.runtime, command), so the domain-qualified
+        # "Runtime.evaluate" never resolves — use the bare snake_case attr
+        # "evaluate" (advertised-vs-executable mismatch pinned separately below).
+        cdp = await get_fn("execute_cdp_command")(
+            instance_id=iid,
+            command="evaluate",
+            params={"expression": "6 * 7", "return_by_value": True},
+        )
+        assert cdp["success"] is True
+        assert "42" in json.dumps(cdp, default=str)
+
+        assert isinstance(
+            await get_fn("discover_global_functions")(instance_id=iid), list
+        )
+        assert isinstance(
+            await get_fn("discover_object_methods")(
+                instance_id=iid, object_path="window.appAPI"
+            ),
+            list,
+        )
+
+        # calcTotal(2, 3) == 5: the retrieved value is our fixture ground truth.
+        call = await get_fn("call_javascript_function")(
+            instance_id=iid, function_path="window.calcTotal", args=[2, 3]
+        )
+        assert isinstance(call, dict)
+        assert "5" in json.dumps(call, default=str)
+
+        assert isinstance(
+            await get_fn("inspect_function_signature")(
+                instance_id=iid, function_path="window.calcTotal"
+            ),
+            dict,
+        )
+
+        injected = await get_fn("inject_and_execute_script")(
+            instance_id=iid, script_code="return 6 * 7;"
+        )
+        assert isinstance(injected, dict)
+
+        assert isinstance(
+            await get_fn("create_persistent_function")(
+                instance_id=iid, function_name="fixtureNoop", function_code="return 1;"
+            ),
+            dict,
+        )
+        seq = await get_fn("execute_function_sequence")(
+            instance_id=iid,
+            function_calls=[{"function_path": "window.calcTotal", "args": [1, 2]}],
+        )
+        # Returns a LIST of per-call records (not a dict). calcTotal(1, 2) == 3.
+        assert isinstance(seq, list) and len(seq) == 1
+        assert seq[0]["result"]["result"] == 3
+        assert isinstance(
+            await get_fn("create_python_binding")(
+                instance_id=iid,
+                binding_name="fixtureBinding",
+                python_code="def handler(x):\n    return x",
+            ),
+            dict,
+        )
+
+        # execute_python_in_browser may lack the optional py2js extra — assert
+        # the graceful dict shape either way (never a crash).
+        assert isinstance(
+            await get_fn("execute_python_in_browser")(
+                instance_id=iid, python_code="result = 1 + 1"
+            ),
+            dict,
+        )
+        assert isinstance(
+            await get_fn("get_function_executor_info")(instance_id=iid), dict
+        )
+    finally:
+        await close(instance_id=iid)
+
+
+@integration_test
+@pytest.mark.characterization
+async def test_execute_cdp_command_rejects_domain_qualified_name(fixture_app_server):
+    """PINS execute_cdp_command's advertised-vs-executable mismatch.
+
+    Finding — execute_cdp_command is Runtime-only and rejects domain-qualified
+    names: it resolves the command via ``getattr(uc.cdp.runtime, command)`` (see
+    cdp_function_executor.py:169-171), so ``list_cdp_commands`` advertises
+    camelCase names like 'evaluate'/'callFunctionOn' but a domain-qualified
+    'Runtime.evaluate' (or any non-Runtime domain) can never resolve. The working
+    path uses ``command="evaluate"`` (test_cdp_functions_walk). Route M4-Ph1/M14.
+    """
+    await warmup_once()
+    base = fixture_app_server
+    spawn = get_fn("spawn_browser")
+    navigate = get_fn("navigate")
+    close = get_fn("close_instance")
+
+    result = await spawn(headless=True, **sandbox_kwargs())
+    iid = result["instance_id"]
+    try:
+        await navigate(instance_id=iid, url=f"{base}/hooks.html")
+        cdp = await get_fn("execute_cdp_command")(
+            instance_id=iid,
+            command="Runtime.evaluate",
+            params={"expression": "6 * 7", "return_by_value": True},
+        )
+        assert cdp["success"] is False
+        assert "Unknown CDP command" in json.dumps(cdp, default=str)
+    finally:
+        await close(instance_id=iid)
+
+
+# ---------------------------------------------------------------------------
+# dynamic-hooks (5 async): create (simple + full) -> list -> details -> remove
+# ---------------------------------------------------------------------------
+
+
+@integration_test
+async def test_dynamic_hooks_lifecycle(fixture_app_server):
+    await warmup_once()
+    base = fixture_app_server
+    spawn = get_fn("spawn_browser")
+    navigate = get_fn("navigate")
+    create_simple = get_fn("create_simple_dynamic_hook")
+    create_full = get_fn("create_dynamic_hook")
+    list_hooks = get_fn("list_dynamic_hooks")
+    get_details = get_fn("get_dynamic_hook_details")
+    remove_hook = get_fn("remove_dynamic_hook")
+    close = get_fn("close_instance")
+
+    result = await spawn(headless=True, **sandbox_kwargs())
+    iid = result["instance_id"]
+    try:
+        await navigate(instance_id=iid, url=f"{base}/hooks.html")
+
+        created = await create_simple(
+            name="fixture-hook",
+            url_pattern="/api/json",
+            action="block",
+            instance_ids=[iid],
+        )
+        assert isinstance(created, dict)
+
+        listing = await list_hooks()
+        assert isinstance(listing, dict)
+        hook_id = _find_hook_id(listing, "fixture-hook")
+        assert hook_id, f"created hook not found in listing: {listing}"
+
+        details = await get_details(hook_id=hook_id)
+        assert isinstance(details, dict)
+        assert "fixture-hook" in json.dumps(details, default=str)
+
+        removed = await remove_hook(hook_id=hook_id)
+        assert isinstance(removed, dict)
+        assert _find_hook_id(await list_hooks(), "fixture-hook") is None
+
+        # Full AI-function variant: assert the graceful dict shape, then clean up
+        # any hook it created (its function contract is exercised more deeply in
+        # the hermetic test_dynamic_hook_system.py).
+        full = await create_full(
+            name="fixture-full-hook",
+            requirements={"url_pattern": "/api/json"},
+            function_code="def hook(request):\n    return request",
+            instance_ids=[iid],
+        )
+        assert isinstance(full, dict)
+        full_id = _find_hook_id(await list_hooks(), "fixture-full-hook")
+        if full_id:
+            await remove_hook(hook_id=full_id)
+    finally:
+        await close(instance_id=iid)
+
+
+# ---------------------------------------------------------------------------
+# debugging (5): all global / env-level, no browser needed
+# ---------------------------------------------------------------------------
+
+
+@integration_test
+async def test_debugging_tools(tmp_path):
+    assert isinstance(await get_fn("get_debug_view")(), dict)
+    assert isinstance(await get_fn("get_debug_lock_status")(), dict)
+    exported = await get_fn("export_debug_logs")(filename=str(tmp_path / "dbg.json"))
+    assert isinstance(exported, str)
+    assert await get_fn("clear_debug_view")() is True
+    assert isinstance(await get_fn("validate_browser_environment_tool")(), dict)
+
+
+# ---------------------------------------------------------------------------
+# dynamic-hooks (5 sync doc/validate tools): hermetic, no browser
+# ---------------------------------------------------------------------------
+
+
+def test_hook_doc_tools():
+    for name in (
+        "get_hook_documentation",
+        "get_hook_examples",
+        "get_hook_requirements_documentation",
+        "get_hook_common_patterns",
+    ):
+        payload = get_fn(name)()
+        assert isinstance(payload, dict) and payload  # non-empty documentation
+
+    validated = get_fn("validate_hook_function")(
+        function_code="def hook(request):\n    return request"
+    )
+    assert isinstance(validated, dict)
+
+
+# ---------------------------------------------------------------------------
+# §2.4 coverage manifest — every SECTION_TOOLS name is E2E-covered or exempt
+# ---------------------------------------------------------------------------
+
+# Explicit reasoned literals (NOT derived from the registry) so that adding a
+# 95th tool without deciding its E2E story breaks this test. E2E_COVERED lists
+# every tool a test in this suite drives against the fixture app; E2E_EXEMPT
+# names any tool intentionally left to another tier, each with a reason.
+E2E_COVERED = {
+    # browser-management (8) — test_e2e_interaction.py
+    "spawn_browser",
+    "list_instances",
+    "close_instance",
+    "get_instance_state",
+    "navigate",
+    "go_back",
+    "go_forward",
+    "reload_page",
+    # element-interaction (12) — test_e2e_interaction.py
+    "query_elements",
+    "click_element",
+    "upload_file",
+    "type_text",
+    "paste_text",
+    "select_option",
+    "get_element_state",
+    "wait_for_element",
+    "scroll_page",
+    "execute_script",
+    "get_page_content",
+    "take_screenshot",
+    # cookies-storage (2 of 3; get_cookies is exempt below) — test_e2e_interaction
+    "set_cookie",
+    "clear_cookies",
+    # tabs (5) — test_e2e_interaction.py
+    "list_tabs",
+    "switch_tab",
+    "close_tab",
+    "get_active_tab",
+    "new_tab",
+    # network-debugging (10) — test_e2e_data_tools.py
+    "list_network_requests",
+    "get_request_details",
+    "get_response_details",
+    "get_response_content",
+    "search_network_requests",
+    "export_network_data",
+    "import_network_data",
+    "set_network_capture_filters",
+    "get_network_capture_filters",
+    "modify_headers",
+    # element-extraction (9) — test_e2e_data_tools.py
+    "extract_element_styles",
+    "extract_element_structure",
+    "extract_element_events",
+    "extract_element_animations",
+    "extract_element_assets",
+    "extract_element_styles_cdp",
+    "extract_related_files",
+    "clone_element_complete",
+    "extract_complete_element_cdp",
+    # progressive-cloning (10) — test_e2e_data_tools.py
+    "clone_element_progressive",
+    "expand_styles",
+    "expand_events",
+    "expand_children",
+    "expand_css_rules",
+    "expand_pseudo_elements",
+    "expand_animations",
+    "list_stored_elements",
+    "clear_stored_element",
+    "clear_all_elements",
+    # file-extraction (9) — test_e2e_data_tools.py
+    "clone_element_to_file",
+    "extract_complete_element_to_file",
+    "extract_element_styles_to_file",
+    "extract_element_structure_to_file",
+    "extract_element_events_to_file",
+    "extract_element_animations_to_file",
+    "extract_element_assets_to_file",
+    "list_clone_files",
+    "cleanup_clone_files",
+    # cdp-functions (13) — test_e2e_functions_hooks.py
+    "list_cdp_commands",
+    "execute_cdp_command",
+    "get_execution_contexts",
+    "discover_global_functions",
+    "discover_object_methods",
+    "call_javascript_function",
+    "inspect_function_signature",
+    "inject_and_execute_script",
+    "create_persistent_function",
+    "execute_function_sequence",
+    "create_python_binding",
+    "execute_python_in_browser",
+    "get_function_executor_info",
+    # dynamic-hooks (10) — test_e2e_functions_hooks.py
+    "create_dynamic_hook",
+    "create_simple_dynamic_hook",
+    "list_dynamic_hooks",
+    "get_dynamic_hook_details",
+    "remove_dynamic_hook",
+    "get_hook_documentation",
+    "get_hook_examples",
+    "get_hook_requirements_documentation",
+    "get_hook_common_patterns",
+    "validate_hook_function",
+    # debugging (5) — test_e2e_functions_hooks.py
+    "get_debug_view",
+    "clear_debug_view",
+    "export_debug_logs",
+    "get_debug_lock_status",
+    "validate_browser_environment_tool",
+}
+
+# Tools intentionally left to another tier, each with a reason.
+E2E_EXEMPT: dict[str, str] = {
+    "get_cookies": (
+        "hangs against real Chrome — the CDP Network.getCookies/getAllCookies "
+        "command never returns in the installed nodriver (get_all_cookies is "
+        "deprecated since 1.3) and poisons the tab's CDP connection so every "
+        "later call times out. Exercising it in E2E would risk leaking a Chrome "
+        "tree; the finding is reported for routing. set_cookie and clear_cookies "
+        "ARE E2E-covered (asserted via document.cookie)."
+    ),
+}
+
+
+def test_e2e_coverage_manifest():
+    """The E2E suite covers every registered section tool (partition tripwire)."""
+    assert server_mod is not None, "server module failed to load"
+    all_names = {name for names in server_mod.SECTION_TOOLS.values() for name in names}
+    assert len(all_names) == 94
+
+    covered = set(E2E_COVERED)
+    exempt = set(E2E_EXEMPT)
+    assert covered.isdisjoint(exempt), (
+        f"name is both covered and exempt: {covered & exempt}"
+    )
+    assert covered | exempt == all_names, {
+        "missing_from_manifest": all_names - covered - exempt,
+        "unknown_names_in_manifest": (covered | exempt) - all_names,
+    }

--- a/tests/test_e2e_interaction.py
+++ b/tests/test_e2e_interaction.py
@@ -23,6 +23,7 @@ from e2e_helpers import (
     eval_js,
     get_fn,
     integration_pytestmark,
+    navigate_and_settle,
     read_actions,
     sandbox_kwargs,
     wait_for_js,
@@ -48,7 +49,6 @@ async def test_browser_lifecycle_and_history(fixture_app_server):
     spawn = get_fn("spawn_browser")
     list_instances = get_fn("list_instances")
     get_instance_state = get_fn("get_instance_state")
-    navigate = get_fn("navigate")
     go_back = get_fn("go_back")
     go_forward = get_fn("go_forward")
     reload_page = get_fn("reload_page")
@@ -66,12 +66,12 @@ async def test_browser_lifecycle_and_history(fixture_app_server):
         assert isinstance(state, dict)
         assert iid in json.dumps(state, default=str)
 
-        nav = await navigate(instance_id=iid, url=f"{base}/index.html")
+        nav = await navigate_and_settle(iid, f"{base}/index.html")
         assert isinstance(nav, dict)
         content = await get_page_content(instance_id=iid)
         assert "fixture-index-page" in json.dumps(content, default=str)
 
-        await navigate(instance_id=iid, url=f"{base}/interact.html")
+        await navigate_and_settle(iid, f"{base}/interact.html")
         assert (
             await wait_for_js(iid, "document.title", "fixture-interact-page")
             == "fixture-interact-page"
@@ -131,7 +131,6 @@ async def test_interaction_controls_and_log(fixture_app_server):
     both the in-page action log and the resulting live DOM property."""
     base = fixture_app_server
     spawn = get_fn("spawn_browser")
-    navigate = get_fn("navigate")
     click = get_fn("click_element")
     select = get_fn("select_option")
     close = get_fn("close_instance")
@@ -139,7 +138,7 @@ async def test_interaction_controls_and_log(fixture_app_server):
     result = await spawn(headless=True, **sandbox_kwargs())
     iid = result["instance_id"]
     try:
-        await navigate(instance_id=iid, url=f"{base}/interact.html")
+        await navigate_and_settle(iid, f"{base}/interact.html")
 
         # query_elements: exact ground-truth counts (bounded-poll past the stale
         # document-node race that transiently returns []).
@@ -183,7 +182,6 @@ async def test_text_input_scroll_and_wait(fixture_app_server):
     """type_text, paste_text, scroll_page, wait_for_element, click_element."""
     base = fixture_app_server
     spawn = get_fn("spawn_browser")
-    navigate = get_fn("navigate")
     type_text = get_fn("type_text")
     paste_text = get_fn("paste_text")
     scroll_page = get_fn("scroll_page")
@@ -194,7 +192,7 @@ async def test_text_input_scroll_and_wait(fixture_app_server):
     result = await spawn(headless=True, **sandbox_kwargs())
     iid = result["instance_id"]
     try:
-        await navigate(instance_id=iid, url=f"{base}/interact.html")
+        await navigate_and_settle(iid, f"{base}/interact.html")
 
         # type_text -> the live .value property reflects exactly what was typed.
         assert await type_text(instance_id=iid, selector="#text-input", text="hello")
@@ -232,7 +230,6 @@ async def test_upload_screenshot_and_content(fixture_app_server, tmp_path):
     """upload_file (single + multi), take_screenshot (PNG bytes), get_page_content."""
     base = fixture_app_server
     spawn = get_fn("spawn_browser")
-    navigate = get_fn("navigate")
     upload = get_fn("upload_file")
     screenshot = get_fn("take_screenshot")
     get_page_content = get_fn("get_page_content")
@@ -246,7 +243,7 @@ async def test_upload_screenshot_and_content(fixture_app_server, tmp_path):
     result = await spawn(headless=True, **sandbox_kwargs())
     iid = result["instance_id"]
     try:
-        await navigate(instance_id=iid, url=f"{base}/interact.html")
+        await navigate_and_settle(iid, f"{base}/interact.html")
 
         single = await upload(
             instance_id=iid, selector="#single-file", file_paths=str(f1)
@@ -299,7 +296,6 @@ async def test_get_element_state_pins_current_shape(fixture_app_server):
     """
     base = fixture_app_server
     spawn = get_fn("spawn_browser")
-    navigate = get_fn("navigate")
     type_text = get_fn("type_text")
     get_element_state = get_fn("get_element_state")
     close = get_fn("close_instance")
@@ -307,7 +303,7 @@ async def test_get_element_state_pins_current_shape(fixture_app_server):
     result = await spawn(headless=True, **sandbox_kwargs())
     iid = result["instance_id"]
     try:
-        await navigate(instance_id=iid, url=f"{base}/interact.html")
+        await navigate_and_settle(iid, f"{base}/interact.html")
 
         # A visible element returns the current dict shape (stable fields).
         card = await get_element_state(instance_id=iid, selector="#select-single")
@@ -349,7 +345,6 @@ async def test_cookies_lifecycle(fixture_app_server):
     """
     base = fixture_app_server
     spawn = get_fn("spawn_browser")
-    navigate = get_fn("navigate")
     click = get_fn("click_element")
     set_cookie = get_fn("set_cookie")
     clear_cookies = get_fn("clear_cookies")
@@ -358,7 +353,7 @@ async def test_cookies_lifecycle(fixture_app_server):
     result = await spawn(headless=True, **sandbox_kwargs())
     iid = result["instance_id"]
     try:
-        await navigate(instance_id=iid, url=f"{base}/cookies.html")
+        await navigate_and_settle(iid, f"{base}/cookies.html")
 
         # Page button sets client_cookie=from-js; the tool sets tool_cookie.
         assert await click(instance_id=iid, selector="#set-client-cookie-btn")
@@ -387,7 +382,6 @@ async def test_cookies_lifecycle(fixture_app_server):
 async def test_tabs_lifecycle(fixture_app_server):
     base = fixture_app_server
     spawn = get_fn("spawn_browser")
-    navigate = get_fn("navigate")
     list_tabs = get_fn("list_tabs")
     new_tab = get_fn("new_tab")
     get_active_tab = get_fn("get_active_tab")
@@ -398,7 +392,7 @@ async def test_tabs_lifecycle(fixture_app_server):
     result = await spawn(headless=True, **sandbox_kwargs())
     iid = result["instance_id"]
     try:
-        await navigate(instance_id=iid, url=f"{base}/index.html")
+        await navigate_and_settle(iid, f"{base}/index.html")
 
         before = await list_tabs(instance_id=iid)
         assert isinstance(before, list) and len(before) >= 1

--- a/tests/test_e2e_interaction.py
+++ b/tests/test_e2e_interaction.py
@@ -1,0 +1,406 @@
+"""plan_E2E STEP 2 — interaction E2E against the fixture app (real headless Chrome).
+
+Covers every tool in browser-management (8), tabs (5), element-interaction (12),
+and cookies-storage (3). Each test spawns ONE browser (nodriver binds websockets
+to the running loop; pytest-asyncio auto mode gives function-scoped loops, so a
+shared browser is a cross-loop hazard), walks a chunk of related tools, asserts
+the fixture's action log / ground truth, and closes in ``finally``.
+
+Determinism (plan §2.6): no sleep-then-assert (bounded ``wait_for_js`` polling or
+tool-native waits only), the fixture animation is paused, screenshots are checked
+by PNG magic bytes + nonzero size only, every URL is ``base_url``-relative.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from e2e_helpers import (
+    eval_js,
+    get_fn,
+    integration_pytestmark,
+    read_actions,
+    sandbox_kwargs,
+    wait_for_js,
+    warmup_once,
+)
+
+pytestmark = integration_pytestmark()
+
+
+@pytest.fixture(autouse=True)
+async def _warmup():
+    await warmup_once()
+    yield
+
+
+# ---------------------------------------------------------------------------
+# browser-management (8): spawn, list, state, navigate, history, reload, close
+# ---------------------------------------------------------------------------
+
+
+async def test_browser_lifecycle_and_history(fixture_app_server):
+    base = fixture_app_server
+    spawn = get_fn("spawn_browser")
+    list_instances = get_fn("list_instances")
+    get_instance_state = get_fn("get_instance_state")
+    navigate = get_fn("navigate")
+    go_back = get_fn("go_back")
+    go_forward = get_fn("go_forward")
+    reload_page = get_fn("reload_page")
+    close = get_fn("close_instance")
+    get_page_content = get_fn("get_page_content")
+
+    result = await spawn(headless=True, **sandbox_kwargs())
+    iid = result["instance_id"]
+    assert result["state"] == "ready"
+    try:
+        instances = await list_instances()
+        assert any(i["instance_id"] == iid for i in instances)
+
+        state = await get_instance_state(instance_id=iid)
+        assert isinstance(state, dict)
+        assert iid in json.dumps(state, default=str)
+
+        nav = await navigate(instance_id=iid, url=f"{base}/index.html")
+        assert isinstance(nav, dict)
+        content = await get_page_content(instance_id=iid)
+        assert "fixture-index-page" in json.dumps(content, default=str)
+
+        await navigate(instance_id=iid, url=f"{base}/interact.html")
+        assert (
+            await wait_for_js(iid, "document.title", "fixture-interact-page")
+            == "fixture-interact-page"
+        )
+
+        # History: back to index, forward to interact.
+        await go_back(instance_id=iid)
+        assert (
+            await wait_for_js(iid, "document.title", "fixture-index-page")
+            == "fixture-index-page"
+        )
+        await go_forward(instance_id=iid)
+        assert (
+            await wait_for_js(iid, "document.title", "fixture-interact-page")
+            == "fixture-interact-page"
+        )
+
+        # Reload keeps us on interact and re-runs app.js (fresh action log).
+        await reload_page(instance_id=iid)
+        assert (
+            await wait_for_js(iid, "document.title", "fixture-interact-page")
+            == "fixture-interact-page"
+        )
+        assert await read_actions(iid) == []
+    finally:
+        await close(instance_id=iid)
+
+
+# ---------------------------------------------------------------------------
+# element-interaction (12) split across three chunky walks + one characterization
+# ---------------------------------------------------------------------------
+
+
+async def test_interaction_controls_and_log(fixture_app_server):
+    """query_elements, click_element, select_option, execute_script — verified by
+    both the in-page action log and the resulting live DOM property."""
+    base = fixture_app_server
+    spawn = get_fn("spawn_browser")
+    navigate = get_fn("navigate")
+    query = get_fn("query_elements")
+    click = get_fn("click_element")
+    select = get_fn("select_option")
+    close = get_fn("close_instance")
+
+    result = await spawn(headless=True, **sandbox_kwargs())
+    iid = result["instance_id"]
+    try:
+        await navigate(instance_id=iid, url=f"{base}/interact.html")
+
+        # query_elements: exact ground-truth counts.
+        singles = await query(instance_id=iid, selector="#btn-counter")
+        assert isinstance(singles, list) and len(singles) == 1
+        radios = await query(
+            instance_id=iid, selector="input[name='flavor']", visible_only=False
+        )
+        assert len(radios) == 3
+
+        # Counter button: click -> increments text + logs click:btn-counter.
+        assert await click(instance_id=iid, selector="#btn-counter")
+        assert "click:btn-counter" in await read_actions(iid)
+        assert (
+            await eval_js(iid, "document.getElementById('counter-value').textContent")
+            == "1"
+        )
+
+        # Select: change to beta -> logs detail + live value updates.
+        assert await select(instance_id=iid, selector="#select-single", value="beta")
+        assert "change:select-single:beta" in await read_actions(iid)
+        assert await eval_js(iid, "document.getElementById('select-single').value") == (
+            "beta"
+        )
+
+        # Checkbox: click toggles checked + logs change:check-me:on.
+        assert await click(instance_id=iid, selector="#check-me")
+        assert "change:check-me:on" in await read_actions(iid)
+        assert await eval_js(iid, "document.getElementById('check-me').checked") is True
+
+        # Radio: click chocolate -> logs change:flavor:chocolate.
+        assert await click(
+            instance_id=iid, selector="input[name='flavor'][value='chocolate']"
+        )
+        assert "change:flavor:chocolate" in await read_actions(iid)
+    finally:
+        await close(instance_id=iid)
+
+
+async def test_text_input_scroll_and_wait(fixture_app_server):
+    """type_text, paste_text, scroll_page, wait_for_element, click_element."""
+    base = fixture_app_server
+    spawn = get_fn("spawn_browser")
+    navigate = get_fn("navigate")
+    type_text = get_fn("type_text")
+    paste_text = get_fn("paste_text")
+    scroll_page = get_fn("scroll_page")
+    click = get_fn("click_element")
+    wait_for_element = get_fn("wait_for_element")
+    close = get_fn("close_instance")
+
+    result = await spawn(headless=True, **sandbox_kwargs())
+    iid = result["instance_id"]
+    try:
+        await navigate(instance_id=iid, url=f"{base}/interact.html")
+
+        # type_text -> the live .value property reflects exactly what was typed.
+        assert await type_text(instance_id=iid, selector="#text-input", text="hello")
+        assert (
+            await eval_js(iid, "document.getElementById('text-input').value") == "hello"
+        )
+
+        # paste_text -> value set directly.
+        assert await paste_text(
+            instance_id=iid, selector="#textarea-input", text="pasted-text"
+        )
+        assert (
+            await eval_js(iid, "document.getElementById('textarea-input').value")
+            == "pasted-text"
+        )
+
+        # scroll_page to the bottom (instant, not smooth) -> scrollY advances.
+        assert await scroll_page(instance_id=iid, direction="bottom", smooth=False)
+        assert await eval_js(iid, "window.scrollY") > 0
+
+        # Bounded reveal: click -> 200ms setTimeout -> #delayed-el visible. The
+        # 5s tool timeout dwarfs the 200ms delay so scheduling jitter can't flake.
+        assert await click(instance_id=iid, selector="#reveal-btn")
+        assert (
+            await wait_for_element(
+                instance_id=iid, selector="#delayed-el", timeout=5000, visible=True
+            )
+            is True
+        )
+    finally:
+        await close(instance_id=iid)
+
+
+async def test_upload_screenshot_and_content(fixture_app_server, tmp_path):
+    """upload_file (single + multi), take_screenshot (PNG bytes), get_page_content."""
+    base = fixture_app_server
+    spawn = get_fn("spawn_browser")
+    navigate = get_fn("navigate")
+    upload = get_fn("upload_file")
+    screenshot = get_fn("take_screenshot")
+    get_page_content = get_fn("get_page_content")
+    close = get_fn("close_instance")
+
+    f1 = tmp_path / "alpha.txt"
+    f1.write_text("alpha", encoding="utf-8")
+    f2 = tmp_path / "beta.txt"
+    f2.write_text("beta", encoding="utf-8")
+
+    result = await spawn(headless=True, **sandbox_kwargs())
+    iid = result["instance_id"]
+    try:
+        await navigate(instance_id=iid, url=f"{base}/interact.html")
+
+        single = await upload(
+            instance_id=iid, selector="#single-file", file_paths=str(f1)
+        )
+        assert single["count"] == 1
+        assert (
+            await eval_js(iid, "document.getElementById('single-file').files[0].name")
+            == "alpha.txt"
+        )
+
+        multi = await upload(
+            instance_id=iid, selector="#multi-file", file_paths=[str(f1), str(f2)]
+        )
+        assert multi["count"] == 2
+        assert (
+            await eval_js(iid, "document.getElementById('multi-file').files.length")
+            == 2
+        )
+
+        # Screenshot: assert valid image magic bytes + nonzero size only (no
+        # pixel asserts). NOTE/FINDING: take_screenshot(file_path=...) delegates
+        # to nodriver save_screenshot, which defaults to JPEG and ignores the
+        # tool's format="png" default — so a .png path receives JPEG bytes. We
+        # accept either magic so the test proves "a screenshot was written"
+        # without coupling to the (buggy) format; the finding is reported.
+        shot = tmp_path / "shot.png"
+        await screenshot(instance_id=iid, file_path=str(shot))
+        raw = shot.read_bytes()
+        assert raw[:8] == b"\x89PNG\r\n\x1a\n" or raw[:3] == b"\xff\xd8\xff"
+        assert len(raw) > 0
+
+        content = await get_page_content(instance_id=iid)
+        assert "fixture-interact-page" in json.dumps(content, default=str)
+    finally:
+        await close(instance_id=iid)
+
+
+@pytest.mark.characterization
+async def test_get_element_state_pins_current_shape(fixture_app_server):
+    """PINS CURRENT get_element_state behavior (two NEW findings).
+
+    (1) get_element_state RAISES on a display:none element: it calls nodriver
+        ``element.get_position()``, which has no layout box to report and throws
+        "could not find position". A *visible* element returns a dict.
+    (2) The returned ``value`` is read from the HTML *attribute*
+        (``element.attrs``), not the live DOM property, so typing into an input
+        does not change the reported value.
+    Both pinned so an intended fix (route: M4-Ph1 / M5b) surfaces as a failing
+    test to update deliberately.
+    """
+    base = fixture_app_server
+    spawn = get_fn("spawn_browser")
+    navigate = get_fn("navigate")
+    type_text = get_fn("type_text")
+    get_element_state = get_fn("get_element_state")
+    close = get_fn("close_instance")
+
+    result = await spawn(headless=True, **sandbox_kwargs())
+    iid = result["instance_id"]
+    try:
+        await navigate(instance_id=iid, url=f"{base}/interact.html")
+
+        # A visible element returns the current dict shape (stable fields).
+        card = await get_element_state(instance_id=iid, selector="#select-single")
+        assert card["tag_name"].lower() == "select"
+        assert card["id"] == "select-single"
+        assert isinstance(card["attributes"], dict)
+
+        # Finding 1: a display:none element (#delayed-el, class="hidden") makes
+        # get_position fail, so the tool raises instead of returning a state dict.
+        with pytest.raises(Exception, match=r"position|element state"):
+            await get_element_state(instance_id=iid, selector="#delayed-el")
+
+        # Finding 2: value comes from the attribute, so typed text is NOT
+        # reflected even though the live DOM property clearly changed.
+        await type_text(instance_id=iid, selector="#text-input", text="typed-value")
+        state = await get_element_state(instance_id=iid, selector="#text-input")
+        assert state["value"] in (None, "")  # attribute empty; live value ignored
+        assert (
+            await eval_js(iid, "document.getElementById('text-input').value")
+            == "typed-value"
+        )
+    finally:
+        await close(instance_id=iid)
+
+
+# ---------------------------------------------------------------------------
+# cookies-storage (3): set via tool + via page button, read, clear
+# ---------------------------------------------------------------------------
+
+
+async def test_cookies_lifecycle(fixture_app_server):
+    """set_cookie + clear_cookies, verified via the live ``document.cookie``.
+
+    get_cookies is deliberately NOT called here — it hangs (the CDP
+    Network.getCookies / deprecated getAllCookies never returns in the installed
+    nodriver) and, worse, poisons the tab's CDP connection so every subsequent
+    call times out. It is E2E_EXEMPT with that finding; cookies are read via
+    document.cookie (non-httpOnly) instead, which is exact ground truth.
+    """
+    base = fixture_app_server
+    spawn = get_fn("spawn_browser")
+    navigate = get_fn("navigate")
+    click = get_fn("click_element")
+    set_cookie = get_fn("set_cookie")
+    clear_cookies = get_fn("clear_cookies")
+    close = get_fn("close_instance")
+
+    result = await spawn(headless=True, **sandbox_kwargs())
+    iid = result["instance_id"]
+    try:
+        await navigate(instance_id=iid, url=f"{base}/cookies.html")
+
+        # Page button sets client_cookie=from-js; the tool sets tool_cookie.
+        assert await click(instance_id=iid, selector="#set-client-cookie-btn")
+        assert (
+            await set_cookie(
+                instance_id=iid, name="tool_cookie", value="tool-val", url=base
+            )
+            is True
+        )
+        cookie_str = await eval_js(iid, "document.cookie")
+        assert "client_cookie=from-js" in cookie_str
+        assert "tool_cookie=tool-val" in cookie_str
+
+        # Clear resets browser-wide state (also this test's own cleanup).
+        assert await clear_cookies(instance_id=iid) is True
+        assert "tool_cookie" not in await eval_js(iid, "document.cookie")
+    finally:
+        await close(instance_id=iid)
+
+
+# ---------------------------------------------------------------------------
+# tabs (5): list, open, active, switch, close
+# ---------------------------------------------------------------------------
+
+
+async def test_tabs_lifecycle(fixture_app_server):
+    base = fixture_app_server
+    spawn = get_fn("spawn_browser")
+    navigate = get_fn("navigate")
+    list_tabs = get_fn("list_tabs")
+    new_tab = get_fn("new_tab")
+    get_active_tab = get_fn("get_active_tab")
+    switch_tab = get_fn("switch_tab")
+    close_tab = get_fn("close_tab")
+    close = get_fn("close_instance")
+
+    result = await spawn(headless=True, **sandbox_kwargs())
+    iid = result["instance_id"]
+    try:
+        await navigate(instance_id=iid, url=f"{base}/index.html")
+
+        before = await list_tabs(instance_id=iid)
+        assert isinstance(before, list) and len(before) >= 1
+        assert all("tab_id" in t for t in before)
+        original_ids = {t["tab_id"] for t in before}
+
+        opened = await new_tab(instance_id=iid, url=f"{base}/interact.html")
+        assert "tab_id" in opened
+        new_id = opened["tab_id"]
+
+        after = await list_tabs(instance_id=iid)
+        after_ids = {t["tab_id"] for t in after}
+        assert new_id in after_ids
+        assert len(after_ids) >= len(original_ids) + 1
+
+        active = await get_active_tab(instance_id=iid)
+        assert isinstance(active, dict)
+        assert active.get("tab_id") in after_ids
+
+        # Switch back to an original tab, then close the tab we opened.
+        an_original = next(iter(original_ids))
+        assert await switch_tab(instance_id=iid, tab_id=an_original) is True
+        assert await close_tab(instance_id=iid, tab_id=new_id) is True
+
+        remaining = {t["tab_id"] for t in await list_tabs(instance_id=iid)}
+        assert new_id not in remaining
+    finally:
+        await close(instance_id=iid)

--- a/tests/test_e2e_interaction.py
+++ b/tests/test_e2e_interaction.py
@@ -13,7 +13,9 @@ by PNG magic bytes + nonzero size only, every URL is ``base_url``-relative.
 
 from __future__ import annotations
 
+import asyncio
 import json
+import time
 
 import pytest
 
@@ -103,13 +105,33 @@ async def test_browser_lifecycle_and_history(fixture_app_server):
 # ---------------------------------------------------------------------------
 
 
+async def _query_at_least(iid, selector, min_count, timeout=10.0, **kwargs):
+    """Bounded-poll query_elements until it returns a list with len >= min_count.
+
+    Finding: query_elements transiently returns [] right after navigation —
+    nodriver's cached document node goes stale so tab.select_all raises a
+    ProtocolException (-32000, "Could not find node with given id"), which the
+    broad except in dom_handler swallows into an empty list (route: src fix; this
+    is a CI-determinism workaround). Returns the last result either way so the
+    caller's assertion shows the real value on timeout."""
+    query = get_fn("query_elements")
+    deadline = time.monotonic() + timeout
+    result = await query(instance_id=iid, selector=selector, **kwargs)
+    while (
+        not (isinstance(result, list) and len(result) >= min_count)
+        and time.monotonic() < deadline
+    ):
+        await asyncio.sleep(0.25)
+        result = await query(instance_id=iid, selector=selector, **kwargs)
+    return result
+
+
 async def test_interaction_controls_and_log(fixture_app_server):
     """query_elements, click_element, select_option, execute_script — verified by
     both the in-page action log and the resulting live DOM property."""
     base = fixture_app_server
     spawn = get_fn("spawn_browser")
     navigate = get_fn("navigate")
-    query = get_fn("query_elements")
     click = get_fn("click_element")
     select = get_fn("select_option")
     close = get_fn("close_instance")
@@ -119,11 +141,12 @@ async def test_interaction_controls_and_log(fixture_app_server):
     try:
         await navigate(instance_id=iid, url=f"{base}/interact.html")
 
-        # query_elements: exact ground-truth counts.
-        singles = await query(instance_id=iid, selector="#btn-counter")
+        # query_elements: exact ground-truth counts (bounded-poll past the stale
+        # document-node race that transiently returns []).
+        singles = await _query_at_least(iid, "#btn-counter", 1)
         assert isinstance(singles, list) and len(singles) == 1
-        radios = await query(
-            instance_id=iid, selector="input[name='flavor']", visible_only=False
+        radios = await _query_at_least(
+            iid, "input[name='flavor']", 3, visible_only=False
         )
         assert len(radios) == 3
 
@@ -400,7 +423,14 @@ async def test_tabs_lifecycle(fixture_app_server):
         assert await switch_tab(instance_id=iid, tab_id=an_original) is True
         assert await close_tab(instance_id=iid, tab_id=new_id) is True
 
+        # close_tab returns before CDP target-detach propagates, so the closed
+        # tab can still be listed for a beat (a Linux/CI race) — bounded-poll
+        # list_tabs until it drops out (plan §2.6 deadline + interval).
+        deadline = time.monotonic() + 10.0
         remaining = {t["tab_id"] for t in await list_tabs(instance_id=iid)}
+        while new_id in remaining and time.monotonic() < deadline:
+            await asyncio.sleep(0.25)
+            remaining = {t["tab_id"] for t in await list_tabs(instance_id=iid)}
         assert new_id not in remaining
     finally:
         await close(instance_id=iid)

--- a/tests/test_fixture_app_server.py
+++ b/tests/test_fixture_app_server.py
@@ -1,0 +1,98 @@
+"""Hermetic smoke tests for the E2E fixture app + its HTTP server (plan_E2E STEP 1).
+
+No Chrome, no integration marker: this runs in the unit job. It proves the
+fixture server serves every page and every §2.2 API route exactly as the
+integration suite depends on, and it enforces the determinism backstop — zero
+external URLs anywhere under ``tests/fixture_app``.
+"""
+
+import re
+from pathlib import Path
+
+import requests
+
+FIXTURE_APP_DIR = Path(__file__).resolve().parent / "fixture_app"
+
+# Each page carries a unique sentinel in a <p id="sentinel"> and its <title>.
+PAGES = {
+    "index.html": "fixture-index-page",
+    "interact.html": "fixture-interact-page",
+    "extract.html": "fixture-extract-page",
+    "network.html": "fixture-network-page",
+    "cookies.html": "fixture-cookies-page",
+    "hooks.html": "fixture-hooks-page",
+}
+
+
+def test_every_page_serves_200_with_sentinel(fixture_app_server):
+    for page, sentinel in PAGES.items():
+        r = requests.get(f"{fixture_app_server}/{page}", timeout=5)
+        assert r.status_code == 200, page
+        assert sentinel in r.text, page
+
+
+def test_api_json_is_exact(fixture_app_server):
+    r = requests.get(f"{fixture_app_server}/api/json", timeout=5)
+    assert r.status_code == 200
+    assert r.headers["Content-Type"] == "application/json"
+    assert r.json() == {"ok": True, "value": 42, "source": "fixture"}
+
+
+def test_api_echo_reflects_body_and_lowercased_headers(fixture_app_server):
+    r = requests.post(
+        f"{fixture_app_server}/api/echo",
+        data="fixture-payload",
+        headers={"X-Fixture-Probe": "probe-value"},
+        timeout=5,
+    )
+    assert r.status_code == 200
+    payload = r.json()
+    assert payload["body"] == "fixture-payload"
+    # Header keys are lowercased; the probe header is reflected verbatim.
+    assert payload["headers"].get("x-fixture-probe") == "probe-value"
+
+
+def test_api_set_cookie(fixture_app_server):
+    r = requests.get(
+        f"{fixture_app_server}/api/set-cookie", timeout=5, allow_redirects=False
+    )
+    assert r.status_code == 200
+    assert r.cookies.get("fixture_cookie") == "server-set"
+
+
+def test_redirect_is_302_to_api_json(fixture_app_server):
+    r = requests.get(f"{fixture_app_server}/redirect", timeout=5, allow_redirects=False)
+    assert r.status_code == 302
+    assert r.headers["Location"] == "/api/json"
+
+
+def test_no_external_urls_in_fixture_app():
+    """Determinism backstop: no http:// or https:// anywhere in fixture_app."""
+    offenders = []
+    for path in sorted(FIXTURE_APP_DIR.rglob("*")):
+        if not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8")
+        for match in re.finditer(r"https?://", text):
+            snippet = text[max(0, match.start() - 20) : match.start() + 20]
+            offenders.append(f"{path.name}: ...{snippet}...")
+    assert offenders == [], f"external URLs found in fixture_app: {offenders}"
+
+
+def test_action_log_helper_present_in_app_js():
+    app_js = (FIXTURE_APP_DIR / "app.js").read_text(encoding="utf-8")
+    assert "window.__actions" in app_js
+    assert "function logAction" in app_js
+    assert "action-log" in app_js
+
+
+def test_fixture_files_are_ascii():
+    """Fixture files must be plain ASCII (readable, no smart quotes / BOM)."""
+    non_ascii = []
+    for path in sorted(FIXTURE_APP_DIR.rglob("*")):
+        if not path.is_file():
+            continue
+        raw = path.read_bytes()
+        if any(byte > 0x7F for byte in raw):
+            non_ascii.append(path.name)
+    assert non_ascii == [], f"non-ASCII bytes in fixture files: {non_ascii}"

--- a/tests/test_mcp_protocol_surface.py
+++ b/tests/test_mcp_protocol_surface.py
@@ -1,0 +1,131 @@
+"""plan_E2E §2.5 — MCP protocol-surface tests (hermetic, no Chrome).
+
+Drives tools through the FastMCP layer (schema validation + serialization) using
+the in-memory ``fastmcp.Client(server.mcp)`` transport, with the M6 fakes patched
+in so the tier stays hermetic. This is the seam nothing else covers: everywhere
+else calls the raw ``.fn`` coroutine directly, bypassing the protocol boundary
+that validates arguments and serializes results. Verified against the installed
+fastmcp 2.11.2 (``CallToolResult.data`` holds the deserialized return value;
+missing/mistyped params raise a validation ``ToolError``).
+
+NOT integration-marked: runs in the unit job.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import fastmcp
+import pytest
+
+# Make embedded/ importable the same way conftest / the entrypoint does.
+EMBEDDED_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "stealth_chrome_devtools_mcp"
+    / "embedded"
+)
+if str(EMBEDDED_DIR) not in sys.path:
+    sys.path.insert(0, str(EMBEDDED_DIR))
+
+import server
+
+from fakes import FakeBrowserManager, FakeStorage, call_tool, fake_instance
+
+
+class _ProtocolBrowserManager(FakeBrowserManager):
+    """``FakeBrowserManager`` plus the no-op lifecycle hooks the FastMCP
+    in-memory Client's server-lifespan invokes on startup/shutdown
+    (``start_idle_reaper`` / ``stop_idle_reaper`` / ``close_all``). Defined here
+    so the fakes-dependent test can boot the *real* transport against a seeded
+    fake without modifying the shared ``tests/fakes.py`` harness.
+    """
+
+    async def start_idle_reaper(self) -> None:
+        """No-op: the idle reaper never runs against a fake."""
+
+    async def stop_idle_reaper(self) -> None:
+        """No-op: paired with start_idle_reaper."""
+
+    async def close_all(self) -> None:
+        """No-op: nothing to close on a fake manager."""
+
+
+async def test_list_instances_via_protocol_matches_seam(patched_server):
+    """Happy path through the protocol layer equals the known seam result.
+
+    The registered tool resolves ``browser_manager`` from the server namespace at
+    call time, so the M6 ``patched_server`` fake is used even when the call comes
+    through FastMCP's in-memory transport — proving the hermetic seam holds one
+    layer up from the raw ``.fn`` calls.
+    """
+    patched_server(
+        browser_manager=_ProtocolBrowserManager(
+            instances=[fake_instance("i1", "active", "https://example.test", "Example")]
+        ),
+        in_memory_storage=FakeStorage(),
+    )
+    # The raw .fn seam result is the reference the protocol result must match.
+    seam_result = await call_tool(server, "list_instances")
+    async with fastmcp.Client(server.mcp) as client:
+        protocol_result = await client.call_tool("list_instances", {})
+
+    # A list return serializes to structured_content under the MCP "result" key
+    # (an object wrapper, since MCP structured content must be an object). That
+    # plain payload — not the opaque ``.data`` models fastmcp builds for a
+    # ``dict[str, Any]`` item type — is what we compare to the seam.
+    assert protocol_result.structured_content == {"result": seam_result}
+    assert seam_result == [
+        {
+            "instance_id": "i1",
+            "state": "active",
+            "current_url": "https://example.test",
+            "title": "Example",
+            "source": "active",
+        }
+    ]
+
+
+async def test_sync_hook_doc_tool_via_protocol():
+    """A sync (plain ``def``) tool still round-trips through the async protocol
+    layer and serializes to structured data."""
+    async with fastmcp.Client(server.mcp) as client:
+        result = await client.call_tool("get_hook_documentation", {})
+
+    assert result.data is not None
+    assert result.structured_content  # non-empty structured payload
+
+
+async def test_list_returning_tool_serializes_cleanly():
+    """A list-returning tool needing no browser serializes to a list of strings —
+    exercises the protocol result-serialization path end to end."""
+    async with fastmcp.Client(server.mcp) as client:
+        result = await client.call_tool("list_cdp_commands", {})
+
+    assert isinstance(result.data, list)
+    assert len(result.data) > 0
+    assert all(isinstance(item, str) for item in result.data)
+
+
+async def test_missing_required_param_is_validation_error():
+    """Omitting a required param fails schema validation (not a body crash)."""
+    async with fastmcp.Client(server.mcp) as client:
+        with pytest.raises(Exception, match="valid"):
+            await client.call_tool("navigate", {})
+
+
+async def test_wrong_type_param_is_validation_error():
+    """A wrong JSON type for a typed param fails schema validation."""
+    async with fastmcp.Client(server.mcp) as client:
+        with pytest.raises(Exception, match="valid"):
+            await client.call_tool(
+                "navigate", {"instance_id": ["not", "a", "string"], "url": "x"}
+            )
+
+
+async def test_unknown_tool_raises():
+    """Calling a tool that is not registered raises (never silently succeeds)."""
+    async with fastmcp.Client(server.mcp) as client:
+        with pytest.raises(Exception):
+            await client.call_tool("does_not_exist_tool", {})


### PR DESCRIPTION
# plan_E2E — fixture web app + deterministic all-tool E2E suite

User-directed plan (2026-07-09), governed by `audit/stage2/plan_E2E.md`. Tests + test fixtures ONLY — zero `src/` changes, zero new dependencies, zero CI-workflow changes. Inserted ahead of M12a; the remaining campaign queue (M12a → M4-Ph1+A1 → M5b → M14+A1) is unchanged.

## What this adds

**1. Self-contained fixture web app** (`tests/fixture_app/`, 6 pages + shared css/js)
- Every interactive element writes an exact `"<kind>:<id>[:detail]"` entry to an in-page action log (`window.__actions`) — tests assert *the right action was performed*.
- Pinned ground truth (rgb styles, `FIXTURE-BEFORE` pseudo-element, paused `fixture-pulse` animation, data-URI assets, `/api/json → {"ok": true, "value": 42, ...}`) — tests assert *the right information was retrieved*.
- Determinism backstops enforced by hermetic smoke tests: zero external URLs, ASCII-only, the only timer is a bounded 200 ms reveal.

**2. Session-scoped stdlib HTTP server fixture** (`tests/conftest.py`) — ephemeral 127.0.0.1 port, 4 deterministic API routes (`/api/json`, `POST /api/echo`, `/api/set-cookie`, `/redirect`).

**3. Real-Chrome E2E suite** (3 files, 16 integration tests, one spawn per test, chunky section walks) riding the existing `-m integration` CI job unchanged — covers all 11 tool sections.

**4. Coverage-manifest tripwire** (`test_e2e_coverage_manifest`): asserts `E2E_COVERED ∪ E2E_EXEMPT` exactly partitions the live 94-tool registry. 93 covered, 1 reasoned exemption. Tool #95 cannot land without deciding its E2E story.

**5. MCP protocol-surface tier** (`tests/test_mcp_protocol_surface.py`, hermetic): drives tools through `fastmcp.Client(server.mcp)` in-memory transport (schema validation + result serialization) — the layer nothing else tests. 6 tests.

## Findings (characterized/pinned, NOT fixed here — per plan §1.2)

| # | Finding | Where pinned | Route |
|---|---------|--------------|-------|
| 1 | **`get_cookies` hangs against real Chrome** — CDP `Network.getCookies`/deprecated `getAllCookies` never returns under the installed nodriver and poisons the tab's CDP connection (every later call times out) | `E2E_EXEMPT` with reason (test_e2e_functions_hooks.py) | standalone fix candidate / M4-Ph1 |
| 2 | **Progressive-clone tier returns EMPTY expansions under real Chrome** — `extract_complete_element` live output shape matches neither shape the `expand_*` readers parse; styles/events/css_rules/pseudo/animations all empty for an element that verifiably has all five; `expand_children` iterates dict KEYS. Fakes-tier goldens pin the intended non-empty shape | `test_progressive_cloning_walk` (characterization) | **M5b** |
| 3 | **`execute_cdp_command` advertised-vs-executable mismatch** — resolves `getattr(uc.cdp.runtime, command)` (snake_case, Runtime-domain-only) while `list_cdp_commands` advertises camelCase names; `"Runtime.evaluate"` can never resolve | `test_execute_cdp_command_rejects_domain_qualified_name` (characterization) | M4-Ph1 / M14 |
| 4 | **`take_screenshot` writes JPEG bytes under a `.png` path** — nodriver `save_screenshot` defaults JPEG and the tool's `format="png"` default is not forwarded | noted in `test_upload_screenshot_and_content` (accepts either magic) | M5b / M14 |
| 5 | **`get_element_state` raises on `display:none` elements** — `element.get_position()` has no layout box and throws | `test_get_element_state_pins_current_shape` (characterization) | M4-Ph1 |
| 6 | **`get_element_state` reports the HTML attribute value, not the live DOM property** — typed text invisible to the tool | same test (characterization) | M4-Ph1 |
| 7 | **Response-details eventual consistency** — with capture on, `_on_response` awaits the body CDP fetch before storing response metadata, so `get_response_details` briefly returns `None` after the request record appears | worked around via bounded poll (`_poll_response_details`) with contract comment | M14 (docs) |
| 8 | **Stale document-node race breaks the first DOM-path tool call after navigation** — nodriver's cached document node is transiently stale post-`navigate`, so `tab.select`/`select_all` raise `ProtocolException -32000` ("Could not find node with given id"). Manifests differently per tool: `query_elements` swallows it into a silent `[]` (wrong answer — `dom_handler.py:196-203` broad except), `click_element` raises. Hit 2 different tests across CI runs. Suggested src fix: on -32000, refresh the cached document and retry once | worked around systemically — `navigate_and_settle` in `e2e_helpers.py` settles the document with a safe body-select after every navigation, plus a bounded poll in `test_interaction_controls_and_log` | M4-Ph1 / standalone (F-181 swallow class) |
| 9 | **`close_tab` returns before CDP target-detach propagates** — a just-closed tab can still appear in `list_tabs` for a beat (Linux/CI race) | worked around via bounded poll in `test_tabs_lifecycle` | M14 (docs) |

Also proven live: the M9 body-capture opt-in path (`set_network_capture_filters(capture_bodies=True)` → body retrievable; default off), `modify_headers` genuinely propagates to subsequent fetches, and F-108 (94 tools) via the manifest.

## Verification

- Hermetic suite: **678 passed** (662 baseline + 8 fixture smoke + 6 protocol + 2 hermetic in the hooks file), 40 deselected.
- Integration (real headless Chrome, isolated `STEALTH_MCP_BROWSER_SESSION_ROOT`): **16 passed**, verified repeatedly. CI (slower, Xvfb) surfaced two timing classes Windows never lost: the `close_tab` target-detach race (finding 9, bounded poll) and the post-navigation stale-document-node class (finding 8), which hit a different test on each CI cycle until fixed **systemically** — `navigate_and_settle` in `e2e_helpers.py` now settles the DOM once per navigation for every browser-driven test. Post-settle: full suite green ×3 consecutively (fix executor ×2, orchestrator ×1).
- ruff format + check clean on all new/edited files; pre-commit gates green on every commit.
- Existing integration file (`test_browser_integration.py`) untouched; `git diff` shows zero `src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYBMRwnkHX2YrVKzZwDE8T
