### PR TITLE
RELEASE-FIX-F: the swallowed half of the F-771 tab family (F-775)

### DIFF
--- a/audit/stage2/plan_RELEASE_FIX_F.md
+++ b/audit/stage2/plan_RELEASE_FIX_F.md
@@ -1,0 +1,172 @@
+# plan_RELEASE_FIX_F — F-775: the F-771 family, where the bare `TypeError` is *swallowed*
+
+**Status: AUTHORIZED, not yet executed.** Branch stacked on `audit/release-fix-e`
+(PR #49). Merge gate: human — **the executor never merges.**
+
+**Found by:** RELEASE-FIX-E while closing F-771, which required auditing every call
+site that awaits an element of `browser.tabs`. Confirmed independently against the
+source before this plan was written.
+**Severity:** the `get_navigation_tab` site is a **silent-correctness / lying-success**
+defect — the Tier-A class this whole campaign exists to eliminate. It ships in 1.2.0.
+
+---
+
+## 1. Why this is worse than F-771
+
+F-771 was *loud*: `list_tabs` raised a bare `TypeError` and the user knew something
+broke. The three remaining sites in the same family are **quiet**, because each one is
+wrapped in a broad `except Exception` that turns the `TypeError` into a plausible-looking
+fallback. A user sees no error at all — just wrong behavior.
+
+The shared mechanism is unchanged from F-771 (nodriver 0.47):
+`Browser.update_targets()` appends raw `Connection` objects
+(`nodriver/core/browser.py:561-583`), `Browser.tabs` returns them despite its
+`List[Tab]` annotation (`browser.py:137-142`), and only `Tab` defines `__await__`
+(`tab.py:1262`) or the ~50 `Tab`-only methods. `Connection.__getattr__` delegates to
+`self.target` (a `TargetInfo`), which is why *attribute reads* still work — and why
+*method calls* fail with a confusing `AttributeError` naming `TargetInfo`.
+
+### F-775a — `get_navigation_tab`: silent tab abandonment + tab leak (HIGHEST VALUE)
+
+`browser_manager.py:1093-1104`:
+
+```python
+for candidate_tab in browser.tabs:
+    if self._get_tab_target_id(candidate_tab) == tracked_target_id:
+        await candidate_tab          # <-- TypeError for a rediscovered target
+        return candidate_tab
+
+if browser.tabs:
+    fallback_tab = browser.tabs[0]
+    await fallback_tab               # <-- same
+    ...
+except Exception as error:           # <-- swallows it as a "tab health check" warning
+    ...
+return await self._replace_main_tab(..., close_existing=False)
+```
+
+The `await` is a *liveness check* on a tab the code has **already correctly found by
+target id**. When it raises, the handler concludes the tracked tab is "missing or
+invalid" — which is false; it was found — and calls `_replace_main_tab`.
+
+Consequences, all invisible to the user:
+
+1. **The user's navigation lands in a different tab** than the one they were tracking.
+2. **`close_existing=False` leaks the abandoned tab**, which stays open forever.
+3. It happens on **every navigation after any `close_tab`**, and worsens with each one.
+4. `NAVIGATION_RECYCLE_THRESHOLD` accounting is distorted by the spurious replacements.
+
+### F-775b — `close_tab` cannot close a rediscovered tab
+
+`browser_manager.py:1391-1396`: `await target_tab.close()`. `Connection` has no
+`close()`; the `__getattr__` delegation surfaces
+`AttributeError: 'TargetInfo' object has no attribute 'close'`, the broad `except`
+catches it, and the method **returns `False` for a tab that is perfectly closeable**.
+FIX-E observed this live. A user cannot close such a tab through the tool at all.
+
+### F-775c — `switch_to_tab`
+
+`browser_manager.py:~1346`: `bring_to_front()` is `Tab`-only, so switching returns
+`False`; and on the success path it would store a `Connection` as the instance's main
+tab, seeding F-775a.
+
+### F-775d — `close_instance` teardown
+
+`browser_manager.py:~865`: same missing `close()`. Cosmetic relative to the others
+(teardown proceeds regardless), but fix it in the same pass if it costs nothing.
+
+---
+
+## 2. The fix
+
+**Principle: never `await` an element of `browser.tabs`, and never call a `Tab`-only
+method on one. Address targets by id through CDP, which works for every object type.**
+
+- **F-775a:** delete the `await candidate_tab` / `await fallback_tab` liveness checks.
+  The tab was located by target id from a just-refreshed `update_targets()`; the `await`
+  adds no information and costs up to 0.5s per tab (`Tab.wait()` blocks on page
+  lifecycle events). This mirrors FIX-E's deletion — same reasoning, same shape.
+  **If** a genuine liveness check is required, it must be one that works for both types
+  (e.g. a bounded CDP round-trip on the target id) and must live in **one** home.
+- **F-775b/d:** close by target id through CDP rather than the `Tab`-only convenience
+  method. Determine the exact call from the pinned nodriver
+  (`cdp.target.close_target(target_id=...)` sent on the browser connection is the
+  likely form) — **verify against the installed source, do not guess**.
+- **F-775c:** same treatment; and do not store a rediscovered object as the main tab
+  without the same guarantees the spawn tab has. If storing it is unsafe, say so and
+  route it rather than inventing a conversion.
+
+### The trap that defines this plan
+
+**Do not widen the broad `except Exception` blocks, and do not narrow them into
+silence.** They are what hid these defects. Either the underlying call cannot raise
+`TypeError`/`AttributeError` any more (the fix), or the failure is surfaced through the
+project's error convention — `raise ToolError` / `InstanceNotFoundError`, never a
+`{"success": False}` dict (`DESIGN.md` §9). A defect that is merely re-swallowed more
+tidily is **not fixed**.
+
+---
+
+## 3. RED-first pins
+
+Local Chrome does **not** naturally reproduce this family (FIX-E established that: every
+`browser.tabs` entry stays a `Tab` on Windows). So RED evidence must come from the two
+tiers FIX-E proved out — reuse its approach rather than inventing a third:
+
+1. **Hermetic tier** — extend `tests/fakes.py` (THE hermetic harness home; never start a
+   second one) with the non-awaitable, `close()`-less discovered-target fake FIX-E added.
+   Pin each of F-775a/b/c against it. These must be RED before the fix with the exact
+   `TypeError`/`AttributeError`, and GREEN after.
+2. **Real-Chrome forced-rediscovery probe** — FIX-E forced nodriver's rediscovery path
+   against real Chrome (drop a target, let `update_targets()` re-append it) to produce a
+   genuine `Connection`. Reuse that technique.
+
+**F-775a needs a behavioral pin, not just a no-raise pin.** Assert that after a
+`close_tab`, a subsequent navigation uses **the same tracked tab id** as before — i.e.
+that `_replace_main_tab` was *not* called and no extra tab was leaked. A pin that only
+proves "no exception" would pass against the current silent-fallback behavior and prove
+nothing. Assert tab identity and the total tab count.
+
+Prove each fix load-bearing: restore the single removed line and show the specific pin
+goes red with the exact original error.
+
+---
+
+## 4. Acceptance
+
+1. All pins green on the unit lane and on the three-OS gate cells that can run them
+   (macOS integration works; macOS *transport* remains blocked by the declared F-773 gap
+   — do not claim macOS transport coverage).
+2. F-775a proven by **tab identity and count**, not by absence of an exception.
+3. No `except Exception` block widened; no error silently swallowed; the error
+   convention honored.
+4. `python tools/check_file_budgets.py` green. `browser_manager.py` was at **1531/1532
+   LOC** after FIX-E — you have essentially **one line of headroom**. If the fix needs
+   more, the correct move is to make the change a net deletion (it should be), **not** to
+   pad the cap. Padding is a standing prohibition. If you genuinely cannot fit, STOP and
+   report rather than raising the cap.
+5. Full local gate: ruff format+check; `ty check --exit-zero-on-warning
+   src/stealth_chrome_devtools_mcp/` at the **76-diagnostic baseline** (a bare `ty check`
+   reports 172 — wrong scope, not a regression); vulture; suppression owners; unit lane.
+6. `--no-verify` never used. PR opened, **never merged**.
+
+### Also in scope, if cheap; route it if not
+
+FIX-E observed a macOS-only flake where **`close_tab` returned `True` while the target
+survived a full 10s poll** — a lying success, distinct from F-775b's lying failure.
+Investigate only far enough to characterize it. If it is not a quick, certain fix,
+**pin and route it as its own finding** rather than growing this plan.
+
+### Out of scope
+
+F-773 (macOS navigation), F-770/F-774 (UA masking — RELEASE-FIX-D), W3's packaging work,
+and any nodriver upstream change. The product must be correct against the pinned
+dependency as it is.
+
+---
+
+## 5. Gates
+
+Branch `audit/release-fix-f` stacked on `audit/release-fix-e`; PR opened against that
+base and held at the human merge gate. Commit messages end with
+`Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.

--- a/src/stealth_chrome_devtools_mcp/embedded/browser_manager.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/browser_manager.py
@@ -862,7 +862,8 @@ class BrowserManager:
                 if hasattr(browser, "tabs") and browser.tabs:
                     for tab in browser.tabs[:]:
                         try:
-                            await asyncio.wait_for(tab.close(), timeout=2.0)
+                            close = uc.cdp.target.close_target(tab.target.target_id)
+                            await asyncio.wait_for(browser.connection.send(close), 2.0)
                         except Exception as tab_err:
                             debug_logger.log_warning(
                                 "browser_manager",
@@ -983,6 +984,18 @@ class BrowserManager:
         return str(target_id)
 
     @staticmethod
+    def _find_tab(browser: Browser, tab_id: str) -> Tab | None:
+        """Return the ``browser.tabs`` entry whose target id is ``tab_id``.
+
+        Callers drive it BY ID over ``browser.connection`` (F-775): the entry is
+        a ``Tab`` only if nodriver made it in-process, else a raw ``Connection``
+        with no ``close()``/``bring_to_front()``.
+        """
+        return next(
+            (t for t in browser.tabs if str(t.target.target_id) == tab_id), None
+        )
+
+    @staticmethod
     def _is_recoverable_navigation_error(error: Exception) -> bool:
         """Return whether a navigation error should trigger one stale-tab
         recovery attempt."""
@@ -1086,22 +1099,17 @@ class BrowserManager:
                 ),
             )
 
+        # F-775a: never await a browser.tabs entry, nor hand one to a caller that
+        # calls Tab-only methods on it (they are raw Connections after any
+        # rediscovery). The loop is a presence check on the target id and returns
+        # the caller's own live Tab; every other path takes _replace_main_tab.
         try:
             await browser.update_targets()
             tracked_target_id = self._get_tab_target_id(tracked_tab)
             if tracked_target_id:
                 for candidate_tab in browser.tabs:
                     if self._get_tab_target_id(candidate_tab) == tracked_target_id:
-                        await candidate_tab
-                        return candidate_tab
-
-            if browser.tabs:
-                fallback_tab = browser.tabs[0]
-                await fallback_tab
-                async with self._lock:
-                    if instance_id in self._instances:
-                        self._instances[instance_id]["tab"] = fallback_tab
-                return fallback_tab
+                        return tracked_tab
         except Exception as error:
             debug_logger.log_warning(
                 "browser_manager",
@@ -1332,17 +1340,13 @@ class BrowserManager:
 
         await browser.update_targets()
 
-        target_tab = None
-        for tab in browser.tabs:
-            if str(tab.target.target_id) == tab_id:
-                target_tab = tab
-                break
-
+        target_tab = self._find_tab(browser, tab_id)
         if not target_tab:
             return False
 
         try:
-            await target_tab.bring_to_front()
+            target_id = target_tab.target.target_id
+            await browser.connection.send(uc.cdp.target.activate_target(target_id))
             async with self._lock:
                 if instance_id in self._instances:
                     self._instances[instance_id]["tab"] = target_tab
@@ -1379,17 +1383,13 @@ class BrowserManager:
         if not browser:
             return False
 
-        target_tab = None
-        for tab in browser.tabs:
-            if str(tab.target.target_id) == tab_id:
-                target_tab = tab
-                break
-
+        target_tab = self._find_tab(browser, tab_id)
         if not target_tab:
             return False
 
         try:
-            await target_tab.close()
+            target_id = target_tab.target.target_id
+            await browser.connection.send(uc.cdp.target.close_target(target_id))
             return True
         except Exception as e:
             debug_logger.log_warning("browser_manager", "close_tab", str(e))

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -32,6 +32,8 @@ import json
 from types import SimpleNamespace
 from typing import Any
 
+import nodriver.cdp.target as cdp_target
+
 # ---------------------------------------------------------------------------
 # In-process tool invoker (THE one way to drive a tool in a test)
 # ---------------------------------------------------------------------------
@@ -91,9 +93,13 @@ class FakeTab:
         evaluate_map: dict[str, Any] | None = None,
         cdp_responses: dict[str, Any] | None = None,
         select_result: Any = None,
+        target_id: str = "T-faketab",
     ) -> None:
         self.url = url
-        self.target = SimpleNamespace(url=url)
+        # ``fake_target`` (defined below) — a Tab's ``.target`` is a real
+        # ``TargetInfo``, so the double carries a real ``TargetID`` too.
+        self.target = fake_target(target_id=target_id, url=url)
+        self.awaited = 0
         self._evaluate_result = evaluate_result
         self._evaluate_map = evaluate_map or {}
         self._cdp_responses = cdp_responses or {}
@@ -103,6 +109,15 @@ class FakeTab:
         self.select_calls: list[str] = []
         self.cdp_frames: list[dict[str, Any]] = []
         self.handlers: list[tuple[Any, Any]] = []
+
+    def __await__(self) -> Any:
+        """nodriver's ``Tab.__await__`` (→ ``Tab.wait()``). Only ``Tab`` defines
+        it — see :class:`FakeDiscoveredTarget`, which deliberately does not."""
+
+        async def _wait() -> None:
+            self.awaited += 1
+
+        return _wait().__await__()
 
     async def evaluate(self, expression: str, *args: Any, **kwargs: Any) -> Any:
         self.evaluate_calls.append(expression)
@@ -161,8 +176,15 @@ def fake_target(
 
     This is the metadata ``list_tabs`` reads off every entry of ``Browser.tabs``,
     and the metadata ``Browser.update_targets()`` refreshes in place.
+
+    ``target_id`` is a real :class:`nodriver.cdp.target.TargetID` (a ``str``
+    subclass), not a bare ``str``: every by-id CDP command serialises it with
+    ``target_id.to_json()`` (``cdp/target.py:258``), so a bare ``str`` here would
+    make the F-775 by-id pins pass against a fake that could not exist.
     """
-    return SimpleNamespace(target_id=target_id, url=url, title=title, type_=type_)
+    return SimpleNamespace(
+        target_id=cdp_target.TargetID(target_id), url=url, title=title, type_=type_
+    )
 
 
 class FakeDiscoveredTarget:
@@ -229,6 +251,15 @@ class FakeBrowser:
     ``tabs`` seeds the target-listing seam (``list_tabs``/``switch_to_tab``/
     ``close_tab`` read it after ``update_targets()``); seed it with
     :class:`FakeAttachedTab` / :class:`FakeDiscoveredTarget`.
+
+    ``connection`` is the BROWSER-level websocket (nodriver ``Browser.connection``,
+    ``core/browser.py:437``) — the one every by-id Target-domain command travels
+    over. It is a :class:`FakeTab`, so ``connection.send_calls`` /
+    ``connection.cdp_frames`` record the command name AND its arguments.
+
+    ``get(url, new_tab=True)`` appends the tab it creates to ``tabs`` and records
+    the call in ``get_calls``, so a test can assert that a code path opened NO
+    extra tab (the F-775a leak).
     """
 
     def __init__(
@@ -246,9 +277,15 @@ class FakeBrowser:
         self.target = SimpleNamespace(url="https://fake.test/page")
         self.tabs = list(tabs or [])
         self.update_targets_calls = 0
+        self.connection = FakeTab(url="ws://fake.test/devtools/browser")
+        self.get_calls: list[tuple[str, bool]] = []
 
     async def get(self, url: str, new_tab: bool = False) -> FakeTab:
-        return FakeTab(url=url)
+        self.get_calls.append((url, new_tab))
+        tab = FakeTab(url=url, target_id=f"T-opened-{len(self.get_calls)}")
+        if new_tab:
+            self.tabs.append(tab)
+        return tab
 
     async def update_targets(self) -> None:
         """nodriver's target refresh. The real one rewrites every known

--- a/tests/test_browser_manager_tab_rediscovery.py
+++ b/tests/test_browser_manager_tab_rediscovery.py
@@ -1,0 +1,225 @@
+"""RELEASE-FIX-F (F-775) — the SWALLOWED half of the F-771 tab family.
+
+F-771 was loud: ``list_tabs`` raised a bare ``TypeError`` and the user knew. The
+three sites pinned here share the exact same mechanism — nodriver 0.47's
+``Browser.update_targets()`` re-appends a rediscovered target as a raw
+``Connection`` (``core/browser.py:561-583``) and ``Browser.tabs`` hands it back
+despite the ``List[Tab]`` annotation (``browser.py:137-142``) — but each one is
+wrapped in a broad ``except Exception`` that turns the failure into a
+plausible-looking fallback. The user sees **no error and wrong behaviour**.
+
+* **F-775a** ``get_navigation_tab`` — finds the tracked tab correctly BY TARGET
+  ID, then awaits it as a liveness check. The await raises for a ``Connection``,
+  the handler concludes the tab is "missing or invalid" (it is not — it was just
+  found) and calls ``_replace_main_tab(close_existing=False)``. Every navigation
+  after any ``close_tab`` silently lands in a DIFFERENT tab and leaks the
+  abandoned one.
+* **F-775b** ``close_tab`` — ``Tab.close()`` does not exist on a ``Connection``;
+  ``__getattr__`` delegates to the ``TargetInfo`` and the ``AttributeError`` is
+  swallowed into ``return False`` for a tab that is perfectly closeable.
+* **F-775c** ``switch_to_tab`` — ``bring_to_front()`` is ``Tab``-only, so
+  switching reports failure for a target that activates fine.
+
+The F-775a pins assert **tab identity and tab count**, never "no exception was
+raised": a no-raise pin passes against today's silent-fallback behaviour and
+therefore proves nothing.
+
+See ``audit/stage2/plan_RELEASE_FIX_F.md``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fakes import (
+    FakeAttachedTab,
+    FakeBrowser,
+    FakeDiscoveredTarget,
+    fake_instance,
+    fake_target,
+)
+from stealth_chrome_devtools_mcp.embedded.browser_manager import BrowserManager
+
+INSTANCE_ID = "i1"
+
+# The instance's tracked main tab: created in-process, so nodriver holds it as a
+# real ``Tab`` and the product stores THAT object in ``_instances[id]["tab"]``.
+TRACKED = {
+    "target_id": "T-main",
+    "url": "https://fake.test/index.html",
+    "title": "fixture-index-page",
+}
+# A second, unrelated page the user also has open.
+OTHER = {
+    "target_id": "T-other",
+    "url": "https://fake.test/interact.html",
+    "title": "fixture-interact-page",
+}
+
+
+@pytest.fixture()
+def manager_and_browser():
+    """A real ``BrowserManager`` one ``close_tab`` after the rediscovery.
+
+    ``browser.tabs`` holds the SAME two target ids the browser had before, but
+    both entries are now raw ``Connection`` objects — that is exactly what
+    ``update_targets()`` leaves behind once a target left nodriver's inventory
+    and came back. The instance still tracks the original, live ``Tab``.
+    """
+    tracked = FakeAttachedTab(fake_target(**TRACKED))
+    browser = FakeBrowser(
+        tabs=[
+            FakeDiscoveredTarget(fake_target(**TRACKED)),
+            FakeDiscoveredTarget(fake_target(**OTHER)),
+        ]
+    )
+    manager = BrowserManager()
+    manager._instances[INSTANCE_ID] = {
+        "browser": browser,
+        "tab": tracked,
+        "instance": fake_instance(INSTANCE_ID),
+        "navigation_count": 0,
+    }
+    return manager, browser, tracked
+
+
+# ---------------------------------------------------------------------------
+# F-775a — get_navigation_tab: silent tab abandonment + tab leak
+# ---------------------------------------------------------------------------
+
+
+async def test_navigation_keeps_the_tracked_tab_identity(manager_and_browser):
+    """THE pin: navigation after a rediscovery uses the SAME tracked tab id.
+
+    Identity, not absence-of-exception. Today the ``await candidate_tab``
+    liveness check raises ``TypeError: object FakeDiscoveredTarget can't be used
+    in 'await' expression``, the broad handler logs a "tab health check failed"
+    warning, and ``_replace_main_tab`` hands back a brand-new tab — so the
+    returned object is neither the tracked tab nor the tracked target id.
+    """
+    manager, _browser, tracked = manager_and_browser
+
+    navigation_tab = await manager.get_navigation_tab(INSTANCE_ID)
+
+    assert navigation_tab is tracked
+    assert manager._get_tab_target_id(navigation_tab) == TRACKED["target_id"]
+
+
+async def test_navigation_after_rediscovery_leaks_no_tab(manager_and_browser):
+    """The other half of F-775a: the tab COUNT must not grow.
+
+    ``_replace_main_tab(..., close_existing=False)`` opens a fresh tab and never
+    closes the abandoned one, so the leak compounds with every navigation.
+    """
+    manager, browser, tracked = manager_and_browser
+
+    await manager.get_navigation_tab(INSTANCE_ID)
+
+    assert browser.get_calls == []
+    assert len(browser.tabs) == 2
+    assert manager._instances[INSTANCE_ID]["tab"] is tracked
+
+
+async def test_navigation_tab_pays_no_per_tab_lifecycle_wait(manager_and_browser):
+    """``update_targets()`` refreshed the metadata the loop compares, and the tab
+    was located BY TARGET ID — the await added no information and cost up to 0.5s
+    (``Tab.wait()`` races the lifecycle event against ``asyncio.sleep(0.5)``)."""
+    manager, browser, tracked = manager_and_browser
+
+    await manager.get_navigation_tab(INSTANCE_ID)
+
+    assert browser.update_targets_calls == 1
+    assert tracked.awaited == 0
+
+
+async def test_navigation_never_adopts_a_browser_tabs_entry_as_main_tab(
+    manager_and_browser,
+):
+    """When the tracked target really IS gone, the replacement must be a tab
+    opened in-process — never an element of ``browser.tabs``.
+
+    ``get_navigation_tab`` used to adopt ``browser.tabs[0]`` as the instance's
+    main tab. That is unsound for the same reason the await was: the adopted
+    object may be a raw ``Connection``, and ``navigate()`` immediately calls the
+    ``Tab``-only ``get()``/``evaluate()`` on whatever it is handed — an
+    ``AttributeError`` that ``_is_recoverable_navigation_error`` does not match,
+    so it would escape instead of self-healing. It also hijacked an unrelated
+    user tab. ``_replace_main_tab`` is the ONE home for "give me a real main
+    tab" (CLAUDE.md convention 4), so the adoption branch is deleted and the
+    method falls through to it.
+
+    Seeded with an *awaitable* survivor on purpose: with a non-awaitable one the
+    old code reached ``_replace_main_tab`` via its exception handler anyway, and
+    the pin would prove nothing.
+    """
+    manager, browser, _tracked = manager_and_browser
+    survivor = FakeAttachedTab(fake_target(**OTHER))
+    browser.tabs = [survivor]
+
+    navigation_tab = await manager.get_navigation_tab(INSTANCE_ID)
+
+    assert navigation_tab is not survivor
+    assert manager._instances[INSTANCE_ID]["tab"] is not survivor
+    assert browser.get_calls == [("about:blank", True)]
+    assert manager._instances[INSTANCE_ID]["tab"] is navigation_tab
+
+
+# ---------------------------------------------------------------------------
+# F-775b — close_tab: a lying failure
+# ---------------------------------------------------------------------------
+
+
+async def test_close_tab_closes_a_rediscovered_target(manager_and_browser):
+    """A rediscovered tab is perfectly closeable — address it by target id.
+
+    Today ``await target_tab.close()`` resolves through
+    ``Connection.__getattr__`` to the ``TargetInfo``, raising
+    ``AttributeError: 'SimpleNamespace' object has no attribute 'close'``
+    (``'TargetInfo' object has no attribute 'close'`` against real nodriver),
+    which the broad ``except`` turns into ``return False``.
+    """
+    manager, browser, _tracked = manager_and_browser
+
+    closed = await manager.close_tab(INSTANCE_ID, OTHER["target_id"])
+
+    assert closed is True
+    assert browser.connection.send_calls == ["close_target"]
+    assert browser.connection.cdp_frames[0] == {
+        "method": "Target.closeTarget",
+        "params": {"targetId": OTHER["target_id"]},
+    }
+
+
+async def test_close_tab_reports_an_unknown_tab_id_unchanged(manager_and_browser):
+    """Unchanged contract: no such tab → ``False``, and no CDP traffic."""
+    manager, browser, _tracked = manager_and_browser
+
+    assert await manager.close_tab(INSTANCE_ID, "T-nope") is False
+    assert browser.connection.send_calls == []
+
+
+# ---------------------------------------------------------------------------
+# F-775c — switch_to_tab: a lying failure + a bad main-tab store
+# ---------------------------------------------------------------------------
+
+
+async def test_switch_to_tab_activates_a_rediscovered_target(manager_and_browser):
+    """``bring_to_front()`` is ``Tab``-only; ``Target.activateTarget`` is not."""
+    manager, browser, _tracked = manager_and_browser
+
+    switched = await manager.switch_to_tab(INSTANCE_ID, OTHER["target_id"])
+
+    assert switched is True
+    assert browser.connection.send_calls == ["activate_target"]
+    assert browser.connection.cdp_frames[0] == {
+        "method": "Target.activateTarget",
+        "params": {"targetId": OTHER["target_id"]},
+    }
+
+
+async def test_switch_to_tab_reports_an_unknown_tab_id_unchanged(manager_and_browser):
+    """Unchanged contract: no such tab → ``False``, and no CDP traffic."""
+    manager, browser, _tracked = manager_and_browser
+
+    assert await manager.switch_to_tab(INSTANCE_ID, "T-nope") is False
+    assert browser.connection.send_calls == []

--- a/tests/test_e2e_interaction.py
+++ b/tests/test_e2e_interaction.py
@@ -17,6 +17,7 @@ import asyncio
 import json
 import time
 
+import nodriver as uc
 import pytest
 
 from e2e_helpers import (
@@ -26,6 +27,7 @@ from e2e_helpers import (
     navigate_and_settle,
     read_actions,
     sandbox_kwargs,
+    server_mod,
     wait_for_js,
     warmup_once,
 )
@@ -555,5 +557,118 @@ async def test_tabs_lifecycle(fixture_app_server):
         # fails the test on the first call; it is never polled away.
         remaining = await _tabs_until(iid, lambda tabs: new_id not in tabs)
         assert new_id not in remaining
+    finally:
+        await close(instance_id=iid)
+
+
+# ---------------------------------------------------------------------------
+# RELEASE-FIX-F (F-775) — the swallowed half of the F-771 tab family
+# ---------------------------------------------------------------------------
+
+
+async def _force_rediscovery(browser, tab_id: str):
+    """Make nodriver hand back target ``tab_id`` as a raw ``Connection``.
+
+    This is the whole point of the probe: local Chrome does not reliably produce
+    the F-775 shape on its own (FIX-E established that every ``browser.tabs``
+    entry stays a ``Tab`` here), so the ONE step that creates it is forced
+    directly — drop the target from nodriver's inventory exactly as its
+    ``TargetDestroyed`` handler does (``core/browser.py:222-231``), then let
+    ``update_targets()`` re-append it, which it does as a ``Connection``, never a
+    ``Tab`` (``core/browser.py:574-583``).
+
+    Returns the genuine ``Connection``, and asserts it really is one — a probe
+    that silently failed to reproduce the shape would make every pin below
+    vacuous.
+    """
+    entry = next(t for t in browser.targets if str(t.target.target_id) == tab_id)
+    browser.targets.remove(entry)
+    await browser.update_targets()
+
+    rediscovered = next(t for t in browser.tabs if str(t.target.target_id) == tab_id)
+    assert not isinstance(rediscovered, uc.Tab), type(rediscovered)
+    assert isinstance(rediscovered, uc.core.connection.Connection)
+    return rediscovered
+
+
+async def test_navigation_survives_a_forced_rediscovery(fixture_app_server):
+    """F-775a against real Chrome and a GENUINE nodriver ``Connection``.
+
+    The tracked tab is found correctly by target id; awaiting it as a "liveness
+    check" then raised ``TypeError`` for the rediscovered object, and the broad
+    handler concluded the tab was "missing or invalid" — it was not, it had just
+    been found — and called ``_replace_main_tab(close_existing=False)``. Every
+    navigation silently landed in a different tab and leaked the abandoned one.
+
+    Asserted by tab IDENTITY and tab COUNT, never by absence of an exception: a
+    no-raise pin passes against the silent fallback and proves nothing.
+    """
+    base = fixture_app_server
+    spawn = get_fn("spawn_browser")
+    list_tabs = get_fn("list_tabs")
+    close = get_fn("close_instance")
+
+    manager = server_mod.browser_manager
+    result = await spawn(headless=True, **sandbox_kwargs())
+    iid = result["instance_id"]
+    try:
+        await navigate_and_settle(iid, f"{base}/index.html")
+
+        data = await manager.get_instance(iid)
+        browser, tracked = data["browser"], data["tab"]
+        tab_id = manager._get_tab_target_id(tracked)
+        before = {t["tab_id"] for t in await list_tabs(instance_id=iid)}
+
+        await _force_rediscovery(browser, tab_id)
+
+        navigation_tab = await manager.get_navigation_tab(iid)
+        assert manager._get_tab_target_id(navigation_tab) == tab_id
+
+        nav = await navigate_and_settle(iid, f"{base}/interact.html")
+        assert nav["url"].endswith("/interact.html")
+
+        after = {t["tab_id"] for t in await list_tabs(instance_id=iid)}
+        assert after == before, "navigation opened or abandoned a tab"
+
+        still_tracked = (await manager.get_instance(iid))["tab"]
+        assert manager._get_tab_target_id(still_tracked) == tab_id
+    finally:
+        await close(instance_id=iid)
+
+
+async def test_close_and_switch_survive_a_forced_rediscovery(fixture_app_server):
+    """F-775b/c against real Chrome and a GENUINE nodriver ``Connection``.
+
+    ``Tab.close()`` / ``Tab.bring_to_front()`` do not exist on a ``Connection``;
+    ``__getattr__`` delegates to the ``TargetInfo`` and the resulting
+    ``AttributeError`` was swallowed into ``return False`` — a lying failure for
+    a tab that closes and activates perfectly well when addressed by id.
+    """
+    base = fixture_app_server
+    spawn = get_fn("spawn_browser")
+    list_tabs = get_fn("list_tabs")
+    new_tab = get_fn("new_tab")
+    switch_tab = get_fn("switch_tab")
+    close_tab = get_fn("close_tab")
+    close = get_fn("close_instance")
+
+    manager = server_mod.browser_manager
+    result = await spawn(headless=True, **sandbox_kwargs())
+    iid = result["instance_id"]
+    try:
+        await navigate_and_settle(iid, f"{base}/index.html")
+        browser = (await manager.get_instance(iid))["browser"]
+
+        doomed_id = (await new_tab(instance_id=iid, url=f"{base}/interact.html"))[
+            "tab_id"
+        ]
+        await _force_rediscovery(browser, doomed_id)
+
+        assert await switch_tab(instance_id=iid, tab_id=doomed_id) is True
+        assert await close_tab(instance_id=iid, tab_id=doomed_id) is True
+
+        remaining = await _tabs_until(iid, lambda tabs: doomed_id not in tabs)
+        assert doomed_id not in remaining, "close_tab lied: the target survived"
+        assert await list_tabs(instance_id=iid)
     finally:
         await close(instance_id=iid)

--- a/tests/test_silent_excepts_log.py
+++ b/tests/test_silent_excepts_log.py
@@ -56,11 +56,14 @@ class TestBrowserManagerSilentExcepts:
         from stealth_chrome_devtools_mcp.embedded.browser_manager import BrowserManager
 
         manager = BrowserManager()
-        tab = _mock_tab("tab-1")
-        tab.bring_to_front = AsyncMock(side_effect=RuntimeError("front-fail"))
         browser = MagicMock()
-        browser.tabs = [tab]
+        browser.tabs = [_mock_tab("tab-1")]
         browser.update_targets = AsyncMock()
+        # RELEASE-FIX-F (F-775c): the failure seam moved from the Tab-only
+        # ``bring_to_front()`` to ``Target.activateTarget`` on the browser
+        # connection. The guarantee pinned here is unchanged — the broad handler
+        # must LOG, not swallow.
+        browser.connection.send = AsyncMock(side_effect=RuntimeError("front-fail"))
 
         with patch.object(manager, "get_browser", AsyncMock(return_value=browser)):
             result = await manager.switch_to_tab("inst-1", "tab-1")
@@ -76,10 +79,11 @@ class TestBrowserManagerSilentExcepts:
         from stealth_chrome_devtools_mcp.embedded.browser_manager import BrowserManager
 
         manager = BrowserManager()
-        tab = _mock_tab("tab-2")
-        tab.close = AsyncMock(side_effect=RuntimeError("close-fail"))
         browser = MagicMock()
-        browser.tabs = [tab]
+        browser.tabs = [_mock_tab("tab-2")]
+        # RELEASE-FIX-F (F-775b): seam moved from the Tab-only ``close()`` to
+        # ``Target.closeTarget`` on the browser connection; same guarantee.
+        browser.connection.send = AsyncMock(side_effect=RuntimeError("close-fail"))
 
         with patch.object(manager, "get_browser", AsyncMock(return_value=browser)):
             result = await manager.close_tab("inst-1", "tab-2")


### PR DESCRIPTION
Closes **F-775** — the three *silent* siblings of F-771. Stacked on `audit/release-fix-e` (PR #49). Plan: `audit/stage2/plan_RELEASE_FIX_F.md` (added in the first commit). **Human holds the merge gate; nothing merged here.**

F-771 was loud — it raised, so the user knew. These sites are wrapped in broad `except Exception` handlers that turn the same failure into a plausible-looking fallback: **no error, wrong behaviour.**

## The principle

Never `await` a `browser.tabs` entry, never call a `Tab`-only method on one, and **never hand one to a caller that will**. Address the target **by id over `browser.connection`** — that works for every object type nodriver puts in `browser.tabs`. As in FIX-E the fix is *deletion*, not an `isinstance` branch: a type switch here would be a second way to do one thing (CLAUDE.md convention 4).

## Per site

### F-775a `get_navigation_tab` — silent tab abandonment + tab leak (the one that mattered)

The code found the tracked tab correctly **by target id**, then `await`ed it as a "liveness check". For a rediscovered target that await raised, the handler concluded the tab was *"missing or invalid"* — it was not, it had just been found — and called `_replace_main_tab(close_existing=False)`. Invisibly, on every navigation after any `close_tab`: navigation landed in a **different tab**, the abandoned tab **leaked**, and `NAVIGATION_RECYCLE_THRESHOLD` accounting was distorted.

The await is deleted; the loop is now purely a presence check on the target id and the method returns the caller's **own tracked `Tab`**. Returning the `browser.tabs` entry instead would only move the failure — `navigate()` immediately calls the `Tab`-only `get()`/`evaluate()` on whatever it is handed.

The `browser.tabs[0]` **adoption fallback is deleted** for the same reason (declared, not hidden — see "Judgement calls" below).

### F-775b `close_tab` / F-775d `close_instance` — a lying failure

`Connection` has no `close()`; `__getattr__` delegates to the `TargetInfo`, so the `AttributeError` was swallowed into `return False` for a tab that is perfectly closeable — a user could not close such a tab through the tool at all. Both now send `cdp.target.close_target(target_id)` on `browser.connection`.

**Verified against the installed nodriver, not guessed:**
- `Tab.close()` *is* `self.send(cdp.target.close_target(target_id=self.target.target_id))` — `nodriver/core/tab.py:1027-1034`
- `close_target` emits `Target.closeTarget` — `nodriver/cdp/target.py:248-264`
- `Browser.connection` is where nodriver itself sends Target-domain commands — `nodriver/core/browser.py:251`, `:558`

### F-775c `switch_to_tab` — a lying failure

`bring_to_front()` is a `Tab`-only alias for `Tab.activate()`, i.e. `cdp.target.activate_target` (`core/tab.py:1096-1106`, `cdp/target.py:193-208`), so switching reported failure for a target that activates fine. Now sent by id on the browser connection.

## No handler was widened, narrowed or tidied

They are what hid these defects. What changed is that the guarded calls **can no longer raise** `AttributeError`/`TypeError` for a rediscovered target; the handlers keep their existing role for genuine CDP failures and their KEEP `bool` contracts are untouched. The two M10a F-181 pins in `test_silent_excepts_log.py` are re-pointed at the new failure seam (`browser.connection.send`) with the guarantee they assert — *log, do not swallow* — unchanged.

## RED → GREEN

Two tiers, both landed RED in commit 1 (`080d16d`, pins only, so CI records the RED) and GREEN in commit 2 (`c2b94ae`).

**Hermetic** (`tests/test_browser_manager_tab_rediscovery.py`, fast unit lane) — RED with the product's own failures:

```
browser_manager.get_navigation_tab: Tab health check failed for i1:
  object FakeDiscoveredTarget can't be used in 'await' expression
  -> assert navigation_tab is tracked   FAILED (a FakeTab from _replace_main_tab)
  -> assert browser.get_calls == []     FAILED: [('about:blank', True)]

browser_manager.close_tab:   'types.SimpleNamespace' object has no attribute 'close'
  -> assert False is True
browser_manager.switch_to_tab: 'types.SimpleNamespace' object has no attribute 'bring_to_front'
  -> assert False is True
```

**Real Chrome** (`tests/test_e2e_interaction.py`) — `_force_rediscovery()` drops a target from nodriver's inventory exactly as its `TargetDestroyed` handler does (`core/browser.py:222-231`) and lets `update_targets()` re-append it, then **asserts the result is a genuine `Connection` and not a `Tab`** — a probe that silently failed to reproduce the shape would make the pins vacuous. Against the pre-fix `src` these are RED with a real nodriver `Connection`:

```
browser_manager.get_navigation_tab: Tab health check failed for 48038195-...:
  object Connection can't be used in 'await' expression
E  assert '7FDF681AA31DA44161CFBE643EAD44FA' == 'DCA94F92ABC65D9C62191EAA1FF24326'
E  assert await switch_tab(...) is True   ->  False
```

That id mismatch **is** the silent tab abandonment, reproduced live.

### The F-775a assertion, specifically

Per the plan, F-775a is pinned by **tab identity and tab count**, never by absence of an exception (a no-raise pin passes against the silent fallback and proves nothing):

- hermetic — `navigation_tab is tracked`; `browser.get_calls == []`; `len(browser.tabs) == 2` (unchanged); `_instances[id]["tab"] is tracked`
- real Chrome — `_get_tab_target_id(navigation_tab) == tab_id`; after a real navigation, `set(list_tabs ids) == before` ("navigation opened or abandoned a tab"); the instance still tracks the same id

### Load-bearing

Each removed line restored individually; the specific pin goes red with the exact original error:

| restored | pin | failure |
|---|---|---|
| `await candidate_tab` | identity + leak | `object FakeDiscoveredTarget can't be used in 'await' expression` → wrong object, `[('about:blank', True)]` |
| `browser.tabs[0]` adoption | never-adopts | `assert <FakeAttachedTab …> is not <FakeAttachedTab …>` |
| `await target_tab.close()` | close_tab | `'…' object has no attribute 'close'` → `assert False is True` |
| `await target_tab.bring_to_front()` | switch_to_tab | `'…' object has no attribute 'bring_to_front'` → `assert False is True` |

## Judgement calls I am flagging rather than burying

1. **The `browser.tabs[0]` adoption fallback in `get_navigation_tab` is deleted**, which is more than "delete the `await`". Deleting the await *alone* would have been strictly worse: the adopted object can be a raw `Connection`, and the `AttributeError` `navigate()` would then raise is **not** matched by `_is_recoverable_navigation_error`, so it would escape instead of self-healing. It was also a second, weaker way to do what `_replace_main_tab` is the one home for, and it hijacked an unrelated user tab. Control now falls through to `_replace_main_tab`, which always yields a real in-process `Tab`. Pinned by `test_navigation_never_adopts_a_browser_tabs_entry_as_main_tab`. **Behaviour change:** when the tracked tab is genuinely gone, a fresh tab is opened instead of adopting a surviving one.

2. **`switch_to_tab` still stores the `browser.tabs` entry as the instance main tab.** Activation is fixed (the actual defect: switching failed). Storing a raw `Connection` there remains latent — every later `Tab`-only call on it would fail *loudly*. Per the plan's instruction ("if storing it is unsafe, say so and route it rather than inventing a conversion"), this is **declared, not fixed here**.

3. **Residual, same family, outside this plan's four sites:** `_replace_main_tab` awaits the object `browser.get(..., new_tab=True)` returned (`browser_manager.py:1030`). `Browser.get` returns whatever is in `browser.targets` for that id (`core/browser.py:255-261`), which is a `Connection` if `update_targets()` won the race against the `TargetCreated` handler. Loud if it fires, so lower severity — routed, not silently patched.

4. **F-775d has no dedicated pin.** `close_instance` is not drivable hermetically without new teardown scaffolding; it is exercised by every integration test's `finally: close_instance` (11/11 green) and shares the verified CDP call. Declared gap.

5. **The macOS "close_tab returned True while the target survived" flake** FIX-E observed was *not* reproducible here (Windows green, including a bounded 10 s poll asserting the target really dies: `assert doomed_id not in remaining, "close_tab lied: the target survived"`). Not characterized; not claimed closed.

## Gates

- ruff format + check: clean
- `ty check --exit-zero-on-warning src/stealth_chrome_devtools_mcp/`: **76 diagnostics** = baseline
- vulture, suppression owners, file budgets: clean
- **`browser_manager.py`: 1531/1532 LOC — exactly its pre-FIX-F size.** The deletions pay for the `_find_tab` helper (the duplicated find-by-id loop in `switch_to_tab`/`close_tab` becomes one home). **No cap padded; the 1-line headroom is preserved.**
- unit lane `-m "not integration"`: **772 passed**, 1 skipped
- full suite incl. integration: **831 passed**, 1 skipped, 0 failed (local Windows + real Chrome)
- `--no-verify` never used.

macOS *transport* remains the declared F-773 gap — no macOS transport coverage is claimed.
