### PR TITLE
E2E-7: hard-DOM fixture + characterization suite (shadow DOM, iframes, contenteditable, multi-select, SVG/canvas/details)

### DIFF
--- a/tests/fixture_app/app.js
+++ b/tests/fixture_app/app.js
@@ -137,6 +137,93 @@
         window.logAction("mouseover", "styled-card");
       });
     }
+
+    // hard_dom.html: shadow roots, contenteditable, multi-select, SVG, canvas,
+    // and a disclosure widget. Each block is gated on its host id, so it stays a
+    // no-op on the other fixture pages (same guarded-wiring contract as above).
+
+    // Open shadow root: a pinned-color <style>, a button that logs through the
+    // page's logAction, and a named <slot> for the host's light-DOM span.
+    var shadowOpenHost = document.getElementById("shadow-open-host");
+    if (shadowOpenHost && shadowOpenHost.attachShadow) {
+      var openRoot = shadowOpenHost.attachShadow({ mode: "open" });
+      openRoot.innerHTML =
+        "<style>button { color: rgb(9, 99, 199); }</style>" +
+        '<button id="shadow-open-btn">Shadow Open</button>' +
+        '<slot name="label"></slot>';
+      var openBtn = openRoot.querySelector("#shadow-open-btn");
+      if (openBtn) {
+        openBtn.addEventListener("click", function () {
+          window.logAction("click", "shadow-open-btn");
+        });
+      }
+    }
+
+    // Closed shadow root: attachShadow returns the root here, but the host's
+    // .shadowRoot property stays null. The reference lives only in this closure
+    // (never stashed on window) so external JS cannot reach the inner button.
+    var shadowClosedHost = document.getElementById("shadow-closed-host");
+    if (shadowClosedHost && shadowClosedHost.attachShadow) {
+      var closedRoot = shadowClosedHost.attachShadow({ mode: "closed" });
+      closedRoot.innerHTML =
+        '<button id="shadow-closed-btn">Shadow Closed</button>';
+      var closedBtn = closedRoot.querySelector("#shadow-closed-btn");
+      if (closedBtn) {
+        closedBtn.addEventListener("click", function () {
+          window.logAction("click", "shadow-closed-btn");
+        });
+      }
+    }
+
+    // contenteditable div logs an input event on every edit.
+    on("editable", "input", function () {
+      window.logAction("input", "editable");
+    });
+
+    // Multi-select logs the comma-joined selected values as the detail.
+    on("select-multi", "change", function (e) {
+      var picked = [];
+      var opts = e.target.options;
+      for (var j = 0; j < opts.length; j++) {
+        if (opts[j].selected) {
+          picked.push(opts[j].value);
+        }
+      }
+      window.logAction("change", "select-multi", picked.join(","));
+    });
+
+    // SVG circle click logs like any other element.
+    on("svg-circle", "click", function () {
+      window.logAction("click", "svg-circle");
+    });
+
+    // Canvas: one deterministic fill on load, plus a click log. Pinned color is
+    // rgb(10, 100, 200) so any pixel oracle stays stable.
+    var canvas = document.getElementById("canvas-box");
+    if (canvas) {
+      if (canvas.getContext) {
+        var ctx = canvas.getContext("2d");
+        if (ctx) {
+          ctx.fillStyle = "rgb(10, 100, 200)";
+          ctx.fillRect(0, 0, 80, 60);
+        }
+      }
+      canvas.addEventListener("click", function () {
+        window.logAction("click", "canvas-box");
+      });
+    }
+
+    // Disclosure widget logs its open/closed state on every toggle.
+    var details = document.getElementById("details-box");
+    if (details) {
+      details.addEventListener("toggle", function () {
+        window.logAction(
+          "toggle",
+          "details-box",
+          details.open ? "open" : "closed"
+        );
+      });
+    }
   }
 
   if (document.readyState === "loading") {

--- a/tests/fixture_app/hard_dom.html
+++ b/tests/fixture_app/hard_dom.html
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>fixture-hard-dom-page</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <h1 id="page-title">HARD DOM</h1>
+    <p id="sentinel">fixture-hard-dom-page</p>
+
+    <!-- Open shadow root: app.js attaches it with a pinned-color <style>, a
+         button, and a <slot>. The light-DOM <span slot="label"> below is the
+         slotted child (stays in light DOM; rendered through the slot). -->
+    <div id="shadow-open-host">
+      <span slot="label">SLOTTED-LIGHT-TEXT</span>
+    </div>
+
+    <!-- Closed shadow root: app.js attaches it with mode:"closed" and keeps the
+         root reference private in its closure, so host.shadowRoot stays null. -->
+    <div id="shadow-closed-host"></div>
+
+    <!-- Child-document iframe: same-origin, served as its own page. -->
+    <iframe id="iframe-src" src="iframe_child.html"></iframe>
+
+    <!-- srcdoc iframe: same-origin inline document (HTML-escaped attribute). -->
+    <iframe
+      id="iframe-srcdoc"
+      srcdoc="&lt;!doctype html&gt;&lt;html&gt;&lt;body&gt;&lt;p id=&quot;srcdoc-sentinel&quot;&gt;SRCDOC-SENTINEL-TEXT&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+    ></iframe>
+
+    <!-- Sandboxed srcdoc iframe: allow-scripts WITHOUT allow-same-origin, so the
+         frame gets an opaque origin (the "weird properties" case: the parent
+         cannot reach its contentDocument). -->
+    <iframe
+      id="iframe-sandbox"
+      sandbox="allow-scripts"
+      srcdoc="&lt;!doctype html&gt;&lt;html&gt;&lt;body&gt;&lt;p id=&quot;sandbox-sentinel&quot;&gt;SANDBOX-SENTINEL-TEXT&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;"
+    ></iframe>
+
+    <!-- contenteditable div with pinned initial text; app.js logs input:editable. -->
+    <div id="editable" contenteditable="true">EDITABLE-INITIAL-TEXT</div>
+
+    <!-- multi-select; app.js logs change:select-multi:<comma-joined values>. -->
+    <select id="select-multi" multiple>
+      <option value="red">red</option>
+      <option value="green">green</option>
+      <option value="blue">blue</option>
+    </select>
+
+    <!-- Inline SVG (no xmlns needed under HTML parsing); circle click logs. -->
+    <svg id="svg-shape" width="100" height="100">
+      <circle id="svg-circle" cx="50" cy="50" r="40" fill="rgb(0, 128, 0)"></circle>
+    </svg>
+
+    <!-- Canvas painted deterministically on load in app.js; click logs. -->
+    <canvas id="canvas-box" width="80" height="60"></canvas>
+
+    <!-- Disclosure widget; toggle logs details-box:<open|closed>. -->
+    <details id="details-box">
+      <summary id="summary-toggle">Toggle me</summary>
+      <p>DETAILS-BODY-TEXT</p>
+    </details>
+
+    <pre id="action-log"></pre>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/tests/fixture_app/iframe_child.html
+++ b/tests/fixture_app/iframe_child.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>fixture-iframe-child</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <p id="child-sentinel">CHILD-SENTINEL-TEXT</p>
+    <button id="child-btn">Child Button</button>
+    <!-- Self-contained: the child owns its OWN window.__actions (it does not
+         load app.js), so an E2E oracle can click #child-btn via the parent and
+         read the entry back from the child window. Deterministic, ASCII. -->
+    <script>
+      (function () {
+        "use strict";
+        window.__actions = [];
+        var btn = document.getElementById("child-btn");
+        if (btn) {
+          btn.addEventListener("click", function () {
+            window.__actions.push("click:child-btn");
+          });
+        }
+      })();
+    </script>
+  </body>
+</html>

--- a/tests/test_e2e_hard_dom.py
+++ b/tests/test_e2e_hard_dom.py
@@ -1,0 +1,348 @@
+"""plan_E2E STEP 7 (E2E-7) — "hard DOM" characterization against the fixture app.
+
+The STEP 2/3 suites cover every tool against mainstream elements; this file adds
+the odd corners the user asked for: shadow roots (open + closed), iframes
+(child-document, srcdoc, sandboxed/opaque-origin), contenteditable, a
+``<select multiple>``, inline SVG, ``<canvas>``, and ``<details>``. All against
+``hard_dom.html``.
+
+These are CHARACTERIZATION tests: where a tool cannot reach an odd corner (CSS
+selectors don't pierce shadow roots; extraction walks light DOM only;
+``select_option`` has no multi-value path) we PIN the current behavior with a
+comment naming the suspected src root cause, so an intended fix surfaces as a
+deliberate test update rather than a silent regression. No src is touched here.
+
+Determinism (plan §2.6): ONE spawn per test closed in ``finally`` (nodriver binds
+websockets to the function-scoped loop, so a shared browser is a cross-loop
+hazard), every navigation through ``navigate_and_settle``, bounded ``wait_for_js``
+polling only (no sleep-then-assert), every URL ``base_url``-relative.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+
+import pytest
+
+from e2e_helpers import (
+    eval_js,
+    get_fn,
+    integration_pytestmark,
+    navigate_and_settle,
+    read_actions,
+    sandbox_kwargs,
+    wait_for_js,
+    warmup_once,
+)
+
+pytestmark = integration_pytestmark()
+
+
+@pytest.fixture(autouse=True)
+async def _warmup():
+    await warmup_once()
+    yield
+
+
+async def _query_at_least(iid, selector, min_count, timeout=10.0, **kwargs):
+    """Bounded-poll query_elements until it returns a list with len >= min_count.
+
+    The first DOM-path call after a navigation can hit nodriver's stale
+    document-node race (query_elements swallows the ProtocolException into []);
+    ``navigate_and_settle`` already settles ``body``, but a fresh-context first
+    query is re-polled here for safety. Returns the last result either way."""
+    query = get_fn("query_elements")
+    deadline = time.monotonic() + timeout
+    result = await query(instance_id=iid, selector=selector, **kwargs)
+    while (
+        not (isinstance(result, list) and len(result) >= min_count)
+        and time.monotonic() < deadline
+    ):
+        await asyncio.sleep(0.25)
+        result = await query(instance_id=iid, selector=selector, **kwargs)
+    return result
+
+
+@pytest.mark.characterization
+async def test_shadow_dom_characterization(fixture_app_server):
+    """Shadow DOM (open + closed) under the DOM/extraction tools.
+
+    Pins:
+      * query_elements is ``document.querySelectorAll`` under the hood, which by
+        spec does NOT pierce shadow boundaries, so a shadow-internal selector
+        returns [] while the light-DOM host resolves normally.
+      * execute_script is the working escape hatch: ``host.shadowRoot`` reaches an
+        OPEN root (clicking its button logs through the page), while a CLOSED host
+        exposes ``shadowRoot === null``.
+      * extract_element_structure walks the light DOM only (extract_structure.js
+        uses ``document.querySelector`` + ``.children``; element_cloner.py:156),
+        so open-shadow content (the inner button and its pinned color) is ABSENT
+        from the structure output — a real limitation, pinned here.
+    """
+    base = fixture_app_server
+    spawn = get_fn("spawn_browser")
+    query = get_fn("query_elements")
+    click = get_fn("click_element")
+    extract_structure = get_fn("extract_element_structure")
+    close = get_fn("close_instance")
+
+    result = await spawn(headless=True, **sandbox_kwargs())
+    iid = result["instance_id"]
+    try:
+        await navigate_and_settle(iid, f"{base}/hard_dom.html")
+
+        # Light-DOM host resolves (bounded-poll past the stale-document race).
+        hosts = await _query_at_least(iid, "#shadow-open-host", 1)
+        assert isinstance(hosts, list) and len(hosts) == 1
+
+        # A shadow-internal selector does NOT pierce: querySelectorAll cannot see
+        # #shadow-open-btn (it lives inside the open root), so the result is [].
+        assert await query(instance_id=iid, selector="#shadow-open-btn") == []
+
+        # The host itself is a normal light-DOM element and is clickable.
+        assert await click(instance_id=iid, selector="#shadow-open-host")
+
+        # Escape hatch: reach INTO the open root and click its button. The click
+        # + the indexOf run in the SAME JS turn, so a non-negative index proves
+        # the page-level listener fired synchronously (attributable to this call).
+        idx = await eval_js(
+            iid,
+            "(function(){var h=document.getElementById('shadow-open-host');"
+            "h.shadowRoot.querySelector('button').click();"
+            "return window.__actions.indexOf('click:shadow-open-btn');})()",
+        )
+        assert idx >= 0
+        assert "click:shadow-open-btn" in await read_actions(iid)
+
+        # Closed root: host.shadowRoot is null from page JS (mode:"closed").
+        assert (
+            await eval_js(
+                iid,
+                "document.getElementById('shadow-closed-host').shadowRoot === null",
+            )
+            is True
+        )
+
+        # Extraction walks light DOM only: the host id is present, but the
+        # shadow-internal button and its pinned color are absent (the finding).
+        structure = await extract_structure(
+            instance_id=iid, selector="#shadow-open-host", include_children=True
+        )
+        blob = json.dumps(structure, default=str)
+        assert "shadow-open-host" in blob
+        assert "shadow-open-btn" not in blob
+        assert "rgb(9, 99, 199)" not in blob
+    finally:
+        await close(instance_id=iid)
+
+
+@pytest.mark.characterization
+async def test_iframe_characterization(fixture_app_server):
+    """iframes (child-document, srcdoc, sandboxed opaque-origin) under the tools.
+
+    Pins:
+      * query_elements on the top document cannot see into any child frame, so a
+        child selector returns [].
+      * get_page_content returns the TOP document only (dom_handler.py:708-709):
+        ``body.innerText`` excludes every frame's text, and the serialized html
+        carries the inline srcdoc attribute (so srcdoc text is present) but not
+        the externally-fetched child document's text.
+      * execute_script reaches same-origin frames (child-doc + srcdoc) via
+        ``contentDocument`` and can drive them; the sandboxed frame
+        (allow-scripts WITHOUT allow-same-origin => opaque origin) exposes
+        ``contentDocument`` as null to the parent (guarded probe: a thrown
+        SecurityError is returned as a value, never a tool failure).
+    """
+    base = fixture_app_server
+    spawn = get_fn("spawn_browser")
+    query = get_fn("query_elements")
+    get_page_content = get_fn("get_page_content")
+    close = get_fn("close_instance")
+
+    result = await spawn(headless=True, **sandbox_kwargs())
+    iid = result["instance_id"]
+    try:
+        await navigate_and_settle(iid, f"{base}/hard_dom.html")
+
+        # Top-document query cannot cross the frame boundary.
+        assert await query(instance_id=iid, selector="#child-sentinel") == []
+
+        # Same-origin child-doc frame: wait for load, then read its text through
+        # contentDocument (guarded so a pre-load access returns a value).
+        child_text = await wait_for_js(
+            iid,
+            "(function(){try{return document.getElementById('iframe-src')"
+            ".contentDocument.getElementById('child-sentinel').textContent;}"
+            "catch(e){return 'ERR:'+e.name;}})()",
+            "CHILD-SENTINEL-TEXT",
+        )
+        assert child_text == "CHILD-SENTINEL-TEXT"
+
+        # Drive the child button through contentWindow and read the CHILD's own
+        # window.__actions back (the child owns a separate action log).
+        child_actions = await eval_js(
+            iid,
+            "(function(){var w=document.getElementById('iframe-src').contentWindow;"
+            "w.document.getElementById('child-btn').click();"
+            "return (w.__actions||[]).join(',');})()",
+        )
+        assert "click:child-btn" in child_actions
+
+        # srcdoc frame: also same-origin, reachable via contentDocument.
+        srcdoc_text = await wait_for_js(
+            iid,
+            "(function(){try{return document.getElementById('iframe-srcdoc')"
+            ".contentDocument.getElementById('srcdoc-sentinel').textContent;}"
+            "catch(e){return 'ERR:'+e.name;}})()",
+            "SRCDOC-SENTINEL-TEXT",
+        )
+        assert srcdoc_text == "SRCDOC-SENTINEL-TEXT"
+
+        # Sandboxed frame: opaque origin => the parent sees contentDocument null.
+        sandbox_probe = await eval_js(
+            iid,
+            "(function(){try{"
+            "var f=document.getElementById('iframe-sandbox');"
+            "if(f.contentDocument===null){return 'contentDocument-null';}"
+            "var p=f.contentDocument.getElementById('sandbox-sentinel');"
+            "return 'accessible:'+(p?p.textContent:'no-sentinel');"
+            "}catch(e){return 'ERR:'+e.name;}})()",
+        )
+        assert sandbox_probe == "contentDocument-null"
+
+        # get_page_content is the top document only. srcdoc text rides along in
+        # the serialized html attribute; the external child-doc text does not.
+        content = await get_page_content(instance_id=iid)
+        blob = json.dumps(content, default=str)
+        assert "SRCDOC-SENTINEL-TEXT" in blob
+        assert "CHILD-SENTINEL-TEXT" not in blob
+        # body.innerText excludes ALL frame text (even the inline srcdoc's).
+        assert "SRCDOC-SENTINEL-TEXT" not in content["text"]
+    finally:
+        await close(instance_id=iid)
+
+
+@pytest.mark.characterization
+async def test_contenteditable_and_multiselect(fixture_app_server):
+    """contenteditable + ``<select multiple>`` under the interaction tools.
+
+    Pins:
+      * type_text's clear_first sets ``elem.value = ''`` (dom_handler.py:347),
+        a no-op on a contenteditable div, so the pinned initial text is NOT
+        cleared; the typed characters DO land (send_keys drives the focused
+        editable) and each fires input:editable.
+      * paste_text uses CDP ``Input.insertText`` (dom_handler.py:476), which
+        inserts into the editable's CONTENT (unlike setting .value), so pasted
+        text lands.
+      * select_option sets ``select.value = <one value>`` (dom_handler.py:519) —
+        which selects exactly ONE option even on a ``<select multiple>`` (there is
+        no multi-value path) — then dispatches change, so the log records the
+        single value only.
+    """
+    base = fixture_app_server
+    spawn = get_fn("spawn_browser")
+    click = get_fn("click_element")
+    type_text = get_fn("type_text")
+    paste_text = get_fn("paste_text")
+    select = get_fn("select_option")
+    close = get_fn("close_instance")
+
+    result = await spawn(headless=True, **sandbox_kwargs())
+    iid = result["instance_id"]
+    try:
+        await navigate_and_settle(iid, f"{base}/hard_dom.html")
+
+        # contenteditable: click to focus, then type.
+        assert await click(instance_id=iid, selector="#editable")
+        assert await type_text(instance_id=iid, selector="#editable", text="TYPED")
+
+        inner_after_type = await eval_js(
+            iid, "document.getElementById('editable').innerText"
+        )
+        # clear_first did NOT clear the div (value-based clear is a no-op here).
+        assert "EDITABLE-INITIAL-TEXT" in inner_after_type
+        # Typed characters landed, and input:editable was logged.
+        assert "TYPED" in inner_after_type
+        assert "input:editable" in await read_actions(iid)
+
+        # paste_text inserts via Input.insertText -> content updates.
+        assert await paste_text(instance_id=iid, selector="#editable", text="PASTED")
+        inner_after_paste = await eval_js(
+            iid, "document.getElementById('editable').innerText"
+        )
+        assert "PASTED" in inner_after_paste
+
+        # select_option on a <select multiple>: single-value only.
+        assert await select(instance_id=iid, selector="#select-multi", value="green")
+        selected = await eval_js(
+            iid,
+            "Array.from(document.getElementById('select-multi').selectedOptions)"
+            ".map(function(o){return o.value;}).join(',')",
+        )
+        assert selected == "green"
+        assert "change:select-multi:green" in await read_actions(iid)
+    finally:
+        await close(instance_id=iid)
+
+
+@pytest.mark.characterization
+async def test_svg_canvas_details(fixture_app_server):
+    """Inline SVG, ``<canvas>``, and ``<details>`` under interaction + state tools.
+
+    Pins:
+      * click_element drives an inline SVG child (#svg-circle) and a <canvas>,
+        logging click:svg-circle / click:canvas-box.
+      * clicking #summary-toggle opens the <details>, whose ASYNCHRONOUS toggle
+        event logs toggle:details-box:open (bounded-wait, not sleep-assert).
+      * get_element_state reports the HTML ``open`` ATTRIBUTE, not a live property
+        (``element.attrs``; dom_handler.py:569) — present once the details opens.
+      * extract_element_structure includes inline SVG descendants (#svg-circle).
+    """
+    base = fixture_app_server
+    spawn = get_fn("spawn_browser")
+    click = get_fn("click_element")
+    get_element_state = get_fn("get_element_state")
+    extract_structure = get_fn("extract_element_structure")
+    close = get_fn("close_instance")
+
+    result = await spawn(headless=True, **sandbox_kwargs())
+    iid = result["instance_id"]
+    try:
+        await navigate_and_settle(iid, f"{base}/hard_dom.html")
+
+        # Inline SVG circle: clickable, logs via its own listener.
+        assert await click(instance_id=iid, selector="#svg-circle")
+        assert "click:svg-circle" in await read_actions(iid)
+
+        # Canvas element: clickable, logs via its own listener.
+        assert await click(instance_id=iid, selector="#canvas-box")
+        assert "click:canvas-box" in await read_actions(iid)
+
+        # Clicking the summary opens <details>; toggle fires asynchronously, so
+        # bounded-wait for the log entry (deadline + interval, per plan §2.6).
+        assert await click(instance_id=iid, selector="#summary-toggle")
+        assert (
+            await wait_for_js(
+                iid,
+                "window.__actions.indexOf('toggle:details-box:open') >= 0",
+                True,
+            )
+            is True
+        )
+
+        # get_element_state reads attributes: after opening, `open` is present.
+        state = await get_element_state(instance_id=iid, selector="#details-box")
+        assert state["tag_name"].lower() == "details"
+        assert "open" in state["attributes"]
+
+        # Extraction includes inline SVG descendants.
+        structure = await extract_structure(
+            instance_id=iid, selector="#svg-shape", include_children=True
+        )
+        blob = json.dumps(structure, default=str)
+        assert "svg-shape" in blob
+        assert "svg-circle" in blob
+    finally:
+        await close(instance_id=iid)

--- a/tests/test_fixture_app_server.py
+++ b/tests/test_fixture_app_server.py
@@ -21,6 +21,7 @@ PAGES = {
     "network.html": "fixture-network-page",
     "cookies.html": "fixture-cookies-page",
     "hooks.html": "fixture-hooks-page",
+    "hard_dom.html": "fixture-hard-dom-page",
 }
 
 
@@ -29,6 +30,17 @@ def test_every_page_serves_200_with_sentinel(fixture_app_server):
         r = requests.get(f"{fixture_app_server}/{page}", timeout=5)
         assert r.status_code == 200, page
         assert sentinel in r.text, page
+
+
+def test_iframe_child_page_serves(fixture_app_server):
+    """The hard_dom.html child-frame document (loaded via <iframe src>) serves
+    with its own child-sentinel and the button the E2E oracle clicks. It carries
+    a distinct <p id="child-sentinel"> (not the shared #sentinel), so it is not
+    part of PAGES above."""
+    r = requests.get(f"{fixture_app_server}/iframe_child.html", timeout=5)
+    assert r.status_code == 200
+    assert "CHILD-SENTINEL-TEXT" in r.text
+    assert 'id="child-btn"' in r.text
 
 
 def test_api_json_is_exact(fixture_app_server):


### PR DESCRIPTION
# E2E-7 — hard-DOM fixture page + characterization suite

Follow-up to PR #31 (plan_E2E), user-directed: the fixture app covered every tool but only mainstream elements. This adds the odd DOM corners — shadow roots, iframes with weird properties, contenteditable, `<select multiple>`, inline SVG, `<canvas>`, `<details>` — and pins exactly how the tool surface behaves against each. Tests + fixtures ONLY: zero `src/` changes, zero new dependencies, zero CI changes; coverage manifest untouched (no new tools). Governed by `audit/stage2/plan_E2E.md` rules (§2.1 fixture contract, §2.6 determinism, characterize-don't-fix).

## What this adds

- **`tests/fixture_app/hard_dom.html`** — open shadow root (pinned `rgb(9, 99, 199)` internal style, logging button, named `<slot>` + slotted light-DOM span), closed shadow root (reference kept private in the app.js closure), three iframe flavors (`src=iframe_child.html`, inline `srcdoc`, and `sandbox="allow-scripts"` **without** `allow-same-origin` → opaque origin), contenteditable with pinned initial text, `<select multiple>`, inline SVG circle, deterministically-painted `<canvas>`, `<details>/<summary>` — every interactive element logs to `window.__actions` per the fixture contract.
- **`tests/fixture_app/iframe_child.html`** — self-contained child document owning its OWN `window.__actions`, so a cross-frame oracle can prove a child-side click.
- **`tests/test_e2e_hard_dom.py`** — 4 real-Chrome characterization tests (one spawn per test, `navigate_and_settle` on every navigation, bounded polls only, all `@pytest.mark.characterization`).
- Smoke-test coverage for both new pages (`test_fixture_app_server.py`); the no-external-URL + ASCII guards pick the new files up automatically via rglob.

## Findings (characterized/pinned, NOT fixed here)

| # | Finding | Kind | Where pinned | Route |
|---|---------|------|--------------|-------|
| E7-1 | **`type_text` `clear_first` cannot clear a contenteditable** — the clear path runs `elem.value = ''` (`dom_handler.py:347`), a no-op on an editable div (no meaningful `.value`); the Ctrl+A fallback (`:350-351`) only fires if that `apply()` throws, which it doesn't. Typed chars DO land and `input` fires — only the clear silently fails | defect | `test_contenteditable_and_multiselect` | M4-Ph1 |
| E7-2 | **`select_option` has no multi-value path** — value path does scalar `select.value = v` + change dispatch (`dom_handler.py:513-523`); on `<select multiple>` it selects exactly one and deselects the rest; multiple selection is unreachable through the tool | limitation | same test | M4-Ph1 / M14 (docs) |
| E7-3 | **`extract_element_structure` does not descend into shadow roots** — `extract_structure.js` walks `document.querySelector` + `.children` (light DOM; loaded at `element_cloner.py:156`); open-shadow content (inner button + pinned style color) is absent from output | limitation | `test_shadow_dom_characterization` | M5b |
| E7-4 | **`query_elements` does not pierce shadow boundaries** — `querySelectorAll` semantics, spec-correct; shadow-internal selectors return `[]`. Pinned so a future pierce-shadow option surfaces as a deliberate update | spec-correct, pinned | same test | M14 (docs) |
| E7-5 | **`get_page_content` is top-document-only with asymmetric frame text** — `html` = top-doc outerHTML (inline `srcdoc` text rides along as a serialized attribute) while `text` = `body.innerText` (excludes ALL frame text); externally-fetched child-frame text appears in neither; `include_frames=True` lists frame src/id/name but never frame bodies (`dom_handler.py:696-750`) | limitation | `test_iframe_characterization` | M14 (docs) |
| E7-6 | **`get_element_state` reports attributes, not live IDL properties** (re-confirmation of PR #31 finding 6 on a new element class: `<details>` open-state read from `element.attrs`; `computed_style` hardcoded `{}`) | known, re-confirmed | `test_svg_canvas_details` | M4-Ph1 (already routed) |

## Proven working (asserted for real — the escape hatches hold)

- `execute_script` reaches an OPEN `shadowRoot` and drives its button (page log proves it); a CLOSED host exposes `shadowRoot === null`.
- `execute_script` reaches same-origin child-doc + srcdoc frames via `contentDocument`/`contentWindow` and drives them; the child's own action log is read back cross-frame.
- Sandboxed (`allow-scripts`, no `allow-same-origin`) iframe is correctly opaque: parent sees `contentDocument === null` (guarded probe).
- `paste_text` (CDP `Input.insertText`) DOES insert into contenteditable content — contrast with E7-1's value-based clear.
- `click_element` drives inline SVG children, `<canvas>`, and `<summary>` (async `toggle` event captured via bounded wait).
- `extract_element_structure` includes inline SVG descendants.

## Verification

- Executor: smoke 9 passed; hermetic 679 passed / 44 deselected; new file 2x consecutively green (54.77s / 55.13s — deterministic); full integration 44 passed / 679 deselected. All 4 hard-DOM tests passed on the first real-Chrome run.
- Orchestrator (independent): hermetic **679 passed, 44 deselected**; full integration **44 passed, 679 deselected** (5m17s, isolated `STEALTH_MCP_BROWSER_SESSION_ROOT`).
- ruff format + check clean; pre-commit and pre-push gates green; `test_e2e_hard_dom.py` is 298 LOC (< 1000 budget).
- `git diff main --stat` shows tests/ only — zero `src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYBMRwnkHX2YrVKzZwDE8T
