### PR TITLE
RELEASE-FIX-A: Tier-A pre-release fixes (silent-correctness / lying-success class)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,10 @@ STEALTH_MCP_NETWORK_CAPTURE_BODIES=false
 STEALTH_MCP_NETWORK_BODY_MAX_BYTES=5242880
 # Total response-body store cap in bytes; oldest bodies evicted first. 0 = no cap. (128 MiB)
 STEALTH_MCP_NETWORK_BODY_STORE_MAX_BYTES=134217728
+# Max retained requests; oldest evicted FIFO once exceeded. 0 = no cap. (A3)
+STEALTH_MCP_NETWORK_REQUEST_MAX_COUNT=10000
+# Per-request post_data cap in bytes; larger post_data stored metadata-only. 0 = no cap. (5 MiB)
+STEALTH_MCP_NETWORK_POST_DATA_MAX_BYTES=5242880
 
 # -- Legacy-named config (no prefix; names preserved exactly) ---------------
 # Real timeout (seconds) for the synchronous kill phase of close_instance.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -276,8 +276,20 @@ byte-bounded, always:
 
 Both caps are enforced at the single write chokepoint
 `network_interceptor.NetworkInterceptor._store_response`. `0` on either cap means
-unbounded. All three knobs are typed fields on `Settings` (§4) — not hand-rolled
-`os.getenv`.
+unbounded.
+
+The **request** store is bounded symmetrically (A3), so a long session cannot leak
+memory through unbounded request retention:
+
+- retained-count cap **10 000** (`STEALTH_MCP_NETWORK_REQUEST_MAX_COUNT`) with **FIFO
+  eviction** of the oldest requests until under cap;
+- per-`post_data` cap **5 MiB** (`STEALTH_MCP_NETWORK_POST_DATA_MAX_BYTES`) — an
+  oversize `post_data` is dropped to `None`, the rest of the request metadata kept.
+
+These are enforced at the single write chokepoint
+`network_interceptor.NetworkInterceptor._store_request` (both the live capture path and
+JSON import route through it). `0` on either cap means unbounded. All five knobs are
+typed fields on `Settings` (§4) — not hand-rolled `os.getenv`.
 
 ---
 

--- a/audit/stage2/TRIAGE_final-review_to_plan_RELEASE.md
+++ b/audit/stage2/TRIAGE_final-review_to_plan_RELEASE.md
@@ -1,0 +1,65 @@
+# Triage — final arch review → plan_RELEASE
+
+**Source:** 7-Opus whole-system review, 2026-07-20, on PR #39 branch `audit/fixes-2026-07-02-m14` @ f0554ef.
+**Purpose:** input to the `plan_RELEASE` PLAN/triage phase. Every review finding is sorted into
+Tier A (pre-release code FIX — real defect, ship-blocking-ish, own scoped chunk — **NOT** bolted onto PR #39),
+Tier B (release-program scope — maps onto existing W-items), or Tier C (doc/cosmetic, rides a docs touch).
+
+**Plan of record (the "recommended approach"):**
+1. Merge PR #39 **as-is** (docs + 2 touches; reviewed scope stays clean) — satisfies the plan_RELEASE HARD-GATE prereq (M14+A1 → main). *User merge gate.*
+2. Greenlight `plan_RELEASE`; its PLAN phase ingests this triage. *New chunk — explicit human confirmation required.*
+3. Run an early Tier-A FIX wave (the silent/correctness bugs that undermine "green gate == reality" and block honest soak/perf measurement) **before** the big W-items, then the W-items with **cross-OS CI first**.
+
+Conventions all PASS (no `server` imports, no relative imports, one cloner engine, no tombstone imports, tool-count=94 derived, debt ledger honest) — no architectural rework needed.
+
+---
+
+## Tier A — pre-release code FIX candidates (ranked)
+
+| # | Defect | Loc | Sev | Fix shape | Verify via |
+|---|---|---|---|---|---|
+| A1 | **Selector-atomicity VIOLATION + silent `[]`.** `query_elements`/`get_page_content` call `tab.select_all` directly, bypassing element_resolution; broad `except` swallows -32000 into empty list → tool lies under DOM churn. Breaks the HARD invariant PR #35 established. | dom_handler.py:88, :725 | **MED (top)** | Route both `select_all` calls through element_resolution's recovery; stop swallowing -32000 (retry or surface). Check dom_handler budget headroom. | B6 |
+| A2 | Multi-session cold-start port divergence behind a foreign port squatter → lock losers poll a dead port ~120s. | singleton.py:639-681 | MED | Losers re-read `server.json` after acquiring/losing the lock instead of committing to their own `_free_port`; or serialize port choice under the lock. | B-crossOS |
+| A3 | Network capture: request **count** unbounded + request `post_data` bytes uncapped (only response bodies capped) → long-session memory leak. Hits "fast/lean". | network_interceptor.py:163-165 | MED | FIFO count cap + per-`post_data` byte cap mirroring the §6 response-body store cap; update DESIGN §6 to say metadata/count bounding. | B5 |
+| A4 | `create_python_binding` is a success-returning **no-op** (no `Runtime.bindingCalled` handler; `call_python_from_js` is dead). | cdp_function_executor.py:754-793 | MED | Either wire `Runtime.bindingCalled` → `call_python_from_js`, or remove/mark-unsupported. Shipping a lying success is worse than absent. | new pin |
+| A5 | `extract_element_styles` raises `NameError` on legal `include_css_rules=False, include_pseudo=True` → silent styles failure. | cdp_element_cloner.py:552 | MED | Fetch `matched_styles` whenever any of css_rules/pseudo/inheritance is requested (or guard the reference). | new pin (param matrix) |
+| A6 | JS extractors embed selector as raw `"$SELECTOR$"` → quoted-attribute selectors (`input[name="email"]`) break structure/events/animations/assets while CDP styles path succeeds (asymmetric). | js/extract_structure.js:12, extract_events.js:19, extract_animations.js:11, extract_assets.js:97 | MED | `JSON.stringify`-encode the selector at substitution time. | new pin |
+| A7 | `close_instance` Phase-2 `await tab.close()` unbounded (no `wait_for`) → hangs on a wedged renderer, defeating the bounded-teardown contract. | browser_manager.py:863-865 | MED | Wrap in `asyncio.wait_for` like the sibling `browser.close()`/`disconnect()`. **browser_manager at 1532 no-grow cap** — keep net-neutral or offset. | B-crossOS (renderer-hang) |
+| A8 | Windows hard-kill (`TerminateProcess`) on evict/restart/stop bypasses `app_lifespan` cleanup → transient orphan window (POSIX shuts down gracefully; behavior diverges by OS). | singleton.py:280-288; browser_manager kill tiers; process_cleanup | MED (Win) | Judgment call: attempt graceful Windows shutdown signal, or accept + document + rely on next-boot reaper. Triage decides fix-vs-accept. | B-crossOS |
+| A9 | Windows `msvcrt.locking` on a **read-only** pid-file handle may fail (swallowed) → orphan recovery sees zero tracked PIDs. | process_cleanup.py (~228, _file_lock) | MED (Win) | Open the pid-file handle with write access for locking; verify on real Windows. | B-crossOS |
+| A10 | TOCTOU free-port race (pick :0, close, rebind later). Low prob, known flake source; compounds A2. | singleton.py:650-655; proxy_forwarder.py:22-29 | LOW | Bind-with-retry on the actual listener rather than pre-picking a port. | B-crossOS |
+| A11 | Naive vs aware datetime: `BrowserInstance.created_at/last_activity` naive, idle reaper subtracts aware UTC → latent `TypeError` (currently caught → "reaped nothing"). | models.py:27-28 | LOW | `default_factory=lambda: datetime.now(timezone.utc)`. | existing reaper pins |
+| A12 | Proxy credentials not percent-decoded → proxies with special-char passwords fail auth (HTTP + SOCKS). | proxy_forwarder.py:231-232,359-366; proxy_utils.py:53-54 | LOW | `urllib.parse.unquote` username/password before use. | B3 (proxy suite) |
+
+---
+
+## Tier B — release-program scope (map onto existing plan_RELEASE W-items)
+
+| # | Item | Maps to | Note |
+|---|---|---|---|
+| B1 | **Cross-OS CI matrix** — add `windows-latest`+`macos-latest` to the unit job; stand up a macOS integration lane. **Highest leverage: until Win/mac are gated, nothing else buys cross-OS confidence.** | §7 3-OS gating (RESOLVED) | Near-zero effort for the unit matrix axis; integration lanes are the real work. |
+| B2 | **Harden publish gate** — `publish.yml` depends on full `test.yml` (integration + quality/budgets) + **install-smoke** (`uv build` → clean-env install → launch → MCP handshake) on all 3 OSes. Today publish is ubuntu-unit-only, no cov floor, no lint/budget, no install. | install-smoke hard-blocks publish (planned) | `test_packaging.py` only *builds*; never installs/launches. |
+| B3 | **Fault-injection + coverage** for thin-net modules: proxy_forwarder (20%), cdp_function_executor (28%), dom_handler (33%), browser_manager (41%) — auth-failure/tunnel-drop, malformed-arg/CDP-error, spawn-failure. | W10 resilience + W7 corpus | Absorbs A12's proxy suite. |
+| B4 | **Perf/resource budgets** — assertion-backed (spawn latency, per-tool wall-clock, backend RSS ceiling). None exist today → a 2× slowdown ships green. | W9 perf/resource budgets | |
+| B5 | **Wire the soak/leak lane** — adopt `tests/stress_memory_leak.py` (never collected — filename isn't `test_*`) into a scheduled nightly soak with an RSS-growth budget. Also the verification vehicle for A3. | W6 soak lane | |
+| B6 | **DOM-churn stress lane** — drive `query_elements`/`get_page_content` against continuous `DOM.documentUpdated`, assert non-empty when elements exist. A naive "no-exception" soak passes while A1 silently lies — this lane is what actually catches A1. | W10 resilience | Pair with A1 fix. |
+| B7 | **Golden-discipline hardening** — `load_or_capture_golden` auto-captures on missing file → a deleted golden silently regenerates & passes. Make missing-golden a hard fail; prune trivial change-detector goldens. | W7 corpus taxonomy | |
+
+---
+
+## Tier C — doc/cosmetic (ride a docs touch; some are one-line follow-ups)
+
+- C1 DESIGN §9 KEEP list: add the hook-interface envelope family (`dynamic_hook_ai_interface.py` ~20 success/error dicts — behaviorally KEEP, currently undocumented).
+- C2 CLAUDE.md nav map: add the 8th CLI verb `profiles` (cli.py:450).
+- C3 `extract_styles.js` + `comprehensive_element_extractor.js` are **dead** (styles is CDP-only; the latter is tombstone residue). Delete + fix CLAUDE.md:84 ("7 extraction scripts"), or annotate "kept, not wired." Removing tidies the one-cloner-engine surface.
+- C4 logging_setup.py:84,88 comment says "96 tools" → 94.
+- C5 cdp_element_cloner.py:989 docstring claims selector forwarded to `related_files` but it isn't (page-scoped; harmless — doc accuracy only).
+- C6 progressive `available_data` advertises `"html"` (no `expand_html`) and `fonts` is served by `expand_animations` — cosmetic mismatch.
+
+---
+
+## Suggested plan_RELEASE ordering
+1. **Phase 0** — re-verify prereq chain (M14+A1 now ancestor of main after merge).
+2. **Early FIX wave** — A1, A3, A5, A6, A4, A7 (cheap, high-signal; A1/A3 block honest soak/perf measurement). Each its own commit under the normal gate discipline; A7 must respect the browser_manager no-grow cap.
+3. **W-items** — B1 (cross-OS CI) FIRST, then B2, then B3/B4/B5/B6/B7. Cross-OS code fixes A2/A8/A9/A10 land alongside B1/B-crossOS (their verification only exists once Win/mac are gated).
+4. **Doc touches** — Tier C rides the relevant W-item's docs edit.

--- a/audit/stage2/plan_RELEASE_FIX_TierA.md
+++ b/audit/stage2/plan_RELEASE_FIX_TierA.md
@@ -1,0 +1,656 @@
+# Stage 2 Plan — RELEASE-FIX-A (Tier-A): fix the silent-correctness / lying-success class
+
+> **Milestone id:** `RELEASE-FIX-A`. **Not** an M-series id — the M-series FIX pipeline
+> is declared complete (12/12); this is a **distinct pre-release fix plan that gates
+> plan_RELEASE**. Filename stays `plan_RELEASE_FIX_TierA.md`. Commit/plan tags and any
+> `# noqa` owner tags use `RELEASE-FIX-A` as the owner string for budget/suppression
+> provenance.
+
+## Position & goal — why this plan gates plan_RELEASE
+
+The final 7-Opus architecture review surfaced a class of Tier-A `src/` defects that
+**lie**: a tool returns success while silently doing nothing correct (`query_elements`
+swallows a stale-node error into `[]`; `create_python_binding` returns `success:true`
+for a round-trip that is never wired), or crashes on a legal argument combination that
+is then caught and reported as a generic error. These cannot be "released around":
+per **plan_RELEASE §8.1, a characterization pin can NEVER satisfy a release claim** —
+pinning a lie just freezes the lie. So the release gate must test *genuinely-fixed*
+behaviour.
+
+This is the one plan in the RELEASE sequence where **editing `src/` IS the job**
+(plan_RELEASE W1–W16 forbid `src/` edits). It runs **BEFORE** W1 so that every later
+workstream builds on true behaviour. Each defect is its own independently-revertible,
+RED-first chunk.
+
+---
+
+## HARD GATE (base provenance)
+
+- **Execution base = `main` @ `484e143`** (plan_RELEASE + MANUAL_QA_PROTOCOL landed on
+  it; the FIX prerequisites `ac89b81` / `b80bd59` / `6b41c63` are proven ancestors).
+  Branch from `484e143` (or a later `main`). If `main` has advanced, rebase onto it and
+  re-verify the full gate before the first chunk.
+- Working checkout may sit on `audit/fixes-2026-07-02-m14`, but this plan's chunks land
+  on a **fresh branch off `main`** — one PR, human merge gate per PR.
+- Verify the base compiles the gate clean **before** C1:
+  `.venv\Scripts\python.exe -m pytest -m "not integration" -q` green, and the lint/type/
+  budget gate green (§Verification).
+
+---
+
+## Binding discipline (non-negotiable; applies to every chunk)
+
+- **Four conventions (CLAUDE.md):** one-import (`from stealth_chrome_devtools_mcp.embedded.X import Y`,
+  absolute-from-package, no relative); **no `embedded/` module imports `server`** (pass
+  `browser_manager`/deps as args); **one-error convention** — tools *raise*
+  `tool_errors.ToolError` / `InstanceNotFoundError`, success helpers return values, **no
+  new `{"success": False}` dicts** except a named KEEP contract; **one cloner engine**
+  (`CDPElementCloner`) — never add extraction elsewhere.
+- **`--no-verify` is BANNED.** If a hook/gate fails, fix the cause.
+- **Every commit message ends** with:
+  `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`
+- **NO new runtime dependencies.** Test-extras only (pytest/pytest-asyncio already
+  present). All fixes use stdlib (`json`, `asyncio`, `urllib.parse`, `datetime`) +
+  existing `Settings`.
+- **Env has one home:** any new knob is a typed field on `settings.Settings`
+  (`STEALTH_MCP_*`). `os.getenv`/`os.environ` are ruff-banned.
+- **M6-pinned error-message bytes are preserved verbatim.** Do not reword any string a
+  golden/characterization test asserts on.
+- **File budgets never grow** (`tools/check_file_budgets.py`). Relevant caps:
+  `browser_manager.py` = **1532**, `cdp_function_executor.py` = **1012**,
+  `cdp_element_cloner.py` = **1013**, `server.py` = **3389**. `element_resolution.py`,
+  `network_interceptor.py`, `models.py`, `dom_handler.py`, `settings.py` are **not**
+  grandfathered (< 1000-LOC budget). Never pad or raise a cap.
+- **Golden discipline:** a golden diff = **STOP and justify** in the same commit, or
+  it's a real regression — fix the code. HARD invariants never bend.
+- **RED-first (TDD):** for each chunk, write the failing test FIRST (it must fail for the
+  *defect's* reason, not a harness error — verify *why* it's red), commit it or stage
+  it, then the fix turns it green. One checkpoint commit per chunk; suite green at every
+  checkpoint (a chunk may be two commits: `test(RED)` then `fix(GREEN)`, or one commit —
+  keep each chunk revert-isolated).
+- **Test runner:** `.venv\Scripts\python.exe -m pytest …` (uv's `pytest` console-script
+  is broken on this `&`+spaces path — CONTRIBUTING §"uv run pytest caveat").
+- **Tests home:** `tests/fakes.py` is THE hermetic harness (fake `Tab`/`Element`,
+  positional-only `call_tool(server_mod, name, /, **kwargs)`). Extend it; don't fork it.
+
+---
+
+## Scope
+
+### In scope (this plan)
+| Chunk | Finding | Subsystem | One-line fix |
+|---|---|---|---|
+| C1 | **A1** | dom_handler / element_resolution | route multi-element `select_all` through recovery; stop swallowing -32000 into `[]` |
+| C2 | **A5** | cdp_element_cloner | bind `matched_styles` whenever css_rules/pseudo/inheritance requested |
+| C3 | **A6** | cdp_element_cloner / js | JSON-encode selector at the `$SELECTOR$` substitution site |
+| C4 | **A3** | network_interceptor / settings / DESIGN | FIFO count cap on retained requests + per-`post_data` byte cap |
+| C5 | **A7** | browser_manager | `asyncio.wait_for(tab.close(), timeout=2.0)` (LOC net-neutral) |
+| C6 | **A4** | cdp_function_executor / **new** python_binding | **wire** `Runtime.bindingCalled` → `call_python_from_js` (real round-trip), machinery extracted to a new module |
+| C7 | **A11** | models | **FIX** — aware-UTC `default_factory` (real 1-line fix, not a pin) |
+| C8 | **A12** | proxy_forwarder / proxy_utils | PIN here (characterization); fix owned by plan_RELEASE W-B3 |
+
+### Out of scope (explicitly deferred)
+- **A2 / A8 / A9 / A10 — cross-OS correctness bugs.** They **cannot be verified** until
+  plan_RELEASE **W2** builds Windows/macOS CI runners. A **follow-up FIX plan** fixes
+  them against the live cross-OS gate (fixing blind now risks a second wrong guess). Do
+  not touch them here.
+- plan_RELEASE W1–W16 workstreams (CI matrix, packaging, proxy suite, etc.).
+
+---
+
+## The chunks
+
+> Each chunk: **finding-id · files+lines · RED-first test · fix · acceptance/green-bar ·
+> LOC-budget note · revert isolation.** Line numbers are HEAD-relative and MAY have
+> drifted — **re-anchor by symbol** (function/marker), not by line, in Stage 3.
+
+---
+
+### C1 — A1: selector-atomicity violation + silent `[]` (HIGHEST SEVERITY)
+
+**Files / lines**
+- `embedded/dom_handler.py:88` — `elements = await tab.select_all(selector)` (inside
+  `query_elements`, non-XPath branch) bypasses `element_resolution`.
+- `embedded/dom_handler.py:201-208` — the enclosing broad
+  `except Exception: … return []` swallows the -32000 stale-node `ProtocolException`
+  into an empty list (lying "no matches").
+- `embedded/dom_handler.py:725` — `iframe_elements = await tab.select_all("iframe")`
+  (inside `get_page_content`, `include_frames` branch). Its outer `except` (line ~757)
+  already `raise`s, so it does not silently swallow — but it still bypasses recovery.
+- `embedded/element_resolution.py` — THE one home for selector resolution. It already
+  has `resolve_element` (single, `tab.select`), `resolve_by_text` (`tab.find`), and
+  `query_selector_all` (raw NodeIds). It has **no multi-`Element` `select_all` wrapper** —
+  that gap is why `dom_handler` calls `tab.select_all` directly.
+
+**Why the memory invariant demands this:** nodriver 0.47 `select`/`find`/`select_all`
+resolve in two non-atomic CDP round-trips; a `DOM.documentUpdated` between them raises
+`-32000` "Could not find node with given id". PR #35 established the HARD invariant:
+**ALL selector resolution routes through `element_resolution.py`**, never `tab.select`/
+`find`/`select_all` directly. `query_elements`/`get_page_content` are the two remaining
+violators, and the broad `except → []` actively hides the race from users.
+
+**Confirmed contract (ruling — bake into the test):** `query_elements` /
+`get_page_content` route through `element_resolution` recovery; on **transient** `-32000`
+they **retry-then-recover**; on **persistent** `-32000` after `_MAX_RESOLVES` they
+**raise `ToolError`** (never silent `[]`); a **genuine zero-match still returns `[]`**.
+
+**RED-first test** (`tests/test_dom_handler.py` or `tests/test_element_resolution.py`) —
+assert **all three** arms:
+1. `test_query_elements_recovers_from_transient_stale_node` — fake `Tab.select_all`
+   raises `ProtocolException("… Could not find node with given id … -32000")` on the
+   first call, returns a fake element list on the second. Assert `query_elements` returns
+   the elements (recovery happened) — **RED today** (direct `tab.select_all` has no
+   recovery; broad except returns `[]`).
+2. `test_query_elements_raises_on_persistent_stale_node` — fake raises `-32000` on every
+   call. Assert it raises `ToolError` (the recovery's post-`_MAX_RESOLVES`
+   `ProtocolException` converted to `ToolError`) — **NOT** a silent `[]`. **RED today**
+   (returns `[]`).
+3. `test_query_elements_genuine_zero_match_returns_empty` — fake `select_all` returns
+   `[]` (no exception). Assert `query_elements` returns `[]` (a real no-match must stay a
+   normal empty list, not become an error). Guards against over-correcting arm 2.
+
+**Fix**
+1. Add to `element_resolution.py` a multi-element recovery wrapper mirroring
+   `resolve_element`:
+   ```
+   async def resolve_elements(tab, selector, timeout=None) -> list[Element]:
+       async def _do(): return await tab.select_all(selector, timeout=...) if timeout else await tab.select_all(selector)
+       return await _resolve_with_recovery(f"select_all {selector!r}", _do)
+   ```
+   (Keeps the raw-NodeId `query_selector_all` untouched; `query_elements` needs
+   `Element` objects with `.attrs`/`.text_all`/`.get_position()`, so it must use the
+   `select_all` wrapper, not the NodeId path.)
+2. `dom_handler.py:88` → `elements = await resolve_elements(tab, selector)`.
+3. `dom_handler.py:725` → `iframe_elements = await resolve_elements(tab, "iframe")`.
+4. **Stop swallowing** in `query_elements`: the broad `except Exception: return []`
+   (201-208) must no longer turn a resolution failure into `[]`. Narrow it so
+   per-selector resolution failure surfaces as `ToolError` (error-convention correct),
+   while the *per-element* inner loop keeps its element-level `continue` (a single bad
+   element must not abort the whole query — that's not the -32000 case). Recovery in
+   `element_resolution` handles the transient race; a genuinely unresolvable selector
+   surfaces after `_MAX_RESOLVES` (→ `ToolError`). A **successful** resolve that returns
+   an empty `Element` list must still return `[]` (genuine zero-match — do NOT convert
+   an empty result into an error).
+5. (Note, not required) the XPath branch (`tab.xpath`, line 81) is a separate
+   resolution path; if it exhibits the same -32000 race, add an xpath recovery wrapper
+   in a follow-up — keep C1 scoped to the flagged `select_all` paths.
+
+**Acceptance / green-bar**
+- Both new RED tests pass; `query_elements` retries on -32000 and raises `ToolError` on
+  persistent failure (never silent `[]`).
+- Full unit suite green, incl. **94-tool tripwire** (`test_tool_registry.py`),
+  `test_tool_dispatch.py`, and any existing `query_elements`/`get_page_content` tests
+  (a happy-path `select_all` that returns normally must still return the list — the
+  wrapper is transparent when no error fires).
+- No new `tab.select_all` outside `element_resolution.py` (grep guard optional).
+
+**LOC-budget:** `dom_handler.py` and `element_resolution.py` are NOT grandfathered
+(< 1000). `element_resolution.py` grows by the small wrapper — fine.
+
+**Revert isolation:** self-contained (new wrapper + two call-site swaps + one except
+narrowing). Revert restores the exact prior behaviour.
+
+---
+
+### C2 — A5: `extract_element_styles` NameError on a legal arg combo
+
+**Files / lines**
+- `embedded/cdp_element_cloner.py:519` — `matched_styles = await tab.send(css.get_matched_styles_for_node(node_id))`
+  is bound **only inside** `if include_css_rules:`.
+- `cdp_element_cloner.py:552` — `if include_pseudo and len(matched_styles) > 3 …`
+  references `matched_styles`.
+- `cdp_element_cloner.py:562` — `if include_inheritance and len(matched_styles) > 4 …`
+  references it too.
+- Calling `extract_element_styles(include_css_rules=False, include_pseudo=True)` (or
+  `include_inheritance=True`) → `NameError` → caught by the method's
+  `except Exception: return {"error": f"CDP extraction failed: …"}` (line ~579) → a
+  legal call is reported as a generic failure.
+
+**RED-first test** (`tests/test_cdp_element_cloner.py`):
+- `test_extract_styles_pseudo_without_css_rules` — fake `Tab` whose `css.get_matched_styles_for_node`
+  returns a shaped tuple; call with `include_css_rules=False, include_pseudo=True`.
+  Assert `result["pseudo_elements"]` is present and no `"error"` key. **RED today**
+  (returns `{"error": "CDP extraction failed: …matched_styles…"}`).
+
+**Fix:** fetch `matched_styles` whenever **any** of css_rules / pseudo / inheritance is
+requested — hoist the `get_matched_styles_for_node` call so it runs under
+`if include_css_rules or include_pseudo or include_inheritance:`, and keep the
+`css_rules`/`inline`/`attributes` population under `if include_css_rules:`. (Do NOT
+guard the reference with `matched_styles = None` + `len(None)` — that just relocates the
+crash.) Preserve the `method == "cdp_direct"` schema shape exactly.
+
+**Acceptance / green-bar**
+- New RED test green; default-args behaviour (`include_css_rules=True`) byte-identical
+  → existing **cloner goldens unchanged** (a golden diff here = STOP).
+- Full suite green.
+
+**LOC-budget:** `cdp_element_cloner.py` cap **1013** (currently at cap). Hoisting is a
+move, not an add — must stay **net-neutral**. If the hoist adds a line, offset by
+removing the now-redundant inner fetch. Verify with `tools/check_file_budgets.py`.
+
+**Revert isolation:** single-method edit.
+
+---
+
+### C3 — A6: JS extractors break on quoted-attribute selectors
+
+**Files / lines**
+- Substitution site: `embedded/cdp_element_cloner.py:444-445`
+  (`js_code.replace("$SELECTOR$", selector)` then `.replace("$SELECTOR", selector)`) and
+  `:732` (`.replace("$SELECTOR", selector)`).
+- JS templates embedding the placeholder as a raw quoted literal:
+  `js/extract_structure.js:12`, `extract_events.js:19`, `extract_animations.js:11`,
+  `extract_styles.js:2`, `comprehensive_element_extractor.js:2` → `const selector = "$SELECTOR$";`
+  and `js/extract_assets.js:97` → `})('$SELECTOR', {` (single-quoted).
+- A selector like `input[name="email"]` → `const selector = "input[name="email"]";`
+  → invalid JS → the extractor throws → generic error.
+
+**RED-first test** (`tests/test_cdp_element_cloner.py`):
+- `test_selector_with_double_quote_produces_valid_js` — call the substitution helper (or
+  a small extracted `_substitute_selector(js, selector)` seam) with
+  `input[name="email"]` and assert the emitted JS parses as a valid single string
+  literal — e.g. assert the emitted line equals `const selector = "input[name=\"email\"]";`
+  (i.e. equals `f'const selector = {json.dumps(selector)};'`). **RED today** (produces
+  the unescaped, quote-breaking form).
+
+**Fix:** JSON-encode the selector at the **Python substitution site** so it becomes a
+safe JS string literal. Because the JS templates already wrap the placeholder in quotes,
+replace the **quoted** placeholder with `json.dumps(selector)` (which supplies its own
+quotes), handling both quote styles:
+```
+enc = json.dumps(selector)            # e.g. '"input[name=\\"email\\"]"'
+for quoted in ('"$SELECTOR$"', "'$SELECTOR$'", '"$SELECTOR"', "'$SELECTOR'"):
+    js_code = js_code.replace(quoted, enc)
+# defensive: any remaining bare placeholder also becomes a safe literal
+js_code = js_code.replace("$SELECTOR$", enc).replace("$SELECTOR", enc)
+```
+Concretely: replace every quoted form (`"$SELECTOR$"`, `'$SELECTOR$'`, `"$SELECTOR"`,
+`'$SELECTOR'`) with `enc`, then encode any remaining bare `$SELECTOR$`/`$SELECTOR` with
+`enc` as a defensive fallback. `import json` at module top (stdlib; no new dep). Do this
+in one place covering both substitution sites (444-445 and 732) — a shared
+`_encode_selector_into(js_code, selector)` helper avoids a second way (convention lens).
+
+**Acceptance / green-bar**
+- New RED test green; for a **plain** selector (`div.foo`) `json.dumps` yields the
+  identical `"div.foo"` → emitted JS byte-identical → **existing cloner goldens
+  unchanged** (golden diff = STOP).
+- Full suite green.
+
+**LOC-budget:** `cdp_element_cloner.py` cap **1013**. The helper must be net-neutral —
+it *replaces* the two-line `.replace(...).replace(...)` pairs, so extract-to-helper
+should not grow the file; if it does, offset. JS files are not LOC-budgeted, but this
+fix touches **no** JS file (Python-site only), minimizing churn.
+
+**Revert isolation:** substitution-site-only; behaviour identical for plain selectors.
+
+---
+
+### C4 — A3: unbounded network capture (request count + `post_data` bytes)
+
+**Files / lines**
+- `embedded/network_interceptor.py:153-165` (`_on_request`) — builds `NetworkRequest`
+  (incl. `post_data=request.post_data`, **no byte cap**) and stores it:
+  `self._requests[request_id] = network_request` /
+  `self._instance_requests[instance_id].append(request_id)` with **no cap on retained
+  request COUNT** → unbounded growth over a long session.
+- `network_interceptor.py:234-283` (`_store_response`) — the existing model: per-body
+  cap (`network_body_max_bytes`) + total-store FIFO byte cap
+  (`network_body_store_max_bytes`) via `_body_bytes`/`_body_order`. **Only response
+  bodies are bounded.**
+- `settings.py:70-72` — the three body knobs. `__init__` (22-31) holds the deques.
+
+**RED-first tests** (`tests/test_network_interceptor.py`):
+1. `test_retained_request_count_is_capped_fifo` — with the new count cap set small,
+   capture N > cap requests; assert `len(self._requests)` (and the per-instance list)
+   ≤ cap and the **oldest** request_ids were evicted FIFO. **RED today** (all retained).
+2. `test_oversize_post_data_is_bounded` — capture a request whose `post_data` exceeds
+   the new per-`post_data` byte cap; assert the stored `post_data` is dropped to `None`
+   (metadata kept), mirroring the per-body-cap semantics. **RED today** (stored whole).
+
+**Fix**
+1. **Settings (env home):** add two typed fields to `settings.Settings`, mirroring the
+   body knobs (0 = unbounded), named per the existing convention:
+   - `network_request_max_count: int = Field(<default, e.g. 10_000>, ge=0)`
+     (`STEALTH_MCP_NETWORK_REQUEST_MAX_COUNT`)
+   - `network_post_data_max_bytes: int = Field(<default, e.g. 5 * 1024 * 1024>, ge=0)`
+     (`STEALTH_MCP_NETWORK_POST_DATA_MAX_BYTES`)
+2. **Request store:** add a single write chokepoint `_store_request(request_id, req,
+   instance_id)` (mirror `_store_response`) that:
+   - drops `req.post_data` to `None` if it exceeds `network_post_data_max_bytes`
+     (encode/len on the string; keep metadata) — reuse the log-debug idiom;
+   - appends to a FIFO order (`self._request_order: deque[str]` added in `__init__`) and,
+     while `len(self._requests) > network_request_max_count`, evicts oldest: pop from the
+     deque, delete from `self._requests`, and remove the id from its
+     `self._instance_requests[...]` list (guard against already-evicted ids, mirroring
+     `_store_response`'s stale-entry skip).
+   - Callers (`_on_request`, and `import_from_json` if it inserts requests) MUST hold
+     `self._lock` — same contract as `_store_response`.
+   Replace lines 163-165 with `self._store_request(...)` under the existing lock.
+3. **DESIGN.md §6** — update the "byte-bounded" section to state that capture is
+   **count- and metadata-bounded**, not only body-bytes: add the request-count FIFO cap
+   and the `post_data` byte cap and their env vars, alongside the existing body caps.
+
+**Acceptance / green-bar**
+- Both RED tests green; response-body cap tests (`_store_response`, F-605) still green
+  (untouched).
+- **`tests/test_doc_claims.py`** (the M14-S8 doc-claim accuracy harness) must stay
+  green — the DESIGN §6 edit must remain factually consistent with the new
+  Settings fields/behaviour it asserts.
+- Full suite green.
+
+**LOC-budget:** `network_interceptor.py` and `settings.py` are NOT grandfathered — free
+to grow within the 1000-LOC budget.
+
+**Revert isolation:** the DESIGN.md edit is a **separate commit** from the code edit
+(CONTRIBUTING: docs touch and code touch revert independently). Settings + interceptor
+land together (the behaviour needs the knob). Two commits: `fix(A3): …` + `docs(A3):
+DESIGN §6 …`.
+
+---
+
+### C5 — A7: `close_instance` unbounded tab teardown
+
+**Files / lines**
+- `embedded/browser_manager.py:863-865` — `for tab in browser.tabs[:]: … await tab.close()`
+  with **no** `asyncio.wait_for`, unlike the siblings `browser.connection.send(close())`
+  (886-889, `timeout=2.0`) and `connection.disconnect()` (899, `timeout=2.0`). A wedged
+  renderer hangs teardown → freezes the fleet (DESIGN §2.4: teardown is offloaded so one
+  wedged close can't freeze the fleet — this path violates that).
+
+**RED-first test** (`tests/test_browser_manager.py`):
+- `test_close_instance_bounds_tab_close` — fake `Tab.close` that `await asyncio.sleep`s
+  longer than the timeout (or hangs on an `Event` never set). Assert `close_instance`
+  completes within a bounded time and continues to the next teardown phase (does not hang
+  the call). **RED today** (awaits `tab.close()` unbounded). Use `asyncio.wait_for`
+  around the call under test to assert boundedness deterministically.
+
+**Fix:** wrap line 865 in `asyncio.wait_for(tab.close(), timeout=2.0)`, matching the
+siblings. The enclosing `except Exception as tab_err` already catches `TimeoutError`
+(subclass of `Exception`) and logs a warning, so a timed-out tab close is logged and the
+loop proceeds — no new except needed. `asyncio` is already imported.
+
+**Acceptance / green-bar**
+- RED test green; existing `close_instance` phase tests (four-phase teardown) still
+  green — the change only bounds phase 2.
+- Full suite green.
+
+**LOC-budget — the sharp one:** `browser_manager.py` is grandfathered at **1532** with a
+strict **no-grow** cap. The edit replaces one line
+(`await tab.close()`) with one line
+(`await asyncio.wait_for(tab.close(), timeout=2.0)`, ≈75 chars @ 28-space indent, under
+the 88 limit) → **net-zero LOC**. **Do NOT** add an extra `except TimeoutError` branch
+(that would grow the file and duplicate the existing catch). Verify
+`tools/check_file_budgets.py` prints `browser_manager.py: 1532/1532` after the edit —
+**never pad or raise the cap.** If ruff reformats the wrapped call onto two lines,
+offset one line elsewhere in the file (e.g. collapse an already-safe multi-line
+expression) — but the single-line form fits, so this should not be needed.
+
+**Revert isolation:** one-line change.
+
+---
+
+### C6 — A4: `create_python_binding` is a lying no-op → WIRE THE REAL ROUND-TRIP
+
+**Ruling: option (a) — implement the genuine JS→Python round-trip.** No fail-honestly
+shortcut: this is a **new working feature surface landing pre-release**, so its
+correctness must be *proven* (a characterization/fixture-only pin cannot satisfy the
+eventual release claim — plan_RELEASE §8.1).
+
+**Files / lines (defect today)**
+- `embedded/cdp_function_executor.py:739-793` (`create_python_binding`) — calls
+  `runtime.add_binding(name)`, then injects a wrapper that overrides `window[name]` to
+  call **`window.chrome.runtime.sendMessage`** (a Chrome-extension API, **not** the CDP
+  binding channel) and returns `{"success": true, …}`. **No `Runtime.bindingCalled`
+  handler is ever registered** (grep confirms), so the binding never fires.
+- `cdp_function_executor.py:951-985` (`call_python_from_js`) — the Python side; currently
+  **dead** (nothing invokes it).
+- `cdp_function_executor.py:100` (`self._python_bindings`), `:1000`
+  (`get_function_executor_info` reports `python_bindings`).
+- `server.py:2869-2900` — the `@section_tool("cdp-functions") create_python_binding` MCP
+  tool. **The tool stays registered** (removing it drops the registry to 93 → breaks the
+  94-tripwire).
+
+**How the CDP round-trip actually works (the design to implement)**
+1. `Runtime.addBinding(name=…)` exposes `window[name]` as a function; when JS calls
+   `window[name](payloadString)` (CDP bindings take a **single string** arg), the CDP
+   runtime emits a `Runtime.bindingCalled` event `{name, payload, executionContextId}`.
+2. Register a handler: `tab.add_handler(uc.cdp.runtime.BindingCalled, on_binding_called)`
+   at `add_binding` time. The handler parses `payload` (JSON: `{callId, args}`),
+   dispatches to `call_python_from_js(name, args)` (the existing Python side), gets the
+   result, then completes the JS-side promise by
+   `Runtime.evaluate` dispatching the wrapper's custom `${name}_response_${callId}`
+   event with `{success, result|error}` — the wrapper JS at `:754-782` already listens
+   for exactly that event, so the **wrapper stays**; only its *transport* changes from
+   the bogus `window.chrome.runtime.sendMessage(...)` to `window[name](JSON.stringify({callId, args}))`.
+3. Keep `_python_bindings` (now genuinely used) and the `get_function_executor_info`
+   report (now truthful).
+
+**LOC discipline — the resolution (NEW MODULE, not an in-file offset).**
+`cdp_function_executor.py` is grandfathered at **1012 (no-grow, never pad/raise)**, and a
+working handler + wiring is net-new surface. **Chosen approach: extract the binding
+machinery into a new module** `embedded/python_binding.py` (new files are **not**
+cap-constrained, and this is the cohesive "JS↔Python binding" concern — a clean seam, not
+a dumping ground). The new module owns:
+- the wrapper-script builder (moved verbatim from `:754-782`),
+- `install_binding(tab, name, python_function, registry)` → `add_binding` + inject
+  wrapper + register the `BindingCalled` handler,
+- `on_binding_called(...)` → parse payload → `call_python_from_js` → dispatch the
+  response event,
+- `call_python_from_js` (**moved out** of `cdp_function_executor.py`, so the executor
+  file **shrinks** by ~35 LOC — that removed surface is the offset that keeps the file
+  comfortably ≤1012 even before counting the wrapper move).
+`cdp_function_executor.py` keeps only a **thin delegation**: `create_python_binding`
+stores into `self._python_bindings` and calls
+`python_binding.install_binding(tab, name, fn, self._python_bindings)`, returning its
+result. Net effect on the capped file: **shrinks** (dead `call_python_from_js` +
+wrapper-string leave; a short delegation arrives). Verify
+`tools/check_file_budgets.py` shows `cdp_function_executor.py ≤ 1012` **after** the move.
+Conventions: new module is a leaf — it imports `debug_logger`, `tool_errors`, nodriver;
+it **must not import `server`** (pass `tab`/`registry` as args), one-import absolute-from-
+package form.
+
+**Error convention:** on install failure, **raise `ToolError`** (drop the
+`{"success": False}` returns at `:790,793`); success returns the binding descriptor.
+
+**RED-first tests** (the round-trip must be *proven*, not just "no longer lies"):
+1. **Hermetic unit** (`tests/test_python_binding.py`) — `test_binding_called_invokes_python_and_dispatches_response`:
+   drive `on_binding_called` with a synthetic `BindingCalled` event
+   (`payload=json.dumps({"callId":"x","args":[2,3]})`) against a fake `Tab` and a
+   registered Python fn `lambda a,b: a+b`; assert (a) the Python fn ran with `(2,3)`, and
+   (b) the handler issued a `Runtime.evaluate` dispatching
+   `..._response_x` with `{success:true, result:5}`. **RED today** (no handler exists).
+   Also assert the wrapper builder emits `window[name](JSON.stringify(...))`, **not**
+   `chrome.runtime.sendMessage`.
+2. **Live-Chrome integration** (`tests/…`, `@pytest.mark.integration`) —
+   `test_create_python_binding_round_trip_end_to_end`: spawn a real browser, create a
+   binding to a Python fn, `evaluate` `await window[name](args)` in the page, assert the
+   **JS-visible return value** equals what Python returned. This is the real-coverage
+   proof the ruling requires (runs in CI job 3 / Xvfb; needs Chrome).
+
+**Acceptance / green-bar**
+- **94-tool tripwire green** (tool stays registered); `test_tool_dispatch.py` green.
+- Unit round-trip test green; integration round-trip test green under `-m integration`.
+- vulture green: `call_python_from_js` is now **live** (invoked by the handler), not
+  allowlisted-dead.
+- `check_file_budgets.py`: `cdp_function_executor.py ≤ 1012`; new `python_binding.py`
+  under the 1000 budget.
+- Full unit suite green.
+
+**LOC-budget:** capped file **shrinks** via the extraction (offset shown above); the new
+module carries the added surface, cap-free. **No cap padded or raised.**
+
+**Revert isolation:** the new module + the thin executor delegation + `server.py`
+error-convention tweak revert together as one chunk.
+
+---
+
+### C7 — A11: naive datetime vs aware-UTC idle reaper — FIX (1-line)
+
+**Ruling: FIX it (not a pin).** Pinning a known-crashing default freezes the bug
+(plan_RELEASE §8.1).
+
+**Files / lines**
+- `embedded/models.py:27-28` — `created_at`/`last_activity` use
+  `default_factory=datetime.now` (**naive**), while `update_activity` (:37) uses
+  `datetime.now(tz=timezone.utc)` (**aware**). The idle-reaper cleanup path (in
+  `browser_manager`) subtracting an aware "now" from a naive `last_activity` raises
+  `TypeError: can't subtract offset-naive and offset-aware datetimes` (currently caught →
+  latent). `timezone` is already imported (`models.py:3`) — no new import.
+
+**RED-first test** (`tests/test_models.py`):
+- `test_default_timestamps_are_utc_aware_and_reaper_safe` — construct
+  `BrowserInstance(...)`; assert BOTH: (a) `created_at.tzinfo is not None` **and**
+  `last_activity.tzinfo is not None`; (b) the **idle-reaper subtraction**
+  `datetime.now(timezone.utc) - inst.last_activity` does **not** raise `TypeError` (the
+  exact hot-path operation). **RED today** (naive defaults → aware-minus-naive TypeError).
+
+**Fix:** `default_factory=lambda: datetime.now(timezone.utc)` for both `created_at` and
+`last_activity`.
+
+**Acceptance / green-bar:** RED test green; no golden pins a naive timestamp; full suite
+green.
+
+**LOC-budget:** `models.py` not grandfathered; net-zero.
+
+**Revert isolation:** two-field edit.
+
+---
+
+### C8 — A12: proxy credentials not percent-decoded — PIN (fix owned by W-B3)
+
+**Files / lines**
+- `embedded/proxy_utils.py:53-54` — `username = parsed.username or None` /
+  `password = parsed.password or None`. `urlsplit` returns userinfo **percent-encoded**
+  (does not decode). A proxy URL `http://us%40er:p%40ss@host:8080` yields literal
+  `us%40er`/`p%40ss`.
+- `embedded/proxy_forwarder.py:231-232` — `credentials = f"{self.username}:{self.password}"`
+  then base64 → forwards the still-encoded creds in `Proxy-Authorization`.
+- (`:359-366` — the paired auth path per the review.)
+
+**Disposition — CONFIRMED: PIN here; fix owned by plan_RELEASE W-B3 (the proxy suite).**
+A12 is proxy-forwarding correctness that W-B3 owns end-to-end (real proxy harness);
+fixing it in isolation here risks a second, un-suite-verified proxy touch. This plan only
+**captures the behaviour as a characterization pin** and hands the fix to W-B3.
+
+**PIN (this plan):** `tests/test_proxy_utils.py::test_proxy_creds_percent_encoding` with
+`@pytest.mark.characterization` + docstring `# finding: A12 — creds not percent-decoded;
+fix owned by plan_RELEASE W-B3`. It asserts the **current** (encoded) behaviour so the
+W-B3 fix surfaces as a deliberate golden/pin update, not a silent pass. (W-B3's fix will
+be `unquote(parsed.username/​password)` via stdlib `urllib.parse.unquote`; this plan does
+NOT change `proxy_utils.py`/`proxy_forwarder.py`.)
+
+**LOC-budget:** none (test-only). **Revert isolation:** test-only.
+
+---
+
+## Sequencing (recommended order + rationale)
+
+Order: **C1 → C2 → C3 → C4 → C5 → C6 → C7 → C8.**
+
+1. **C1 (A1) first** — the highest-severity **silent** bug (a success-shaped `[]` that
+   hides a race). It restores the PR #35 HARD invariant that all later selector-driven
+   behaviour depends on; do it before anything else touches DOM paths.
+2. **C2, C3 (A5, A6) next — grouped by subsystem** (both in `cdp_element_cloner.py`).
+   Landing them back-to-back means one re-anchor of that file, one golden re-verify pass,
+   and a single LOC-budget check for the 1013-cap file. Both are net-neutral, low blast
+   radius, and share the "legal call currently reported as generic error" shape.
+3. **C4 (A3)** — network subsystem, isolated (`network_interceptor.py` + `settings.py` +
+   DESIGN §6). Independent of C1–C3; sequenced after the cloner group to keep subsystem
+   churn contiguous.
+4. **C5 (A7)** — browser-lifecycle, the one **no-grow-cap** edit (1532). Isolated, one
+   line; done alone so the budget check is unambiguous.
+5. **C6 (A4)** — the largest chunk (new `python_binding.py` module + `bindingCalled`
+   wiring + integration test); sequenced late so the smaller correctness fixes are
+   already banked and green, and because it is the only chunk needing a live-Chrome
+   integration pass. Must preserve the 94-tripwire (tool stays registered) and keep
+   `cdp_function_executor.py` ≤ 1012 via the extraction offset.
+6. **C7 (A11)** — trivial FIX; independent, anywhere, placed near the end.
+7. **C8 (A12)** — PIN only (fix handed to W-B3); last, as it primarily hands off.
+
+Each chunk is one PR-checkpoint (RED then GREEN), suite green at every checkpoint, so any
+chunk reverts alone. Chunks touch disjoint files except C2/C3 (same file, sequenced
+adjacently and re-anchored by symbol); C6 adds a new module rather than growing the
+capped executor file.
+
+---
+
+## Verification (per chunk AND final)
+
+Run with the venv Python directly (uv `pytest` is broken on this path):
+
+**Unit suite + tripwire (every checkpoint):**
+```
+.venv\Scripts\python.exe -m pytest -m "not integration" -q
+.venv\Scripts\python.exe -m pytest tests/test_tool_registry.py -q      # 94-tool tripwire
+.venv\Scripts\python.exe -m pytest tests/test_tool_dispatch.py -q
+.venv\Scripts\python.exe -m pytest tests/test_doc_claims.py -q         # after C4's DESIGN §6 edit
+```
+
+**Full lint/type/dead-code/budget gate (before opening the PR, and after C5 & C6):**
+```
+.venv\Scripts\python.exe -m ruff format --check
+.venv\Scripts\python.exe -m ruff check
+.venv\Scripts\python.exe -m ty check --exit-zero-on-warning src/stealth_chrome_devtools_mcp/
+.venv\Scripts\python.exe -m vulture src/stealth_chrome_devtools_mcp/ tools/vulture_allowlist.py
+.venv\Scripts\python.exe tools/check_suppression_owners.py
+.venv\Scripts\python.exe tools/check_file_budgets.py     # browser_manager 1532/1532, cdp_element_cloner ≤1013, cdp_function_executor ≤1012, new python_binding.py ≤1000
+```
+
+**Coverage (CI parity, once at the end):**
+```
+.venv\Scripts\python.exe -m pytest -m "not integration" --cov=stealth_chrome_devtools_mcp --cov-fail-under=55 -q
+```
+
+**Integration (CI job 3 / Xvfb — REQUIRED for C6's real-round-trip proof):**
+```
+.venv\Scripts\python.exe -m pytest -m integration --timeout=120 -q     # needs Chrome; proves A4 JS→Python round-trip end-to-end
+```
+
+**Green-bar checklist**
+- Full unit suite green; **94-tool tripwire** green (registry count unchanged — C6 keeps
+  the tool registered).
+- **Cloner goldens unchanged** by C2/C3 (any golden diff = STOP-and-justify; for these
+  two it should be zero — plain-selector/default-arg paths are byte-identical).
+- `test_doc_claims.py` green after the DESIGN §6 edit (C4).
+- `check_file_budgets.py` green — **no cap grew**; `browser_manager.py` exactly 1532;
+  `cdp_function_executor.py` ≤ 1012 (shrunk by the C6 extraction); new
+  `python_binding.py` under the 1000 budget.
+- vulture green — C6 makes `call_python_from_js` **live** (invoked by the new
+  `bindingCalled` handler), not dead/allowlisted.
+- **C6 integration round-trip green** (real JS→Python return value observed) — the
+  new feature's coverage is real, not fixture-only (plan_RELEASE §8.1).
+- Integration suite also run once locally for C1/C5 (they touch live-browser paths) —
+  sanity pass.
+
+---
+
+## Resolved rulings (baked into the chunks above — no open decisions remain)
+
+1. **A4 (C6):** **WIRE IT UP** — register `Runtime.bindingCalled` → `call_python_from_js`
+   for a genuine round-trip. LOC resolved by **extracting a new module**
+   `embedded/python_binding.py` (cap-free) + thin executor delegation, so
+   `cdp_function_executor.py` **shrinks** and stays ≤ 1012. Proven by a hermetic unit
+   test **and** a live-Chrome integration test (real coverage, no pin). Tool stays
+   registered (94-tripwire intact).
+2. **A11 (C7):** **FIX** — `default_factory=lambda: datetime.now(timezone.utc)`; RED test
+   asserts tz-aware defaults **and** reaper-subtraction safety.
+3. **A1 (C1):** confirmed contract — route through `element_resolution` recovery;
+   transient `-32000` → retry-then-recover; persistent `-32000` → **raise `ToolError`**;
+   genuine zero-match → **`[]`**. Test asserts all three arms.
+4. **A12 (C8):** **PIN here** (characterization); fix owned by plan_RELEASE **W-B3**.
+5. **Milestone id / filename:** milestone **`RELEASE-FIX-A`** (NOT M16 — the M-series FIX
+   pipeline is complete 12/12; this is a distinct pre-release fix gating plan_RELEASE).
+   Filename stays `plan_RELEASE_FIX_TierA.md`.
+6. **Execution base:** `main` @ **`484e143`** (plan_RELEASE + MANUAL_QA_PROTOCOL landed;
+   FIX prereqs `ac89b81`/`b80bd59`/`6b41c63` are proven ancestors).
+
+---
+
+### Header recap for the gate
+Milestone **`RELEASE-FIX-A`**; execution base `main`@`484e143`; 8 chunks (C1 A1 · C2 A5 ·
+C3 A6 · C4 A3 · C5 A7 · C6 A4 · C7 A11 · C8 A12); each RED-first + revert-isolated;
+**A4 wired** (new `python_binding.py`, integration-proven); **A11 fixed**; **A12 pinned**
+(fix → W-B3); A2/A8/A9/A10 deferred to a post-W2 cross-OS FIX plan; `--no-verify` banned;
+commits `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`; no new runtime deps;
+`browser_manager.py` 1532 & `cdp_function_executor.py` 1012 no-grow (C6 shrinks it);
+94-tool tripwire + cloner goldens must stay green.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,6 +234,9 @@ ban-relative-imports = "all"
 "src/stealth_chrome_devtools_mcp/embedded/cdp_function_executor.py" = [
     "ANN204", "BLE001", "TID251", "TRY300",
 ]  # DEBT(F-181) + plan_M4ph1
+"src/stealth_chrome_devtools_mcp/embedded/python_binding.py" = [
+    "ANN401", "BLE001", "TID251", "TRY300", "TRY301",
+]  # RELEASE-FIX-A C6 (A4) — lint profile inherited from cdp_function_executor.py
 "src/stealth_chrome_devtools_mcp/embedded/dynamic_hook_system.py" = [
     "ANN001", "ANN201", "ANN202", "ANN204", "BLE001", "TID251", "TRY300",
 ]  # DEBT(F-181) + plan_M4ph1

--- a/src/stealth_chrome_devtools_mcp/embedded/browser_manager.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/browser_manager.py
@@ -862,7 +862,7 @@ class BrowserManager:
                 if hasattr(browser, "tabs") and browser.tabs:
                     for tab in browser.tabs[:]:
                         try:
-                            await tab.close()
+                            await asyncio.wait_for(tab.close(), timeout=2.0)
                         except Exception as tab_err:
                             debug_logger.log_warning(
                                 "browser_manager",

--- a/src/stealth_chrome_devtools_mcp/embedded/cdp_element_cloner.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/cdp_element_cloner.py
@@ -430,22 +430,22 @@ class CDPElementCloner:
             return node_info.node.node_id
         return None
 
+    def _encode_into(self, js_code: str, name: str, value: object) -> str:
+        # Sub json.dumps(value) into "$NAME$"/'$NAME'/bare $NAME, eating any quotes.
+        enc = json.dumps(value)
+        return re.sub(rf"""(["']?)\${name}\$?\1""", lambda _: enc, js_code)
+
     def _load_js_file(self, filename: str, selector: str, options: dict) -> str:
         """Load and prepare a JavaScript file with template substitution."""
         js_dir = Path(__file__).parent / "js"
         js_file = js_dir / filename
-
         if not js_file.exists():
             raise FileNotFoundError(f"JavaScript file not found: {js_file}")
 
         with js_file.open(encoding="utf-8") as f:
             js_code = f.read()
-
-        js_code = js_code.replace("$SELECTOR$", selector)
-        js_code = js_code.replace("$SELECTOR", selector)
-        js_code = js_code.replace("$OPTIONS$", json.dumps(options))
-        js_code = js_code.replace("$OPTIONS", json.dumps(options))
-
+        js_code = self._encode_into(js_code, "SELECTOR", selector)
+        js_code = self._encode_into(js_code, "OPTIONS", options)
         for key, value in options.items():
             placeholder_key = f"${key.upper()}"
             placeholder_value = "true" if value else "false"
@@ -729,7 +729,7 @@ class CDPElementCloner:
             with js_file.open(encoding="utf-8") as f:
                 js_code = f.read()
 
-            js_code = js_code.replace("$SELECTOR", selector)
+            js_code = self._encode_into(js_code, "SELECTOR", selector)
             js_code = js_code.replace(
                 "$INCLUDE_IMAGES", "true" if include_images else "false"
             )

--- a/src/stealth_chrome_devtools_mcp/embedded/cdp_element_cloner.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/cdp_element_cloner.py
@@ -514,11 +514,11 @@ class CDPElementCloner:
                 result["computed_styles"] = {
                     prop.name: prop.value for prop in computed_styles_list
                 }
-
-            if include_css_rules:
+            if include_css_rules or include_pseudo or include_inheritance:
                 matched_styles = await tab.send(
                     uc.cdp.css.get_matched_styles_for_node(node_id)
                 )
+            if include_css_rules:
                 result["css_rules"] = []
                 if matched_styles[2]:
                     for rule_match in matched_styles[2]:

--- a/src/stealth_chrome_devtools_mcp/embedded/cdp_function_executor.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/cdp_function_executor.py
@@ -18,6 +18,7 @@ from typing import Any
 import nodriver as uc
 from nodriver import Tab
 
+from stealth_chrome_devtools_mcp.embedded import python_binding
 from stealth_chrome_devtools_mcp.embedded.debug_logger import debug_logger
 
 
@@ -747,50 +748,14 @@ class CDPFunctionExecutor:
         Returns:
             Dict[str, Any]: Result of binding creation.
         """
-        try:
-            await self.enable_runtime(tab)
-            self._python_bindings[binding_name] = python_function
-            await tab.send(uc.cdp.runtime.add_binding(name=binding_name))
-            wrapper_script = f"""
-            (function() {{
-                if (!window.{binding_name}) {{
-                    window.{binding_name} = function(...args) {{
-                        return new Promise((resolve, reject) => {{
-                            const callId = Math.random().toString(36).substr(2, 9);
-                            const evtName = `{binding_name}_response_${{callId}}`;
-                            window.addEventListener(evtName, function(event) {{
-                                if (event.detail.success) {{
-                                    resolve(event.detail.result);
-                                }} else {{
-                                    reject(new Error(event.detail.error));
-                                }}
-                            }}, {{ once: true }});
-                            window.chrome.runtime.sendMessage({{
-                                binding: '{binding_name}',
-                                args: args,
-                                callId: callId
-                            }});
-                        }});
-                    }};
-                }}
-                return {{
-                    success: true,
-                    binding_name: '{binding_name}',
-                    available_as: 'window.{binding_name}'
-                }};
-            }})()
-            """
-            result = await tab.send(
-                uc.cdp.runtime.evaluate(
-                    expression=wrapper_script, return_by_value=True, await_promise=True
-                )
-            )
-            if result and result[0] and result[0].value:
-                return result[0].value
-            return {"success": False, "error": "Failed to create binding"}
-        except Exception as e:
-            debug_logger.log_error("cdp_function_executor", "create_python_binding", e)
-            return {"success": False, "error": str(e)}
+        await self.enable_runtime(tab)
+        self._python_bindings[binding_name] = python_function
+        # The genuine Runtime.bindingCalled round-trip lives in python_binding
+        # (extracted so this file stays within its LOC budget). Raises ToolError
+        # on failure — the executor no longer returns a lying success dict.
+        return await python_binding.install_binding(
+            tab, binding_name, self._python_bindings
+        )
 
     async def execute_python_in_browser(
         self, tab: Tab, python_code: str
@@ -812,8 +777,6 @@ class CDPFunctionExecutor:
                 "execute_python_in_browser",
                 f"Translated JS: {js_code}",
             )
-
-            import asyncio
 
             return await asyncio.wait_for(
                 self.inject_and_execute_script(tab, js_code), timeout=10.0
@@ -947,42 +910,6 @@ class CDPFunctionExecutor:
             js_code = js_code.rsplit(";", 2)[0] + f"; return {last_line};"
 
         return f"(function() {{ {js_code} }})()"
-
-    async def call_python_from_js(
-        self, binding_name: str, args: list[Any]
-    ) -> dict[str, Any]:
-        """
-        Handles JavaScript calls to Python functions.
-
-        Args:
-            binding_name (str): Name of the Python binding.
-            args (List[Any]): Arguments to pass to the Python function.
-
-        Returns:
-            Dict[str, Any]: Result of the Python function call.
-        """
-        try:
-            if binding_name not in self._python_bindings:
-                return {"success": False, "error": f"Unknown binding: {binding_name}"}
-            python_function = self._python_bindings[binding_name]
-            if asyncio.iscoroutinefunction(python_function):
-                result = await python_function(*args)
-            else:
-                result = python_function(*args)
-            return {
-                "success": True,
-                "result": result,
-                "binding_name": binding_name,
-                "args": args,
-            }
-        except Exception as e:
-            debug_logger.log_error("cdp_function_executor", "call_python_from_js", e)
-            return {
-                "success": False,
-                "error": str(e),
-                "binding_name": binding_name,
-                "args": args,
-            }
 
     async def get_function_executor_info(
         self, instance_id: str | None = None

--- a/src/stealth_chrome_devtools_mcp/embedded/dom_handler.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/dom_handler.py
@@ -12,8 +12,10 @@ from stealth_chrome_devtools_mcp.embedded.debug_logger import debug_logger
 from stealth_chrome_devtools_mcp.embedded.element_resolution import (
     resolve_by_text,
     resolve_element,
+    resolve_elements,
 )
 from stealth_chrome_devtools_mcp.embedded.models import ElementInfo
+from stealth_chrome_devtools_mcp.embedded.tool_errors import ToolError
 
 
 class DOMHandler:
@@ -85,7 +87,7 @@ class DOMHandler:
                     f"XPath query returned {len(elements)} elements",
                 )
             else:
-                elements = await tab.select_all(selector)
+                elements = await resolve_elements(tab, selector)
                 debug_logger.log_info(
                     "DOMHandler",
                     "query_elements",
@@ -205,7 +207,9 @@ class DOMHandler:
                 e,
                 {"selector": selector, "tab": str(tab)},
             )
-            return []
+            raise ToolError(
+                f"Failed to query elements for selector {selector!r}: {e!s}"
+            ) from e
 
     @staticmethod
     async def click_element(
@@ -722,7 +726,7 @@ class DOMHandler:
 
             if include_frames:
                 frames = []
-                iframe_elements = await tab.select_all("iframe")
+                iframe_elements = await resolve_elements(tab, "iframe")
 
                 for i, iframe in enumerate(iframe_elements):
                     try:

--- a/src/stealth_chrome_devtools_mcp/embedded/element_resolution.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/element_resolution.py
@@ -117,6 +117,22 @@ async def resolve_by_text(
     return await _resolve_with_recovery(f"find {text!r}", _do)
 
 
+async def resolve_elements(tab: Tab, selector: str) -> list[Element]:
+    """``tab.select_all(selector)`` with stale-document recovery.
+
+    The multi-``Element`` counterpart to :func:`resolve_element`: returns the
+    full match list of live ``Element`` objects (with ``.attrs``/``.text_all``/
+    ``.get_position()``), or an empty list on a genuine zero-match. A -32000
+    stale-node race re-resolves against a fresh document; a persistent one
+    surfaces after ``_MAX_RESOLVES`` exactly like the single-element path.
+    """
+
+    async def _do() -> list[Element]:
+        return await tab.select_all(selector)
+
+    return await _resolve_with_recovery(f"select_all {selector!r}", _do)
+
+
 async def query_selector_all(tab: Tab, selector: str) -> list[NodeId]:
     """``DOM.getDocument`` + ``DOM.querySelectorAll`` with stale-document recovery.
 

--- a/src/stealth_chrome_devtools_mcp/embedded/models.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/models.py
@@ -24,8 +24,8 @@ class BrowserInstance(BaseModel):
     state: BrowserState = Field(default=BrowserState.STARTING)
     current_url: str | None = Field(default=None, description="Current page URL")
     title: str | None = Field(default=None, description="Current page title")
-    created_at: datetime = Field(default_factory=datetime.now)
-    last_activity: datetime = Field(default_factory=datetime.now)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    last_activity: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     headless: bool = Field(default=False)
     user_agent: str | None = None
     viewport: dict[str, int] = Field(

--- a/src/stealth_chrome_devtools_mcp/embedded/network_interceptor.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/network_interceptor.py
@@ -29,6 +29,9 @@ class NetworkInterceptor:
         # bytes, plus the FIFO capture order used for oldest-first eviction.
         self._body_bytes: int = 0
         self._body_order: deque[str] = deque()
+        # Count-bounded request store (A3): FIFO capture order used for
+        # oldest-first eviction once the retained request count exceeds the cap.
+        self._request_order: deque[str] = deque()
 
     async def setup_interception(
         self, tab: Tab, instance_id: str, block_resources: list[str] | None = None
@@ -161,8 +164,7 @@ class NetworkInterceptor:
                 resource_type=resource_type,
             )
             async with self._lock:
-                self._requests[request_id] = network_request
-                self._instance_requests[instance_id].append(request_id)
+                self._store_request(request_id, network_request, instance_id)
         except Exception as e:
             debug_logger.log_warning(
                 "network_interceptor",
@@ -281,6 +283,63 @@ class NetworkInterceptor:
                 f"to stay under store cap {max_store}",
             )
             victim.body = None
+
+    def _store_request(
+        self, request_id: str, request: NetworkRequest, instance_id: str
+    ) -> None:
+        """Insert a request into the count-bounded request store (A3).
+
+        The single write chokepoint for the request store; callers
+        (``_on_request``, ``import_from_json``) MUST already hold ``self._lock``.
+        Both caps are resolved from Settings at call time and treat 0 as "no
+        cap":
+
+        * per-``post_data`` (``network_post_data_max_bytes``): a request whose
+          ``post_data`` encodes to more than the cap has it dropped to ``None``
+          (all other metadata is still stored).
+        * retained count (``network_request_max_count``): once the number of
+          retained requests exceeds the cap, oldest-captured requests are
+          evicted FIFO — removed from ``self._requests`` and from their own
+          instance's id list — until back under the cap.
+        """
+        settings = get_settings()
+        max_post = settings.network_post_data_max_bytes
+        max_count = settings.network_request_max_count
+
+        if request.post_data is not None and max_post:
+            post_bytes = len(request.post_data.encode("utf-8"))
+            if post_bytes > max_post:
+                debug_logger.log_debug(
+                    "network_interceptor",
+                    "_store_request",
+                    f"post_data for {request_id} ({post_bytes} bytes) exceeds "
+                    f"per-post_data cap {max_post}; storing metadata only",
+                )
+                request.post_data = None
+
+        is_new = request_id not in self._requests
+        self._requests[request_id] = request
+        if instance_id not in self._instance_requests:
+            self._instance_requests[instance_id] = []
+        if request_id not in self._instance_requests[instance_id]:
+            self._instance_requests[instance_id].append(request_id)
+        if is_new:
+            self._request_order.append(request_id)
+
+        while max_count and len(self._requests) > max_count and self._request_order:
+            oldest_id = self._request_order.popleft()
+            victim = self._requests.pop(oldest_id, None)
+            if victim is None:
+                continue  # already evicted; skip its stale order entry
+            victim_list = self._instance_requests.get(victim.instance_id)
+            if victim_list and oldest_id in victim_list:
+                victim_list.remove(oldest_id)
+            debug_logger.log_debug(
+                "network_interceptor",
+                "_store_request",
+                f"evicted oldest request {oldest_id} to stay under "
+                f"count cap {max_count}",
+            )
 
     async def set_capture_filters(
         self,
@@ -602,9 +661,7 @@ class NetworkInterceptor:
                     resource_type=req_data.get("resource_type"),
                     timestamp=datetime.fromisoformat(req_data["timestamp"]),
                 )
-                self._requests[req.request_id] = req
-                if req.request_id not in self._instance_requests[instance_id]:
-                    self._instance_requests[instance_id].append(req.request_id)
+                self._store_request(req.request_id, req, instance_id)
 
             for resp_data in data.get("responses", []):
                 resp = NetworkResponse(

--- a/src/stealth_chrome_devtools_mcp/embedded/python_binding.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/python_binding.py
@@ -1,0 +1,193 @@
+"""JS→Python binding: the genuine ``Runtime.bindingCalled`` round-trip (A4).
+
+Extracted from ``cdp_function_executor.py`` (which is at its LOC budget) so the
+executor keeps only a thin delegation. This module owns the whole JS↔Python
+binding concern:
+
+* :func:`build_wrapper_script` — the page-side wrapper that turns
+  ``window[name](...args)`` into a Promise;
+* :func:`install_binding` — ``Runtime.addBinding`` + the ``bindingCalled``
+  handler + wrapper injection;
+* :func:`on_binding_called` — the handler that runs the Python function and
+  dispatches the result back into the page;
+* :func:`call_python_from_js` — the Python-side dispatch (moved here).
+
+How the round-trip actually works (the old code never wired it): ``addBinding``
+exposes ``window[name]`` as a function that, when called with a **single
+string**, emits ``Runtime.bindingCalled``. The wrapper preserves that raw
+function, then overrides ``window[name]`` with a Promise-returning shim that
+calls the raw binding with ``JSON.stringify({callId, args})``. The handler runs
+the Python function and dispatches a ``<name>_response_<callId>`` CustomEvent
+that the shim is listening for. The previous implementation instead overrode
+``window[name]`` and called ``window.chrome.runtime.sendMessage`` (an extension
+API, not the CDP channel), so no binding ever fired.
+
+Leaf module: imports only ``debug_logger``, ``tool_errors``, and nodriver — it
+must never import ``server`` (the ``tab`` is passed in as an argument).
+"""
+
+import asyncio
+import json
+from collections.abc import Callable
+from typing import Any
+
+import nodriver as uc
+from nodriver import Tab
+
+from stealth_chrome_devtools_mcp.embedded.debug_logger import debug_logger
+from stealth_chrome_devtools_mcp.embedded.tool_errors import ToolError
+
+
+def build_wrapper_script(binding_name: str) -> str:
+    """Return the page-side wrapper installed for ``binding_name``.
+
+    Saves the raw CDP binding (``window[name]`` created by ``addBinding``) under
+    a private slot, then overrides ``window[name]`` with a Promise wrapper that
+    invokes the raw binding with a single JSON string — the only shape a CDP
+    binding accepts — and resolves when the Python side dispatches the matching
+    ``<name>_response_<callId>`` event.
+    """
+    return f"""
+    (function() {{
+        if (!window.__{binding_name}_binding) {{
+            window.__{binding_name}_binding = window.{binding_name};
+        }}
+        window.{binding_name} = function(...args) {{
+            return new Promise((resolve, reject) => {{
+                const callId = Math.random().toString(36).substr(2, 9);
+                const evtName = `{binding_name}_response_${{callId}}`;
+                window.addEventListener(evtName, function(event) {{
+                    if (event.detail.success) {{
+                        resolve(event.detail.result);
+                    }} else {{
+                        reject(new Error(event.detail.error));
+                    }}
+                }}, {{ once: true }});
+                window.__{binding_name}_binding(
+                    JSON.stringify({{ callId: callId, args: args }})
+                );
+            }});
+        }};
+        return {{
+            success: true,
+            binding_name: '{binding_name}',
+            available_as: 'window.{binding_name}'
+        }};
+    }})()
+    """
+
+
+async def call_python_from_js(
+    bindings: dict[str, Callable[..., Any]], binding_name: str, args: list[Any]
+) -> dict[str, Any]:
+    """Run the bound Python function for a JS call and return the outcome dict.
+
+    Sync and coroutine functions are both supported. Never raises: a failure is
+    reported as ``{"success": False, "error": ...}`` so the handler can always
+    dispatch a response back to the waiting page promise.
+    """
+    try:
+        if binding_name not in bindings:
+            return {"success": False, "error": f"Unknown binding: {binding_name}"}
+        python_function = bindings[binding_name]
+        if asyncio.iscoroutinefunction(python_function):
+            result = await python_function(*args)
+        else:
+            result = python_function(*args)
+        return {
+            "success": True,
+            "result": result,
+            "binding_name": binding_name,
+            "args": args,
+        }
+    except Exception as e:
+        debug_logger.log_error("python_binding", "call_python_from_js", e)
+        return {
+            "success": False,
+            "error": str(e),
+            "binding_name": binding_name,
+            "args": args,
+        }
+
+
+async def _dispatch_response(
+    tab: Tab, binding_name: str, call_id: str, outcome: dict[str, Any]
+) -> None:
+    """Dispatch the ``<name>_response_<callId>`` CustomEvent carrying ``outcome``
+    back into the page so the wrapper's one-shot listener resolves/rejects."""
+    evt_name = f"{binding_name}_response_{call_id}"
+    try:
+        detail = json.dumps(outcome)
+    except (TypeError, ValueError):
+        detail = json.dumps(
+            {"success": False, "error": "binding result is not JSON-serializable"}
+        )
+    dispatch_js = (
+        f"window.dispatchEvent(new CustomEvent({json.dumps(evt_name)}, "
+        f"{{ detail: {detail} }}))"
+    )
+    try:
+        await tab.send(
+            uc.cdp.runtime.evaluate(expression=dispatch_js, return_by_value=True)
+        )
+    except Exception as e:
+        debug_logger.log_warning("python_binding", "_dispatch_response", str(e))
+
+
+async def on_binding_called(
+    tab: Tab, event: Any, binding_name: str, bindings: dict[str, Callable[..., Any]]
+) -> None:
+    """Handle one ``Runtime.bindingCalled`` event for ``binding_name``.
+
+    Each installed binding registers its own handler filtered to its name, so
+    handlers for different bindings on the same tab never cross-process an event.
+    """
+    if event.name != binding_name:
+        return  # another binding's event; not ours
+    try:
+        payload = json.loads(event.payload)
+        call_id = payload["callId"]
+        args = payload.get("args", [])
+    except (ValueError, KeyError, TypeError) as e:
+        debug_logger.log_warning(
+            "python_binding",
+            "on_binding_called",
+            f"malformed payload for {binding_name}: {e}",
+        )
+        return
+    outcome = await call_python_from_js(bindings, binding_name, args)
+    await _dispatch_response(tab, binding_name, call_id, outcome)
+
+
+async def install_binding(
+    tab: Tab, binding_name: str, bindings: dict[str, Callable[..., Any]]
+) -> dict[str, Any]:
+    """Wire the genuine round-trip for ``binding_name`` on ``tab``.
+
+    Registers the CDP binding, the ``bindingCalled`` handler, and injects the
+    page-side wrapper. ``bindings`` is the caller's live registry (already
+    holding ``binding_name``). Raises :class:`ToolError` on failure.
+    """
+    try:
+        await tab.send(uc.cdp.runtime.add_binding(name=binding_name))
+        tab.add_handler(
+            uc.cdp.runtime.BindingCalled,
+            lambda event: asyncio.create_task(
+                on_binding_called(tab, event, binding_name, bindings)
+            ),
+        )
+        result = await tab.send(
+            uc.cdp.runtime.evaluate(
+                expression=build_wrapper_script(binding_name),
+                return_by_value=True,
+                await_promise=True,
+            )
+        )
+        if result and result[0] and result[0].value:
+            return result[0].value
+        raise ToolError(f"Failed to install binding {binding_name!r}")
+    except ToolError:
+        raise
+    except Exception as e:
+        debug_logger.log_error("python_binding", "install_binding", e)
+        raise ToolError(f"Failed to create binding {binding_name!r}: {e!s}") from e

--- a/src/stealth_chrome_devtools_mcp/settings.py
+++ b/src/stealth_chrome_devtools_mcp/settings.py
@@ -71,6 +71,14 @@ class Settings(BaseSettings):
     network_body_max_bytes: int = Field(5 * 1024 * 1024, ge=0)
     network_body_store_max_bytes: int = Field(128 * 1024 * 1024, ge=0)
 
+    # -- Request capture bounding (A3) ---------------------------------------
+    # Request metadata is always captured; the retained set is count-bounded
+    # (oldest evicted FIFO) and each request's post_data is byte-bounded. This
+    # mirrors the response-body caps above so a long session cannot leak memory
+    # through unbounded request retention. 0 on either cap = unbounded.
+    network_request_max_count: int = Field(10_000, ge=0)
+    network_post_data_max_bytes: int = Field(5 * 1024 * 1024, ge=0)
+
     # -- Legacy unprefixed config (names preserved verbatim via alias) -------
     # 0 = idle reaping disabled (never auto-close): the correct default for a
     # persistent server. The old server.py forced BROWSER_IDLE_TIMEOUT=0 via an

--- a/tests/test_cdp_element_cloner.py
+++ b/tests/test_cdp_element_cloner.py
@@ -16,6 +16,7 @@ Uses the hermetic ``fakes.FakeTab`` harness (``evaluate``/``send`` are canned;
 no real Chrome).
 """
 
+import json
 from types import SimpleNamespace
 
 from fakes import FakeTab
@@ -65,3 +66,30 @@ class TestExtractStylesPseudoWithoutCssRules:
         assert result["pseudo_elements"] == {"before": {"matches": 2}}
         # css_rules were NOT requested, so that key must be absent.
         assert "css_rules" not in result
+
+
+class TestSelectorSubstitutionEncoding:
+    def test_selector_with_double_quote_produces_valid_js(self):
+        # A quoted-attribute selector must survive substitution into the
+        # double-quoted template `const selector = "$SELECTOR$";`. Before the
+        # fix the raw selector was embedded, producing invalid JS
+        # (`const selector = "input[name="email"]";`).
+        selector = 'input[name="email"]'
+        js = cdp_element_cloner._load_js_file("extract_styles.js", selector, {})
+        expected = f"const selector = {json.dumps(selector)};"
+        assert expected in js
+
+    def test_single_quoted_template_selector_is_encoded(self):
+        # extract_assets.js wraps the placeholder in single quotes
+        # (`})('$SELECTOR', {`); json.dumps supplies its own double quotes.
+        selector = "a[href='/x']"
+        js = cdp_element_cloner._encode_into("})('$SELECTOR', {", "SELECTOR", selector)
+        assert js == "})(" + json.dumps(selector) + ", {"
+
+    def test_plain_selector_is_byte_identical_to_prior_output(self):
+        # For a plain selector json.dumps yields the same double-quoted literal
+        # the template already had, so the emitted JS is unchanged.
+        js = cdp_element_cloner._encode_into(
+            'const selector = "$SELECTOR$";', "SELECTOR", "div.foo"
+        )
+        assert js == 'const selector = "div.foo";'

--- a/tests/test_cdp_element_cloner.py
+++ b/tests/test_cdp_element_cloner.py
@@ -1,0 +1,67 @@
+"""RELEASE-FIX-A C2/C3 regression tests for the CDP element cloner engine.
+
+These pin two Tier-A defects that made a legal call return a generic
+``{"error": ...}`` failure:
+
+* **C2 (A5)** — ``extract_element_styles`` bound ``matched_styles`` only inside
+  ``if include_css_rules:``, so the legal combo
+  ``include_css_rules=False, include_pseudo=True`` raised ``NameError`` (caught
+  and reported as ``CDP extraction failed: …``).
+* **C3 (A6)** — the ``$SELECTOR`` placeholder was substituted raw into JS
+  templates that wrap it in quotes, so a selector like ``input[name="email"]``
+  produced invalid JS. The fix JSON-encodes the placeholder at the Python
+  substitution site.
+
+Uses the hermetic ``fakes.FakeTab`` harness (``evaluate``/``send`` are canned;
+no real Chrome).
+"""
+
+from types import SimpleNamespace
+
+from fakes import FakeTab
+from stealth_chrome_devtools_mcp.embedded.cdp_element_cloner import (
+    cdp_element_cloner,
+)
+
+
+def _pseudo_matched_styles():
+    """A ``get_matched_styles_for_node`` tuple with a populated pseudo entry
+    (index 3) so the pseudo branch has something to emit."""
+    pseudo_match = SimpleNamespace(
+        pseudo_type=SimpleNamespace(value="before"),
+        matches=[object(), object()],
+    )
+    # Positional CDP tuple: inline, attributes, matched rules, pseudo, inherited.
+    return [None, None, [], [pseudo_match], []]
+
+
+def _styles_cdp_responses():
+    return {
+        "enable": None,
+        "get_computed_style_for_node": [
+            SimpleNamespace(name="color", value="rgb(0, 0, 0)"),
+        ],
+        "get_matched_styles_for_node": _pseudo_matched_styles(),
+    }
+
+
+class TestExtractStylesPseudoWithoutCssRules:
+    async def test_extract_styles_pseudo_without_css_rules(self):
+        # The legal combo the defect crashed on: pseudo requested, css_rules not.
+        tab = FakeTab(
+            cdp_responses=_styles_cdp_responses(),
+            select_result=SimpleNamespace(node_id=2),
+        )
+        result = await cdp_element_cloner.extract_element_styles(
+            tab,
+            selector="#demo",
+            include_css_rules=False,
+            include_pseudo=True,
+        )
+        # Before the fix the pseudo tuple was never fetched, so the broad except
+        # reported a generic CDP-extraction failure instead of the pseudo data.
+        assert "error" not in result
+        assert result["method"] == "cdp_direct"
+        assert result["pseudo_elements"] == {"before": {"matches": 2}}
+        # css_rules were NOT requested, so that key must be absent.
+        assert "css_rules" not in result

--- a/tests/test_close_instance_offload.py
+++ b/tests/test_close_instance_offload.py
@@ -251,6 +251,40 @@ async def test_concurrent_close_exactly_one_claims(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# 5. Phase-2 tab close is bounded (RELEASE-FIX-A C5 / A7)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_close_instance_bounds_hung_tab_close():
+    """A wedged renderer whose ``tab.close()`` never returns must not hang
+    close_instance. Phase-2 wraps each ``tab.close()`` in ``asyncio.wait_for``
+    (timeout=2.0), so a hung tab is logged and teardown proceeds to completion.
+
+    RED before the fix: the bare ``await tab.close()`` blocks forever, so the
+    outer 15s guard cancels close_instance and raises TimeoutError.
+    """
+
+    class _HungTab:
+        async def close(self):
+            await asyncio.Event().wait()  # never set — hangs forever
+
+    manager = BrowserManager()
+    browser, _instance = _seed_manager(manager, "hung-1")
+    browser.tabs = [_HungTab()]
+
+    t0 = time.monotonic()
+    result = await asyncio.wait_for(manager.close_instance("hung-1"), timeout=15)
+    elapsed = time.monotonic() - t0
+
+    assert result is True
+    assert "hung-1" not in manager._instances
+    # Phase-2 bounded the hung tab close at ~2s; without the fix it would run
+    # until the outer guard cancels at 15s (raising TimeoutError above instead).
+    assert elapsed < 10.0, f"close_instance took {elapsed:.1f}s — tab close unbounded"
+
+
 @pytest.mark.asyncio
 async def test_happy_path_fast_kill(monkeypatch):
     """Fast stubbed kill: returns True, instance removed, in_memory_storage called."""

--- a/tests/test_dom_handler.py
+++ b/tests/test_dom_handler.py
@@ -1,0 +1,95 @@
+"""RED-first pins for C1 (finding A1): query_elements must route select_all
+through element_resolution recovery and stop swallowing the CDP -32000
+stale-node race into a lying empty list.
+
+nodriver resolves a selector in two non-atomic CDP calls; a DOM.documentUpdated
+between them raises ProtocolException "Could not find node with given id
+[code: -32000]". query_elements' broad ``except Exception: return []`` turned
+that transient race -- and a genuinely-unresolvable selector -- into a
+success-shaped ``[]`` ("no matches"). The confirmed contract
+(plan_RELEASE_FIX_TierA, C1): a transient -32000 retries-then-recovers; a
+persistent -32000 raises ``ToolError`` (never a silent ``[]``); a genuine
+zero-match still returns ``[]``. Hermetic (a fake Tab), so the fast unit lane.
+"""
+
+import pytest
+from nodriver.core.connection import ProtocolException
+
+from stealth_chrome_devtools_mcp.embedded import element_resolution
+from stealth_chrome_devtools_mcp.embedded.dom_handler import DOMHandler
+from stealth_chrome_devtools_mcp.embedded.element_resolution import _MAX_RESOLVES
+from stealth_chrome_devtools_mcp.embedded.tool_errors import ToolError
+
+
+@pytest.fixture(autouse=True)
+def _instant_backoff(monkeypatch):
+    # Zero the recovery backoff so the unit lane stays fast while the real
+    # sleep(0) code path still runs. Mirrors tests/test_element_resolution.py.
+    monkeypatch.setattr(element_resolution, "_SETTLE_SECONDS", 0.0)
+
+
+def _stale():
+    # Mirrors the real CDP error: str() contains the -32000 marker text.
+    return ProtocolException(
+        {"message": "Could not find node with given id", "code": -32000}
+    )
+
+
+class _FakeElement:
+    """Minimal nodriver-Element stand-in for the per-element loop."""
+
+    def __init__(self, tag="div", text="hello", attrs=None):
+        self.tag_name = tag
+        self.text_all = text
+        self.attrs = attrs or {}
+
+    async def update(self):
+        return None
+
+    async def get_position(self):
+        return None
+
+
+class _FakeTab:
+    """Fake tab whose ``select_all`` replays an effects list (raise or return),
+    matching the recovery-fake idiom in tests/test_element_resolution.py."""
+
+    def __init__(self, select_all_effects):
+        self._effects = list(select_all_effects)
+        self.select_all_calls = 0
+
+    async def select_all(self, selector, *args, **kwargs):
+        self.select_all_calls += 1
+        effect = self._effects.pop(0)
+        if isinstance(effect, Exception):
+            raise effect
+        return effect
+
+
+@pytest.mark.asyncio
+async def test_query_elements_recovers_from_transient_stale_node():
+    # First select_all hits the -32000 race, the re-resolve on a fresh document
+    # succeeds -> the elements surface (recovery), never a swallowed [].
+    tab = _FakeTab([_stale(), [_FakeElement()]])
+    results = await DOMHandler.query_elements(tab, "div.foo", visible_only=False)
+    assert len(results) == 1
+    assert tab.select_all_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_query_elements_raises_on_persistent_stale_node():
+    # -32000 on every attempt -> after _MAX_RESOLVES the failure surfaces as a
+    # ToolError, NOT a lying empty list.
+    tab = _FakeTab([_stale() for _ in range(_MAX_RESOLVES)])
+    with pytest.raises(ToolError):
+        await DOMHandler.query_elements(tab, "div.foo", visible_only=False)
+
+
+@pytest.mark.asyncio
+async def test_query_elements_genuine_zero_match_returns_empty():
+    # A successful resolve that legitimately matches nothing must stay a normal
+    # empty list -- guards against over-correcting the persistent-failure arm.
+    tab = _FakeTab([[]])
+    results = await DOMHandler.query_elements(tab, "div.none", visible_only=False)
+    assert results == []
+    assert tab.select_all_calls == 1

--- a/tests/test_e2e_functions_hooks.py
+++ b/tests/test_e2e_functions_hooks.py
@@ -155,6 +155,51 @@ async def test_cdp_functions_walk(fixture_app_server):
 
 
 @integration_test
+async def test_python_binding_is_callable_from_javascript(fixture_app_server):
+    """RELEASE-FIX-A C6 (A4): the genuine JS→Python round-trip, end-to-end.
+
+    create_python_binding wires Runtime.bindingCalled → the Python function;
+    calling ``window[name](...)`` in the page must resolve to the value the
+    Python function returned. Before the fix the binding was never wired (the
+    wrapper called ``chrome.runtime.sendMessage`` and no handler existed), so the
+    page promise never resolved. This asserts the JS-visible return value equals
+    Python's — the real-coverage proof a characterization pin cannot give.
+    """
+    await warmup_once()
+    base = fixture_app_server
+    spawn = get_fn("spawn_browser")
+    close = get_fn("close_instance")
+
+    result = await spawn(headless=True, **sandbox_kwargs())
+    iid = result["instance_id"]
+    try:
+        await navigate_and_settle(iid, f"{base}/hooks.html")
+
+        binding = await get_fn("create_python_binding")(
+            instance_id=iid,
+            binding_name="pyAdd",
+            python_code="def add(a, b):\n    return a + b",
+        )
+        assert isinstance(binding, dict) and binding.get("success") is True
+
+        # Call the binding from JS and await the promise it returns; the resolved
+        # value must equal what Python returned (40 + 2 == 42).
+        cdp = await get_fn("execute_cdp_command")(
+            instance_id=iid,
+            command="evaluate",
+            params={
+                "expression": "window.pyAdd(40, 2)",
+                "await_promise": True,
+                "return_by_value": True,
+            },
+        )
+        assert cdp["success"] is True, cdp
+        assert "42" in json.dumps(cdp, default=str), cdp
+    finally:
+        await close(instance_id=iid)
+
+
+@integration_test
 @pytest.mark.characterization
 async def test_execute_cdp_command_rejects_domain_qualified_name(fixture_app_server):
     """PINS execute_cdp_command's advertised-vs-executable mismatch.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,24 @@
+"""RELEASE-FIX-A C7 (A11): BrowserInstance timestamps must be tz-aware (UTC).
+
+update_activity writes an aware UTC ``last_activity`` (models.py:37), but the
+defaults were naive ``datetime.now``. The idle reaper subtracts an aware "now"
+from ``last_activity``; a naive default makes that raise
+``TypeError: can't subtract offset-naive and offset-aware datetimes`` (currently
+caught → the reaper silently reaps nothing). Defaults are now aware UTC.
+"""
+
+from datetime import datetime, timezone
+
+from stealth_chrome_devtools_mcp.embedded.models import BrowserInstance
+
+
+def test_default_timestamps_are_utc_aware_and_reaper_safe():
+    inst = BrowserInstance(instance_id="i1")
+
+    # (a) both default timestamps are tz-aware
+    assert inst.created_at.tzinfo is not None, "created_at default is naive"
+    assert inst.last_activity.tzinfo is not None, "last_activity default is naive"
+
+    # (b) the exact idle-reaper hot-path subtraction must not raise TypeError
+    delta = datetime.now(timezone.utc) - inst.last_activity
+    assert delta.total_seconds() >= 0

--- a/tests/test_network_interceptor.py
+++ b/tests/test_network_interceptor.py
@@ -110,6 +110,28 @@ class _FakeEvent:
         self.response = response
 
 
+class _FakeReqType:
+    def __init__(self, value):
+        self.value = value
+
+
+class _FakeRequestObj:
+    def __init__(self, url, method="GET", headers=None, post_data=None):
+        self.url = url
+        self.method = method
+        self.headers = headers or {}
+        self.post_data = post_data
+
+
+class _FakeReqEvent:
+    """Minimal ``RequestWillBeSent`` double for ``_on_request``."""
+
+    def __init__(self, request_id, request, rtype="XHR"):
+        self.request_id = request_id
+        self.request = request
+        self.type = _FakeReqType(rtype)
+
+
 class TestCaptureFilters:
     async def test_default_filters_empty(self):
         ni = NetworkInterceptor()
@@ -293,6 +315,44 @@ class TestBodyStoreByteCaps:
         await ni.clear_instance_data("i1")
         assert ni._body_bytes == 0
         assert ni._responses == {}
+
+
+class TestRequestStoreCaps:
+    """C4 (A3): the request store is count- and metadata-bounded at its single
+    write chokepoint ``_store_request``, mirroring the byte-bounded body store.
+    Caps are resolved from Settings at call time (the autouse
+    ``_reset_settings_cache`` fixture makes ``monkeypatch.setenv`` visible); 0 on
+    either cap = unbounded. Driven through the real ``_on_request`` capture path.
+    """
+
+    async def test_retained_request_count_is_capped_fifo(self, monkeypatch):
+        monkeypatch.setenv("STEALTH_MCP_NETWORK_REQUEST_MAX_COUNT", "3")
+        ni = NetworkInterceptor()
+        ni._instance_requests["i1"] = []
+        for i in range(5):
+            await ni._on_request(
+                _FakeReqEvent(f"r{i}", _FakeRequestObj(f"https://x/{i}")), "i1"
+            )
+        assert len(ni._requests) == 3  # retained count capped
+        assert "r0" not in ni._requests and "r1" not in ni._requests  # oldest evicted
+        assert list(ni._requests) == ["r2", "r3", "r4"]  # FIFO
+        assert ni._instance_requests["i1"] == ["r2", "r3", "r4"]  # per-instance pruned
+
+    async def test_oversize_post_data_is_bounded(self, monkeypatch):
+        monkeypatch.setenv("STEALTH_MCP_NETWORK_POST_DATA_MAX_BYTES", "100")
+        ni = NetworkInterceptor()
+        ni._instance_requests["i1"] = []
+        await ni._on_request(
+            _FakeReqEvent(
+                "r1",
+                _FakeRequestObj("https://x/1", method="POST", post_data="p" * 200),
+            ),
+            "i1",
+        )
+        stored = ni._requests["r1"]
+        assert stored.post_data is None  # over per-post_data cap -> dropped
+        assert stored.url == "https://x/1"  # metadata retained
+        assert stored.method == "POST"
 
 
 class TestCaptureOptIn:

--- a/tests/test_proxy_utils.py
+++ b/tests/test_proxy_utils.py
@@ -61,6 +61,20 @@ class TestParseProxyConfig:
         with pytest.raises(ProxyConfigError):
             parse_proxy_config("http://user:@host.example:8080")
 
+    @pytest.mark.characterization
+    def test_proxy_creds_percent_encoding(self):
+        """PIN (finding A12): credentials are NOT percent-decoded — fix owned by
+        plan_RELEASE W-B3 (the proxy suite). ``urlsplit`` returns userinfo
+        percent-ENCODED, so a proxy password like ``p@ss`` (written ``p%40ss`` in
+        the URL) is forwarded literally as ``p%40ss`` and auth fails. This pins
+        the current (encoded) behaviour so W-B3's ``urllib.parse.unquote`` fix
+        surfaces as a deliberate pin update, not a silent pass. C8 changes NO
+        production code (proxy_utils.py / proxy_forwarder.py stay untouched)."""
+        cfg = parse_proxy_config("http://us%40er:p%40ss@host.example:8080")
+        # Current behaviour: still-encoded (the bug W-B3 will fix to us@er / p@ss).
+        assert cfg.username == "us%40er"
+        assert cfg.password == "p%40ss"
+
 
 class TestMergeProxyServerArg:
     def test_none_leaves_args_untouched(self):

--- a/tests/test_python_binding.py
+++ b/tests/test_python_binding.py
@@ -1,0 +1,132 @@
+"""RELEASE-FIX-A C6 (A4): hermetic proof of the JS→Python binding round-trip.
+
+The old ``create_python_binding`` returned ``success: true`` while wiring
+nothing — it overrode ``window[name]`` and called ``chrome.runtime.sendMessage``
+(an extension API), and no ``Runtime.bindingCalled`` handler ever existed. These
+tests prove the genuine round-trip WITHOUT a browser: driving ``on_binding_called``
+with a synthetic ``BindingCalled`` event must run the registered Python function
+and dispatch a matching ``<name>_response_<callId>`` event back into the page.
+
+The live-Chrome end-to-end proof (JS-visible return value == Python's return) is
+``tests/test_e2e_functions_hooks.py::test_python_binding_is_callable_from_javascript``.
+"""
+
+from __future__ import annotations
+
+import json
+
+from stealth_chrome_devtools_mcp.embedded import python_binding
+
+
+class _FakeBindingCalled:
+    """Minimal ``Runtime.bindingCalled`` double: name + JSON payload string."""
+
+    def __init__(self, name: str, payload: str):
+        self.name = name
+        self.payload = payload
+
+
+class _FakeTab:
+    """Records the CDP command generators passed to ``send`` for inspection."""
+
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, cdp_command):
+        self.sent.append(cdp_command)
+
+
+def _expression_of(cdp_command) -> str:
+    """Pull the ``expression`` param out of a Runtime.evaluate command generator.
+
+    nodriver CDP commands are generators that yield a ``{"method", "params"}``
+    dict on first advance — this reads that without a real connection.
+    """
+    request = next(cdp_command)
+    return request["params"]["expression"]
+
+
+def test_wrapper_uses_cdp_binding_not_sendmessage():
+    """The wrapper must route through the CDP binding channel (a single JSON
+    string), NOT the bogus ``chrome.runtime.sendMessage`` the old code used."""
+    script = python_binding.build_wrapper_script("fixtureBinding")
+    assert "chrome.runtime.sendMessage" not in script
+    assert "JSON.stringify" in script
+    # It preserves and calls the raw addBinding-created function.
+    assert "__fixtureBinding_binding" in script
+    assert "fixtureBinding_response_" in script
+
+
+async def test_binding_called_invokes_python_and_dispatches_response():
+    """A synthetic BindingCalled event runs the Python fn with the decoded args
+    and dispatches ``<name>_response_<callId>`` carrying the result."""
+    calls = []
+
+    def add(a, b):
+        calls.append((a, b))
+        return a + b
+
+    bindings = {"add": add}
+    tab = _FakeTab()
+    event = _FakeBindingCalled("add", json.dumps({"callId": "x", "args": [2, 3]}))
+
+    await python_binding.on_binding_called(tab, event, "add", bindings)
+
+    # (a) the Python function ran with the decoded args
+    assert calls == [(2, 3)]
+    # (b) exactly one dispatch happened, carrying the response event + result
+    assert len(tab.sent) == 1
+    expr = _expression_of(tab.sent[0])
+    assert "add_response_x" in expr
+    detail = json.loads(expr.split("detail: ", 1)[1].rsplit("}))", 1)[0])
+    assert detail["success"] is True
+    assert detail["result"] == 5
+
+
+async def test_binding_called_ignores_other_bindings_name():
+    """A handler filtered to 'add' must ignore an event for a different binding
+    (prevents cross-processing when several bindings live on one tab)."""
+    ran = []
+    bindings = {"add": lambda *a: ran.append(a)}
+    tab = _FakeTab()
+    event = _FakeBindingCalled("other", json.dumps({"callId": "y", "args": [1]}))
+
+    await python_binding.on_binding_called(tab, event, "add", bindings)
+
+    assert ran == []
+    assert tab.sent == []
+
+
+async def test_call_python_from_js_reports_unknown_binding():
+    """An unknown binding name is reported, not raised."""
+    outcome = await python_binding.call_python_from_js({}, "missing", [])
+    assert outcome == {"success": False, "error": "Unknown binding: missing"}
+
+
+async def test_call_python_from_js_supports_coroutine_functions():
+    """Async bound functions are awaited."""
+
+    async def amul(a, b):
+        return a * b
+
+    outcome = await python_binding.call_python_from_js({"amul": amul}, "amul", [4, 5])
+    assert outcome["success"] is True
+    assert outcome["result"] == 20
+
+
+async def test_binding_result_error_is_dispatched_not_raised():
+    """A Python function that raises yields an error response event (the page
+    promise rejects), never an unhandled handler exception."""
+
+    def boom():
+        raise ValueError("kaboom")
+
+    tab = _FakeTab()
+    event = _FakeBindingCalled("boom", json.dumps({"callId": "z", "args": []}))
+    await python_binding.on_binding_called(tab, event, "boom", {"boom": boom})
+
+    assert len(tab.sent) == 1
+    expr = _expression_of(tab.sent[0])
+    detail = json.loads(expr.split("detail: ", 1)[1].rsplit("}))", 1)[0])
+    assert detail["success"] is False
+    assert "kaboom" in detail["error"]

--- a/tools/check_suppression_owners.py
+++ b/tools/check_suppression_owners.py
@@ -3,6 +3,8 @@
 
 Owner-tag grammar (from the 2.5-gates spec):
     plan_M<id>               -- an approved Stage-3 plan owns this code
+    RELEASE-FIX-<tier>       -- an approved pre-release fix plan owns this code
+                                (e.g. RELEASE-FIX-A; a non-M-series FIX plan)
     PERMANENT(<reason>)      -- by-design; will never be "fixed"
     FALSE-POSITIVE(<reason>) -- ruff is wrong here
     DEBT(F-<id>)             -- known debt tracked in audit/findings.json
@@ -21,7 +23,8 @@ import sys
 from pathlib import Path
 
 OWNER_RE = re.compile(
-    r"(plan_M\w+|PERMANENT\(.+?\)|FALSE-POSITIVE\(.+?\)|DEBT\(F-\d+\))"
+    r"(plan_M\w+|RELEASE-FIX-[A-Z]\w*|PERMANENT\(.+?\)|FALSE-POSITIVE\(.+?\)"
+    r"|DEBT\(F-\d+\))"
 )
 
 # An inline ruff suppression marker (the "n-o-q-a" comment), with or without


### PR DESCRIPTION
## RELEASE-FIX-A — Tier-A pre-release fixes (gates plan_RELEASE)

Fixes the **silent-correctness / lying-success** class of `src/` defects the final
7-Opus review surfaced, so plan_RELEASE's W-items build on *true* behaviour. Per
plan_RELEASE §8.1 a characterization pin can never satisfy a release claim, so these
are genuine fixes (not pins) except A12 which is explicitly handed to W-B3.

Base: `main @ 484e143`. Each chunk RED-first + independently revertible.

| Chunk | Finding | Fix |
|---|---|---|
| **C1** | A1 (top sev) | `query_elements`/`get_page_content` bypassed `element_resolution` and swallowed `-32000` into a lying `[]`. New `resolve_elements()` recovery wrapper; 3-arm contract — transient `-32000` → recover, persistent → **raise `ToolError`**, genuine zero-match → `[]`. |
| **C2** | A5 | `extract_element_styles` `NameError` on `include_css_rules=False, include_pseudo=True` → hoisted `matched_styles` fetch. Cloner 1013/1013 net-neutral; goldens unchanged. |
| **C3** | A6 | JS extractors broke on `input[name="email"]` → JSON-encode the selector at the substitution site (regex seam, also folds `$OPTIONS`). Plain selectors byte-identical; goldens unchanged. |
| **C4** | A3 | Unbounded request retention + `post_data` bytes → `_store_request` chokepoint (FIFO count cap + `post_data` byte cap), 2 new `Settings` knobs, DESIGN §6 updated. |
| **C5** | A7 | `close_instance` Phase-2 `await tab.close()` unbounded → `asyncio.wait_for(…, 2.0)`. `browser_manager.py` **1532/1532 net-zero**. |
| **C6** | A4 | `create_python_binding` was a lying no-op (overrode `window[name]`, called `chrome.runtime.sendMessage`, no handler). **Wired the real `Runtime.bindingCalled` round-trip** in new leaf module `embedded/python_binding.py`; `cdp_function_executor.py` **shrinks 1012→939**. Proven by hermetic unit tests **and** a live-Chrome round-trip (`window.pyAdd(40,2)===42` from Python). |
| **C7** | A11 | Naive `datetime.now` defaults vs aware-UTC reaper → `default_factory=lambda: datetime.now(timezone.utc)`. |
| **C8** | A12 | Proxy creds not percent-decoded → **characterization pin only**; fix owned by plan_RELEASE **W-B3**. |

Deferred (need cross-OS CI first): A2/A8/A9/A10 → a post-W2 cross-OS FIX plan.

### Gate (local, CI-parity)
- Unit suite **750 passed** (`-m "not integration"`); 94-tool tripwire green.
- Coverage **61.30%** (≥55 floor; `--cov=src/stealth_chrome_devtools_mcp`).
- ruff format + check clean · ty 76-diagnostic baseline · vulture clean.
- Budgets: all within; **no cap grew** (executor shrank via the C6 extraction).
- Integration (live Chrome): C6 round-trip proven end-to-end; C1/C5 paths green.
- `tools/check_suppression_owners.py` now recognises `RELEASE-FIX-<tier>` as a valid owner tag (the gap the C1 executor flagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
