### PR TITLE
[STAGING - DO NOT MERGE] release integration tree for W5 evidence generation

### DIFF
--- a/.github/workflows/fix-d-stealth-cells.yml
+++ b/.github/workflows/fix-d-stealth-cells.yml
@@ -1,0 +1,73 @@
+name: fix-d-stealth-cells
+
+# TEMPORARY — plan_RELEASE_FIX_D scaffolding, delete when this stack lands.
+#
+# FIX-D must report the F-770 User-Agent leak-vector measurement on all three
+# qualified cells (Linux/X64, Windows/X64, macOS/ARM64) and then prove the fix on
+# the same three. The three-cell `offline-stealth` edge lives in W2's reusable
+# `release-gate.yml`, which is NOT on this branch's ancestry (FIX-D is stacked on
+# `audit/release-4-w4`, whose CI is the ubuntu-only `test.yml`). This job is the
+# stopgap that gives FIX-D that evidence — it is NOT a second gate: it runs the
+# SAME selector as W2's edge (`-m "stealth and not online"`) and is superseded by
+# it the moment `release-gate.yml` is in this branch's history. Delete it then.
+#
+# Trigger is scoped to PRs whose base is the W4 branch, so it cannot fire on any
+# other PR in the repo.
+
+on:
+  pull_request:
+    branches: ['audit/release-4-w4']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  offline-stealth:
+    name: offline-stealth (${{ matrix.runner_os }}/${{ matrix.runner_arch }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest, runner_os: Linux, runner_arch: X64 }
+          - { os: windows-latest, runner_os: Windows, runner_arch: X64 }
+          - { os: macos-latest, runner_os: macOS, runner_arch: ARM64 }
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --extra test --extra sentry
+
+      - name: Record cell + Chrome identity
+        shell: bash
+        run: |
+          echo "runner: ${{ runner.os }}/${{ runner.arch }} (expected ${{ matrix.runner_os }}/${{ matrix.runner_arch }})"
+          uv run python -c "from stealth_chrome_devtools_mcp.embedded.platform_utils import check_browser_executable as c; print('chrome:', c())"
+
+      - name: Run the offline stealth lane (F-770 vector measurement)
+        # -s so the D0 per-vector table reaches the log on a PASSING run; the
+        # selector is W2's `offline-stealth` selector verbatim.
+        shell: bash
+        run: uv run pytest -m "stealth and not online" -v -s --tb=short --timeout=300
+        env:
+          STEALTH_MCP_BROWSER_SESSION_ROOT: ${{ runner.temp }}/stealth-mcp-session-root
+          STEALTH_PROBE_ARTIFACT_DIR: ${{ runner.temp }}/stealth-artifact
+
+      - name: Print the F-770 vector artifact
+        if: always()
+        shell: bash
+        run: cat "${{ runner.temp }}/stealth-artifact/stealth_probe_result_v1.json" || echo "no artifact"
+
+      - name: Upload the F-770 vector artifact
+        if: always()
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: f770-vectors-${{ matrix.runner_os }}-${{ matrix.runner_arch }}
+          path: ${{ runner.temp }}/stealth-artifact

--- a/.github/workflows/fix-d-stealth-cells.yml
+++ b/.github/workflows/fix-d-stealth-cells.yml
@@ -51,12 +51,21 @@ jobs:
           echo "runner: ${{ runner.os }}/${{ runner.arch }} (expected ${{ matrix.runner_os }}/${{ matrix.runner_arch }})"
           uv run python -c "from stealth_chrome_devtools_mcp.embedded.platform_utils import check_browser_executable as c; print('chrome:', c())"
 
+      - name: Start Xvfb (Linux only — mirrors W2's integration cell)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq xvfb
+          Xvfb :99 -screen 0 1920x1080x24 -ac +extension GLX +render -noreset &
+          sleep 3
+
       - name: Run the offline stealth lane (F-770 vector measurement)
         # -s so the D0 per-vector table reaches the log on a PASSING run; the
         # selector is W2's `offline-stealth` selector verbatim.
         shell: bash
         run: uv run pytest -m "stealth and not online" -v -s --tb=short --timeout=300
         env:
+          DISPLAY: ${{ runner.os == 'Linux' && ':99' || '' }}
           STEALTH_MCP_BROWSER_SESSION_ROOT: ${{ runner.temp }}/stealth-mcp-session-root
           STEALTH_PROBE_ARTIFACT_DIR: ${{ runner.temp }}/stealth-artifact
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,72 +1,69 @@
 name: Publish to PyPI
 
+# plan_RELEASE W3 (gap G-C): a tag publishes the ARTIFACTS THE GATE TESTED.
+#
+# The gate is not re-implemented here — this workflow CALLS the one reusable
+# `release-gate.yml` at the tag's SHA, so the tag is qualified by exactly the
+# same jobs (including the six install-smoke cells) a pull request runs. That
+# call builds the distribution once and uploads it as the run's `dist` artifact;
+# `publish` then DOWNLOADS those same files, re-checks their SHA-256 hashes
+# against the build manifest, and uploads them. It never runs `uv build`, never
+# rebuilds from the checkout, and never fetches the version from PyPI.
+#
+# Because `publish` needs the gate job, a failed, skipped, or cancelled cell in
+# ANY gate lane leaves `needs.gate` non-success and neither PyPI nor the GitHub
+# release happens.
+
 on:
   push:
     tags:
       - "v*"
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 jobs:
-  test:
-    name: Run tests before publish
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.11", "3.12", "3.13"]
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
-
-      - name: Set up Python ${{ matrix.python-version }}
-        run: uv python install ${{ matrix.python-version }}
-
-      - name: Install dependencies
-        run: uv sync --extra test
-
-      - name: Run unit tests
-        run: uv run pytest -m "not integration" -v --tb=short
+  # The full release gate, at the tag SHA, with the tag passed in so the gate
+  # itself fails if the tag and the built artifact's metadata version disagree.
+  gate:
+    uses: ./.github/workflows/release-gate.yml
+    with:
+      ref: ${{ github.sha }}
+      release_tag: ${{ github.ref_name }}
 
   publish:
-    name: Build and publish
+    name: Publish the gated artifacts
     runs-on: ubuntu-latest
-    needs: test
+    needs: gate
     environment: pypi
+    permissions:
+      contents: write # create the GitHub release
+      id-token: write # PyPI trusted publishing
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+      - name: Download the gated dist artifact (no rebuild)
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: dist
 
-      - name: Set up Python
-        run: uv python install 3.12
-
-      - name: Verify version matches tag
+      - name: Re-check hashes, membership, and the tag/version agreement
+        shell: bash
         run: |
-          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
-          PKG_VERSION=$(python -c "
-          import re
-          with open('pyproject.toml') as f:
-              m = re.search(r'version\s*=\s*\"([^\"]+)\"', f.read())
-              print(m.group(1))
-          ")
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "::error::Tag v${TAG_VERSION} does not match pyproject.toml version ${PKG_VERSION}"
-            exit 1
-          fi
-          echo "VERSION=${TAG_VERSION}" >> "$GITHUB_ENV"
-
-      - name: Build package
-        run: uv build
+          set -euo pipefail
+          python3 tools/package_verify.py verify \
+            --dist dist --manifest release-manifest.json \
+            --expect-version "${GITHUB_REF_NAME}"
+          echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+          echo "These exact files are about to be published:"
+          sha256sum dist/*
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          packages-dir: dist
 
       - name: Generate changelog
         run: |
@@ -111,6 +108,9 @@ jobs:
           name: v${{ env.VERSION }}
           body_path: changelog.md
           append_body: true
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
           body: |
             ## Installation
 

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -245,7 +245,7 @@ jobs:
   # start, tab/CDP health, reachability, Fetch interception, profile location,
   # the network-service process, and Chrome errors). The cell is EXCLUDED, not
   # xfail-quarantined: an xfail would let a green gate imply macOS coverage.
-  # `transport-known-gaps` below states the gap in the job list, so it is
+  # `known-gaps` below states the gap in the job list, so it is
   # visible without reading this file. Re-add the cell the moment F-773 closes —
   # `finding_F773_macos_detached_navigation.md` §7 is the experiment that does it.
   transport:
@@ -307,15 +307,23 @@ jobs:
   # the check list where a reviewer reads it — so coverage gaps cost a visible
   # line rather than living only in a YAML comment. It passes: it reports, it
   # does not judge. Delete a line here only when the gap actually closes.
-  transport-known-gaps:
-    name: transport-known-gaps
+  # Renamed from `transport-known-gaps` in W3: the same root cause now bounds a
+  # second lane (install-smoke), and gap declarations get ONE home, not two.
+  known-gaps:
+    name: known-gaps
     runs-on: ubuntu-latest
     steps:
       - name: State the gaps
         run: |
           echo "::warning title=F-773::transport (macOS/ARM64) is NOT run. Chrome under the detached backend completes no network navigation on the hosted macOS runner. Cause unknown; 11 CI rounds, full elimination table in audit/stage2/finding_F773_macos_detached_navigation.md. Unknown whether real Macs are affected -- that needs a run on real hardware."
-          echo "This gate verifies the real-stdio journey on Linux/X64 and Windows/X64 ONLY."
-          echo "It makes NO claim about macOS navigation. Do not advertise one."
+          echo "::warning title=F-773::install-smoke (macOS/ARM64) runs as a PARTIAL cell for BOTH wheel and sdist: install + launcher resolve + initialize + tools/list + list_instances, and NO navigation. W3 confirmed F-773 reaches this lane from a FRESH INSTALL of the built artifacts, not just from the checkout."
+          echo "FULL-JOURNEY (navigating) coverage in this gate:"
+          echo "  transport      : Linux/X64, Windows/X64"
+          echo "  install-smoke  : Linux/X64, Windows/X64 -- wheel AND sdist (4 full cells)"
+          echo "PARTIAL, NON-NAVIGATING coverage:"
+          echo "  install-smoke  : macOS/ARM64 -- wheel AND sdist (2 install+handshake cells)"
+          echo "This gate makes NO claim about macOS navigation. Do not advertise one."
+          echo "It DOES claim the built artifacts install and serve on macOS/ARM64."
 
   # ── Offline stealth lane (W2 wires the edge; W4 lands the tests) ───────────
   offline-stealth:
@@ -492,8 +500,21 @@ jobs:
   # Install the EXACT downloaded artifact into a fresh environment and run W1's
   # canonical journey through the launcher that install produced. Both
   # publishable artifacts on every qualified cell.
+  #
+  # The macOS/ARM64 cells run `--stages handshake`: install + launcher resolve +
+  # initialize + tools/list + list_instances, and NO navigation. That is a
+  # DECLARED PARTIAL cell, not a quiet reduction — F-773 makes any navigation
+  # through the detached backend hang on hosted macOS runners, and this run
+  # proved it reaches this lane too (both macOS cells, from a FRESH INSTALL of
+  # the built wheel/sdist rather than the checkout: about:blank ok in 1.1s, a
+  # connection to a CLOSED port hung 35.3s, fixture served nothing). It is
+  # deliberately NOT an xfail and NOT continue-on-error: nothing failing is
+  # marked expected-to-fail; a strictly smaller claim is made and labelled in
+  # the cell NAME, in the tool's own output, and in the `known-gaps` job.
+  # The stage is the ONLY difference — same tool, same harness, same journey
+  # function. Flip these cells back to `full` the moment F-773 closes.
   install-smoke:
-    name: install-smoke (${{ matrix.kind }} ${{ matrix.cell.runner_os }}/${{ matrix.cell.runner_arch }})
+    name: install-smoke (${{ matrix.kind }} ${{ matrix.cell.runner_os }}/${{ matrix.cell.runner_arch }}${{ matrix.cell.stages == 'handshake' && ' NO-NAVIGATION partial' || '' }})
     needs: build-dist
     runs-on: ${{ matrix.cell.os }}
     strategy:
@@ -501,9 +522,9 @@ jobs:
       matrix:
         kind: [wheel, sdist]
         cell:
-          - { os: ubuntu-latest, runner_os: Linux, runner_arch: X64 }
-          - { os: windows-latest, runner_os: Windows, runner_arch: X64 }
-          - { os: macos-latest, runner_os: macOS, runner_arch: ARM64 }
+          - { os: ubuntu-latest, runner_os: Linux, runner_arch: X64, stages: full }
+          - { os: windows-latest, runner_os: Windows, runner_arch: X64, stages: full }
+          - { os: macos-latest, runner_os: macOS, runner_arch: ARM64, stages: handshake }
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -540,6 +561,10 @@ jobs:
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: dist
+      - name: 'KNOWN GAP: this macOS cell verifies NO navigation (F-773)'
+        if: matrix.cell.stages == 'handshake'
+        run: |
+          echo "::warning title=F-773::install-smoke (${{ matrix.kind }} macOS/ARM64) is a PARTIAL cell: it proves the artifact installs, the launcher resolves out of the fresh environment, and the server completes initialize + tools/list + list_instances. It performs NO navigation, so it makes NO macOS navigation claim. See audit/stage2/finding_F773_macos_detached_navigation.md."
       - name: Install the exact artifact and run W1's journey
         # Step-level env for the same reason as the integration job: the
         # `runner` context is NOT available in job-level env (actionlint).
@@ -548,6 +573,7 @@ jobs:
           uv run python tools/install_smoke.py
           --dist-dir dist --manifest release-manifest.json
           --kind "${{ matrix.kind }}"
+          --stages "${{ matrix.cell.stages }}"
           --work-dir "${{ runner.temp }}/install-smoke-${{ matrix.kind }}"
           --out "install-smoke-${{ matrix.kind }}.json"
         env:
@@ -573,7 +599,7 @@ jobs:
       - coverage
       - integration
       - transport
-      - transport-known-gaps
+      - known-gaps
       - offline-stealth
       - build-dist
       - package-verify
@@ -597,7 +623,7 @@ jobs:
           check coverage       "${{ needs.coverage.result }}"
           check integration    "${{ needs.integration.result }}"
           check transport      "${{ needs.transport.result }}"
-          check transport-known-gaps "${{ needs.transport-known-gaps.result }}"
+          check known-gaps    "${{ needs.known-gaps.result }}"
           check offline-stealth "${{ needs.offline-stealth.result }}"
           check build-dist     "${{ needs.build-dist.result }}"
           check package-verify "${{ needs.package-verify.result }}"

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -354,22 +354,25 @@ jobs:
           --runner-name "${{ runner.name }}" --expect-os "${{ matrix.runner_os }}"
           --expect-arch "${{ matrix.runner_arch }}" --python "3.12"
           --out "runner-identity.json"
-      - name: Run offline stealth lane
-        # W2 wires the job id; the stealth TESTS land in W4. The selector collects
-        # zero tests today → pytest exits 5. That empty edge is expected and is
-        # NOT continue-on-error: exit 5 is treated as success, any other non-zero
-        # (a real failure once W4 adds tests) still fails the job and the gate.
+      - name: Resolve image Chrome Stable identity
         shell: bash
+        run: uv run python tools/resolve_chrome.py --out chrome-identity.json
+      - name: Start Xvfb (Linux only)
+        if: runner.os == 'Linux'
         run: |
-          set +e
-          uv run pytest -m "stealth and not online" -v --tb=short --timeout=180
-          code=$?
-          set -e
-          if [ "$code" -eq 5 ]; then
-            echo "offline-stealth: 0 tests collected (W4 fills this lane) — pass"
-            exit 0
-          fi
-          exit "$code"
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq xvfb
+          Xvfb :99 -screen 0 1920x1080x24 -ac +extension GLX +render -noreset &
+      - name: Run offline stealth lane
+        # W4's stealth tests are now in this history, so the lane is no longer
+        # empty and pytest's exit 5 (zero collected) is NO LONGER treated as a
+        # pass. An empty selector now fails: a marker rename that silently
+        # stopped collecting these tests would otherwise leave a green lane
+        # asserting nothing, which is exactly the false green §8.1 forbids.
+        shell: bash
+        run: uv run pytest -m "stealth and not online" -v --tb=short --timeout=300
+        env:
+          DISPLAY: ${{ runner.os == 'Linux' && ':99' || '' }}
 
   # ── W3: build ONCE, verify and smoke THOSE EXACT FILES (gap G-C) ───────────
   # The only `uv build` in the entire run. Everything downstream consumes the

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -10,6 +10,13 @@ name: release-gate
 # offline-stealth. W3 adds build-dist, package-verify, install-smoke; W5 adds
 # release-evidence. Each new edge slots into the aggregate's `needs:` list — the
 # aggregate is never replaced and never forgets a direct edge.
+#
+# W3 topology (gap G-C): the distribution is built EXACTLY ONCE, in `build-dist`,
+# which hashes it into a manifest and uploads it as the run's one immutable
+# `dist` artifact. `package-verify` and every `install-smoke` cell DOWNLOAD that
+# artifact and re-check its hashes; none of them runs `uv build`, rebuilds from
+# the checkout, or fetches the same version from PyPI. `publish.yml` calls this
+# same workflow at the tag SHA and uploads those very files.
 
 on:
   workflow_call:
@@ -22,6 +29,19 @@ on:
         type: string
         required: false
         default: ""
+      release_tag:
+        description: >-
+          Release tag being qualified (``v1.2.0``/``refs/tags/v1.2.0``). When
+          non-empty, `build-dist` fails unless the built artifact's metadata
+          version equals it — so a tag/version disagreement is caught by the
+          gate itself, before any publish job can run.
+        type: string
+        required: false
+        default: ""
+    outputs:
+      version:
+        description: The version recorded in this run's build manifest.
+        value: ${{ jobs.build-dist.outputs.version }}
 
 permissions:
   contents: read
@@ -343,6 +363,206 @@ jobs:
           fi
           exit "$code"
 
+  # ── W3: build ONCE, verify and smoke THOSE EXACT FILES (gap G-C) ───────────
+  # The only `uv build` in the entire run. Everything downstream consumes the
+  # uploaded artifact; nothing rebuilds and nothing downloads this version from
+  # PyPI. `python3` (not `uv run`) runs the packaging tools deliberately: they
+  # are stdlib-only by design, so this job needs no dependency sync at all.
+  build-dist:
+    name: build-dist
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.manifest.outputs.version }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+      - name: Build the distribution (the ONLY build in this run)
+        run: uv build
+      - name: Validate metadata + package data, hash into the manifest
+        id: manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 tools/package_verify.py manifest \
+            --dist dist --out release-manifest.json
+          version=$(python3 -c "import json;print(json.load(open('release-manifest.json'))['version'])")
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "built version ${version}"
+      - name: Assert the release tag matches the built version
+        if: inputs.release_tag != ''
+        run: >-
+          python3 tools/package_verify.py assert-version
+          --manifest release-manifest.json --tag "${{ inputs.release_tag }}"
+      - name: Upload the one immutable dist artifact
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: dist
+          path: |
+            dist
+            release-manifest.json
+          if-no-files-found: error
+
+  # Independent re-check of the DOWNLOADED bytes, plus the negative controls
+  # that prove these rules can actually fail. Distinct from installation.
+  package-verify:
+    name: package-verify
+    needs: build-dist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Download the one dist artifact
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: dist
+      - name: Verify the downloaded artifacts against the build manifest
+        run: >-
+          python3 tools/package_verify.py verify --dist dist
+          --manifest release-manifest.json --out package-verify.json
+      # ── Bite proofs. Each corrupts a THROWAWAY COPY and asserts rejection;
+      # the run's real hashed artifact is never touched (corrupt_artifact.py
+      # refuses to write to its source and re-checks the source size). No
+      # branch, commit, push, tag, or publication is involved.
+      - name: 'BITE PROOF 1/3: a flipped byte is rejected by the hash check'
+        shell: bash
+        run: |
+          set -euo pipefail
+          wheel=$(ls dist/*.whl)
+          copy="bite-hash/$(basename "$wheel")"
+          python3 tools/corrupt_artifact.py --source "$wheel" --out "$copy" --flip-byte
+          if python3 tools/package_verify.py hash-check \
+               --artifact "$copy" --manifest release-manifest.json; then
+            echo "::error::hash-check ACCEPTED a corrupted artifact"
+            exit 1
+          fi
+          echo "OK: the publish/smoke hash precondition rejects a mutated copy."
+      - name: 'BITE PROOF 2/3: a wheel missing package data is rejected'
+        shell: bash
+        # Independent of the hash rule on purpose: the copy is re-hashed into
+        # its OWN manifest, so only the membership rule can reject it.
+        run: |
+          set -euo pipefail
+          wheel=$(ls dist/*.whl)
+          sdist=$(ls dist/*.tar.gz)
+          mkdir -p bite-member
+          python3 tools/corrupt_artifact.py --source "$wheel" \
+            --out "bite-member/$(basename "$wheel")" \
+            --drop-member stealth_chrome_devtools_mcp/embedded/js/extract_styles.js
+          cp "$sdist" bite-member/
+          if python3 tools/package_verify.py manifest \
+               --dist bite-member --out bite-member/manifest.json; then
+            echo "::error::manifest ACCEPTED a wheel missing embedded/js package data"
+            exit 1
+          fi
+          if python3 tools/package_verify.py verify \
+               --dist bite-member --manifest release-manifest.json; then
+            echo "::error::verify ACCEPTED a wheel missing embedded/js package data"
+            exit 1
+          fi
+          echo "OK: a wheel that would install and then fail at runtime is rejected."
+      - name: 'BITE PROOF 3/3: the publish tag precondition rejects a wrong tag'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if python3 tools/package_verify.py assert-version \
+               --manifest release-manifest.json --tag v0.0.0; then
+            echo "::error::assert-version ACCEPTED a tag that is not the built version"
+            exit 1
+          fi
+          echo "OK: publishing under a tag that disagrees with the artifact is blocked."
+      - name: The real artifact is still intact after the bite proofs
+        run: >-
+          python3 tools/package_verify.py verify --dist dist
+          --manifest release-manifest.json
+      - name: Upload package-verify evidence
+        if: always()
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: package-verify-evidence
+          path: |
+            package-verify.json
+            release-manifest.json
+
+  # Install the EXACT downloaded artifact into a fresh environment and run W1's
+  # canonical journey through the launcher that install produced. Both
+  # publishable artifacts on every qualified cell.
+  install-smoke:
+    name: install-smoke (${{ matrix.kind }} ${{ matrix.cell.runner_os }}/${{ matrix.cell.runner_arch }})
+    needs: build-dist
+    runs-on: ${{ matrix.cell.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        kind: [wheel, sdist]
+        cell:
+          - { os: ubuntu-latest, runner_os: Linux, runner_arch: X64 }
+          - { os: windows-latest, runner_os: Windows, runner_arch: X64 }
+          - { os: macos-latest, runner_os: macOS, runner_arch: ARM64 }
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+      - name: Install dependencies
+        # Client side only: the harness needs fastmcp/psutil to DRIVE the smoke.
+        # The server side under test comes exclusively from the fresh venv the
+        # smoke builds out of the downloaded artifact.
+        run: uv sync --extra test --extra sentry
+      - name: Assert qualified runner + record identity
+        shell: bash
+        run: >-
+          uv run python tools/runner_identity.py
+          --runner-os "${{ runner.os }}" --runner-arch "${{ runner.arch }}"
+          --runner-name "${{ runner.name }}"
+          --expect-os "${{ matrix.cell.runner_os }}"
+          --expect-arch "${{ matrix.cell.runner_arch }}" --python "3.12"
+          --out "runner-identity.json"
+      - name: Resolve image Chrome Stable identity
+        shell: bash
+        run: uv run python tools/resolve_chrome.py --out chrome-identity.json
+      - name: Start Xvfb (Linux headed cases only)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq xvfb
+          Xvfb :99 -screen 0 1920x1080x24 -ac +extension GLX +render -noreset &
+          sleep 3
+      - name: Download the one dist artifact
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: dist
+      - name: Install the exact artifact and run W1's journey
+        # Step-level env for the same reason as the integration job: the
+        # `runner` context is NOT available in job-level env (actionlint).
+        shell: bash
+        run: >-
+          uv run python tools/install_smoke.py
+          --dist-dir dist --manifest release-manifest.json
+          --kind "${{ matrix.kind }}"
+          --work-dir "${{ runner.temp }}/install-smoke-${{ matrix.kind }}"
+          --out "install-smoke-${{ matrix.kind }}.json"
+        env:
+          DISPLAY: ${{ runner.os == 'Linux' && ':99' || '' }}
+      - name: Upload smoke result + identity
+        if: always()
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: install-smoke-${{ matrix.kind }}-${{ matrix.cell.runner_os }}-${{ matrix.cell.runner_arch }}
+          path: |
+            install-smoke-${{ matrix.kind }}.json
+            chrome-identity.json
+            runner-identity.json
+          if-no-files-found: warn
+
   # ── Stable aggregate: the ONE public required check ────────────────────────
   release-gate:
     name: release-gate
@@ -355,6 +575,9 @@ jobs:
       - transport
       - transport-known-gaps
       - offline-stealth
+      - build-dist
+      - package-verify
+      - install-smoke
     runs-on: ubuntu-latest
     steps:
       - name: Require every edge to have succeeded
@@ -376,6 +599,9 @@ jobs:
           check transport      "${{ needs.transport.result }}"
           check transport-known-gaps "${{ needs.transport-known-gaps.result }}"
           check offline-stealth "${{ needs.offline-stealth.result }}"
+          check build-dist     "${{ needs.build-dist.result }}"
+          check package-verify "${{ needs.package-verify.result }}"
+          check install-smoke  "${{ needs.install-smoke.result }}"
           if [ "$overall" -ne 0 ]; then
             echo "::error::release-gate: one or more required edges were not success"
             exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,10 @@ element_clones/
 # graphify knowledge-graph artifacts (local navigation aid)
 graphify-out/
 .graphify_*
+
+# Agent worktree scratch: each entry is a FULL checkout of this repo. Left
+# un-ignored it is linted as if it were project source (ruff walks it and
+# reports the same findings three times over) and, worse, hatchling sweeps it
+# into the sdist — a local `uv build` produced a 56 MB sdist of which 55 MB was
+# this directory. Ephemeral by construction; never part of the distribution.
+.claude/worktrees/

--- a/audit/stage2/finding_F773_macos_detached_navigation.md
+++ b/audit/stage2/finding_F773_macos_detached_navigation.md
@@ -62,10 +62,20 @@ distinguishes the cause further.
 
 ## 4. Reproduction
 
-- **Reliable** on `macos-latest` (ARM64) GitHub-hosted runners, every run, 11/11.
+- **Reliable** on `macos-latest` (ARM64) GitHub-hosted runners, every run, 11/11
+  (13/13 including the two W3 cells below).
 - **Never** on Windows/X64 (local dev machine and CI) or Ubuntu/X64 CI.
 - CI job: `release-gate / transport (macOS/ARM64)`; test
   `tests/test_e2e_transport.py::test_real_stdio_release_gate_journey`.
+- **Also from a FRESH INSTALL of the built distribution** (plan_RELEASE W3, PR #48,
+  run 30161880495): `install-smoke (wheel macOS/ARM64)` and
+  `install-smoke (sdist macOS/ARM64)` both reproduced it after installing the
+  artifact into a brand-new venv — `about:blank` ok in 1.1s/3.1s, closed port
+  `127.0.0.1:1` hung 35.3s, fixture served nothing, network-service process alive,
+  workspace already under `RUNNER_TEMP`. This **rules out the editable/source-tree
+  install as a factor**: the same hang occurs through the exact wheel and sdist a
+  user would download. It narrows nothing about the mechanism, but it does mean a
+  packaging or install-layout explanation is no longer available.
 - Evidence lands in the failure text automatically: nav probe, fixture hit list,
   Chrome process snapshot, Chrome's log, and the backend's own logs.
 
@@ -105,3 +115,17 @@ uv run python -m pytest tests/test_e2e_transport.py -m transport -v
   release-blocking for a macOS claim and needs its own FIX plan.
 
 Until one of those runs, F-773 stays open and macOS navigation stays unclaimed.
+
+## 8. What the gate does claim on macOS (W3)
+
+W3 did not shrink macOS coverage to nothing. The two `install-smoke` macOS cells
+run as **declared partial cells** (`--stages handshake`): they install the exact
+built wheel/sdist into a fresh environment, resolve that environment's console
+launcher, and complete `initialize` → `tools/list` (94 tools) → `list_instances`
+over real stdio. They perform **no navigation**.
+
+So the qualified claim on macOS/ARM64 is: *the published artifacts install and
+serve*. It is **not**: *the published artifacts navigate*. These cells are not
+xfails — nothing failing is marked expected-to-fail; a strictly smaller thing is
+run and labelled, in the cell name, in the tool's stdout, in the result record's
+`stages`/`navigation_verified` fields, and in the `known-gaps` job.

--- a/audit/stage2/finding_F774_ua_client_hints_high_entropy_blanked.md
+++ b/audit/stage2/finding_F774_ua_client_hints_high_entropy_blanked.md
@@ -1,0 +1,64 @@
+# F-774 — a `--user-agent` override blanks Chrome's high-entropy UA client hints
+
+**Status: OPEN.** Opened by RELEASE-FIX-D (the F-770 fix), measured not inferred,
+pinned as a strict `xfail` in `tests/test_stealth.py` (`XFAIL_SIGNALS`,
+`test_product_ua_client_hints_high_entropy_pinned_gap`).
+**Severity: LOW** — strictly smaller and strictly more expensive to exploit than
+the `HeadlessChrome` token it replaced, but it is a new tell and is recorded as one.
+
+---
+
+## The finding
+
+RELEASE-FIX-D closes F-770 by supplying a masked default `--user-agent=` launch
+flag. Whenever that override is active, Chrome **blanks the high-entropy UA
+client hints it cannot derive from the override string**.
+
+Measured on Chrome 150.0.7871.186, headless, same binary, with and without the mask:
+
+| `getHighEntropyValues()` field | unmasked | masked |
+|---|---|---|
+| `architecture` | `"x86"` | `""` |
+| `bitness` | `"64"` | `""` |
+| `platformVersion` | `"19.0.0"` | `""` |
+| `uaFullVersion` | `"150.0.7871.186"` | `""` |
+| `fullVersionList` | 3 brands | `[]` |
+| `brands` | 3 brands | **unchanged** |
+| `mobile` | `false` | **unchanged** |
+| `platform` | `"Windows"` | **unchanged** |
+
+## What is and is not affected
+
+- **The wire is unaffected.** The hints Chrome actually sends by default —
+  `sec-ch-ua`, `sec-ch-ua-mobile`, `sec-ch-ua-platform` — are the low-entropy set,
+  and all three remain populated and coherent with the masked User-Agent (the
+  gating `ua_major_matches_client_hints` signal asserts that coherence).
+- **Only JS matters.** The blanked fields are reachable solely through
+  `navigator.userAgentData.getHighEntropyValues()`, which a site must call
+  explicitly. Compare with what it replaced: `HeadlessChrome` in the User-Agent is
+  one server-side substring test, run before a byte of JavaScript executes.
+
+## Why FIX-D did not fix it
+
+The only mechanism that restores these values is
+`Emulation.setUserAgentOverride`'s `userAgentMetadata`, which is **per-target**:
+every path that creates a tab would have to apply it, and a tab the page itself
+opens (`window.open`, `target=_blank`) would not be covered — the exact
+second-way/maintenance hazard the launch-flag mechanism was chosen to avoid, and
+the failure mode that made RELEASE-FIX-C's `create_hook` re-arm necessary. It is a
+different mechanism with its own design decision, deliberately out of FIX-D's scope.
+
+Any fix must also solve where the metadata comes from: once `--user-agent` is set
+at launch, the real values are *already* blanked, so they cannot simply be read
+back and re-applied — they would have to be captured before the override exists,
+or constructed, which is the guessing FIX-D's coherence rule forbids.
+
+## Routing
+
+- Recorded as a strict `xfail`, so a future fix (or a Chrome behaviour change)
+  XPASSes and turns the suite red, forcing a review. It is never resolved by
+  relaxing `strict`.
+- **W5's `RELEASE_CONTRACT.md` must qualify the stealth claim accordingly:**
+  headless no longer advertises `HeadlessChrome` on any vector that reaches a
+  site, and the low-entropy client hints are coherent; the high-entropy client
+  hints are blank under the mask.

--- a/audit/stage2/plan_RELEASE_FIX_D.md
+++ b/audit/stage2/plan_RELEASE_FIX_D.md
@@ -1,8 +1,44 @@
 # plan_RELEASE_FIX_D — F-770: the headless User-Agent still advertises `HeadlessChrome`
 
-**Status: AUTHORIZED, not yet executed.** Human authorized the FIX-plan route
-2026-07-25. Branch stacked on `audit/release-4-w4` (PR #45). Merge gate: human —
+**Status: EXECUTED.** Human authorized the FIX-plan route 2026-07-25. Branch
+`audit/release-fix-d` stacked on `audit/release-4-w4` (PR #47). Merge gate: human —
 **the executor never merges.**
+
+> ## D0's measurement (the part that decided the mechanism)
+>
+> Measured under `headless=True` on all three qualified cells, Chrome 150:
+>
+> | Vector | Linux/X64 | Windows/X64 | macOS/ARM64 |
+> |---|---|---|---|
+> | V1 `navigator.userAgent` | **LEAK** | **LEAK** | **LEAK** |
+> | V2 HTTP `User-Agent` header the server received | **LEAK** | **LEAK** | **LEAK** |
+> | V3 `userAgentData` brands / high entropy / `sec-ch-ua` | clean | clean | clean |
+> | V4 `Browser.getVersion().userAgent` | **LEAK** | **LEAK** | **LEAK** |
+>
+> Two of §2/§3's stated assumptions were wrong, which is exactly what D0 exists
+> to catch:
+>
+> * **V3 does not leak.** The brands are identical headless and headed on every
+>   cell, so the UA-CH path (M-B) was never required.
+> * **V4 *is* covered by `--user-agent=`.** §3 lists it as not covered; the flag
+>   is process-wide and `Browser.getVersion` follows it.
+>
+> So **M-A alone covers every leaking vector** — chosen, and M-B not implemented.
+> `--user-agent-product=` was also measured and is inert in release Chrome.
+>
+> The frozen reduced-UA platform tokens the mask is built from were confirmed on
+> the runners themselves: `Windows NT 10.0; Win64; x64`,
+> `Macintosh; Intel Mac OS X 10_15_7` (frozen even on ARM64), `X11; Linux x86_64`.
+>
+> ## What the fix opened: F-774
+>
+> A `--user-agent` override makes Chrome blank the high-entropy UA client hints
+> (`architecture`, `bitness`, `platformVersion`, `uaFullVersion`,
+> `fullVersionList`); `brands`/`mobile`/`platform` — and therefore every
+> `sec-ch-ua*` header on the wire — stay correct. Recorded honestly as a strict
+> `xfail` and routed: see
+> [finding_F774_ua_client_hints_high_entropy_blanked.md](./finding_F774_ua_client_hints_high_entropy_blanked.md).
+> §6's scope-limit clause applies: partial fix + honest claim.
 
 **Found by:** plan_RELEASE W4's offline stealth probe (`audit/release-4-w4`, PR #45),
 pinned as a strict `xfail` in `tests/test_stealth.py`.

--- a/audit/stage2/plan_RELEASE_FIX_D.md
+++ b/audit/stage2/plan_RELEASE_FIX_D.md
@@ -1,0 +1,214 @@
+# plan_RELEASE_FIX_D — F-770: the headless User-Agent still advertises `HeadlessChrome`
+
+**Status: AUTHORIZED, not yet executed.** Human authorized the FIX-plan route
+2026-07-25. Branch stacked on `audit/release-4-w4` (PR #45). Merge gate: human —
+**the executor never merges.**
+
+**Found by:** plan_RELEASE W4's offline stealth probe (`audit/release-4-w4`, PR #45),
+pinned as a strict `xfail` in `tests/test_stealth.py`.
+**Severity:** the single most commercially significant open finding. It directly
+contradicts the product's headline claim.
+
+---
+
+## 1. The finding (F-770)
+
+The package advertises "undetectable browser automation" and
+`Development Status :: 5 - Production/Stable`. Under `headless=True` — a first-class,
+documented option — the product's User-Agent still contains the literal token
+`HeadlessChrome`:
+
+```
+Mozilla/5.0 (...) HeadlessChrome/<major>.0.0.0 Safari/537.36
+```
+
+This is the **cheapest, most universally deployed bot check in existence**: one
+substring test, server-side, before a single byte of JavaScript runs. A product whose
+entire value proposition is evading detection fails the first check anyone writes.
+
+nodriver does not mask the UA token, and the product does not either. The spawn path
+(`browser_manager.py:84 _append_user_agent_arg`) applies `--user-agent=` **only when the
+caller explicitly supplies one**. The default headless user gets the leak.
+
+### Why the current pin is not a fix
+
+`tests/test_stealth.py` records this honestly and deliberately:
+
+- the signal lives in `XFAIL_SIGNALS` with `finding_id="F-770"`, not in the gating table;
+- `test_product_ua_headless_token_pinned_gap` is `@pytest.mark.xfail(strict=True)`.
+
+An xfailed invariant **does not satisfy a release claim** (plan_RELEASE §0.2). W4's
+green therefore does not currently support the stealth headline for headless. Either
+this plan closes it, or W5's `RELEASE_CONTRACT.md` must qualify the stealth claim to
+exclude headless — those are the only two honest outcomes.
+
+---
+
+## 2. Learn from FIX-C: measure before you fix
+
+RELEASE-FIX-C shipped on a hypothesis that was strongly evidenced and **wrong**
+(see `plan_RELEASE_FIX_C.md`, correction block). The cost was a CI round-trip and a
+plan doc that had to be corrected in place. FIX-D therefore front-loads measurement,
+and **D1's mechanism is not chosen until D0 has reported.**
+
+### D0 — characterize the ACTUAL leak surface (tests only, no `src/` edit)
+
+"The UA leaks" is not precise enough to fix. `--user-agent=` and
+`Emulation.setUserAgentOverride` cover **different** subsets of the surface, so measure
+all four vectors, on each of Linux/X64, Windows/X64, macOS/ARM64, under `headless=True`:
+
+| # | Vector | How to observe | Covered by `--user-agent=`? |
+|---|---|---|---|
+| V1 | `navigator.userAgent` | probe page | yes |
+| V2 | The **HTTP `User-Agent` request header actually sent** | the W1/W4 fixture server records request headers — assert on what the server received, not on what the page claims | yes |
+| V3 | `navigator.userAgentData.brands` + `getHighEntropyValues()` | probe page | **no** — UA client-hint brands are built from Chrome's version info and are not affected by the flag |
+| V4 | `Browser.getVersion` → `userAgent` (the CDP-level value) | CDP | no |
+
+**Report which vectors actually contain `Headless`.** Do not assume; Chrome's
+new-headless behavior has changed across majors and the runner image version is what
+matters, not any published summary. If V3 leaks, `--user-agent=` alone is insufficient
+and D1 must take the UA-CH path.
+
+D0 lands as a **characterization test** with an F-770 docstring, recording current
+behavior per vector. It is committed and pushed so CI reports the measurement on all
+three OS cells before D1 is written.
+
+---
+
+## 3. D1 — the fix
+
+**Principle: a default headless spawn must not advertise headless.** Universal
+default, applied for every user, with **no new config knob** — a knob that must be
+found and enabled is not a fix for a headline claim.
+
+### The two candidate mechanisms
+
+Pick based on D0's measurement; do not implement both.
+
+**M-A — pre-launch `--user-agent=` flag.** Derive the masked UA from the resolved
+`browser_executable` and pass it as a launch arg when the caller supplied no explicit
+`user_agent`.
+
+- *Pros:* one place; covers V1 and V2 (the HTTP header) for **every** tab, worker, and
+  subresource for the whole browser process; survives `new_tab`; needs no per-target
+  bookkeeping. Verified: `--user-agent` is **not** on `platform_utils._stealth_blocked_args()`,
+  so unlike `--use-mock-keychain` it will actually reach Chrome. Confirm that still holds.
+- *Cons:* does not touch V3 (UA-CH brands). Needs the Chrome version **before** launch —
+  obtain it from the already-resolved executable (bounded subprocess, cached per
+  executable path; a launch-path subprocess on every spawn is a perf regression and
+  must not be added naively).
+
+**M-B — `Emulation.setUserAgentOverride` with `userAgentMetadata`.** Apply post-launch
+per target.
+
+- *Pros:* the only mechanism that can fix V3, because it sets client-hint brands
+  explicitly.
+- *Cons:* per-target. Every path that creates a tab must apply it or the override
+  leaks on the next tab — that is a second-way hazard and a maintenance trap. If you
+  take this path, it gets **one home** that every tab-creating path calls, and a pin
+  proving a *newly created* tab is covered (the exact failure mode that made FIX-C's
+  `create_hook` re-arm necessary).
+
+**A combination is permitted only if D0 proves it necessary** (e.g. M-A for V1/V2 plus
+M-B for V3). If so, state plainly in the completion report that this is two mechanisms
+serving two vectors, not two ways to do one thing.
+
+### Hard constraints
+
+- **Do not weaken any probe.** The fix makes the assertion pass; it never edits the
+  predicate to accept the leak. `_p_ua_no_headless` is the contract.
+- **Do not break the caller's explicit `user_agent`.** An explicit value always wins.
+  Pin this.
+- **Consistency is itself a tell.** A UA that claims `Chrome/141` while
+  `navigator.userAgentData` reports a different major, or while the platform token
+  disagrees with the real OS, is a *worse* signal than the honest headless UA — it is a
+  mismatch no real browser produces. Whatever you mask, mask coherently, and pin the
+  coherence.
+- No new runtime dependencies. No `embedded/` module imports `server`. M6-pinned error
+  bytes preserved. `tools/check_file_budgets.py` green with **no cap padded**.
+
+---
+
+## 4. D2 — the sensitivity control must survive the fix (read this carefully)
+
+W4's stealth suite is only valid because it proves a **vanilla control is still
+detected**. `_collect_probe(base_url, control=True)` builds that control by
+monkeypatching:
+
+```python
+_bm_mod.merge_browser_args = lambda args: (list(args or []), [])
+```
+
+That neutralizes `platform_utils.merge_browser_args` — and **nothing else**.
+
+So: if D1's masking is applied anywhere *outside* `merge_browser_args` (for example in
+`_append_user_agent_arg`, in the spawn path, or via a post-launch CDP call), the
+**control browser will also receive the masked UA**. The control then stops being
+detectable, `vanilla_detected` goes false, and the entire stealth suite silently becomes
+vacuous — it would assert that a stealthy browser is stealthy and that a "vanilla"
+browser is also stealthy, proving nothing.
+
+This is a test-invalidation trap of exactly the kind §8.1 warns about, and it will not
+announce itself. D2 must therefore, in the same commit as D1:
+
+1. Route the masking through a seam the control genuinely disables, **or** extend the
+   control to disable the new seam explicitly.
+2. Assert `control_outcomes["vanilla_detected"] is True` **still holds after the fix**,
+   and that the control's UA **does** contain `Headless` while the product's does not.
+   That differential is the proof the fix is real and the test is still sensitive.
+
+If you cannot make the control fail while the product passes, **STOP and report** — do
+not ship a fix whose test cannot tell the two apart.
+
+---
+
+## 5. D3 — flip the pin honestly
+
+- Move `ua_no_headless_token` from `XFAIL_SIGNALS` into the gating `SIGNALS` table.
+- **Delete** `test_product_ua_headless_token_pinned_gap`. Do not leave it as a
+  non-strict xfail. (Its `strict=True` is self-policing: once the fix lands it XPASSes
+  and turns the suite red, which is the intended tripwire — resolve it by deleting the
+  now-redundant test, never by relaxing `strict`.)
+- Update the F-770 comment block above `XFAIL_SIGNALS` to record the closure, or remove
+  the block if it becomes empty.
+- Any doc that describes headless stealth as a known gap gets updated in the same commit.
+
+---
+
+## 6. Acceptance — what "fixed" means
+
+All of the following, or the plan is not done:
+
+1. On **all three** W2 cells (Linux/X64, Windows/X64, macOS/ARM64), under
+   `headless=True`, every vector D0 found leaking now passes, asserted as a **gating**
+   signal — no xfail, no skip, no characterization.
+2. The V2 assertion is made against **what the fixture server actually received**, not
+   only what the page reports. A page-only assertion can be satisfied by a page-level
+   override while the real HTTP header still leaks.
+3. `vanilla_detected is True` still holds; the control's UA still contains `Headless`.
+4. An explicit caller-supplied `user_agent` still wins, pinned.
+5. A **newly created tab** (`new_tab`, not just the spawn tab) is covered — pinned.
+6. Full local gate green: ruff format+check; `ty check --exit-zero-on-warning
+   src/stealth_chrome_devtools_mcp/` at the **76-diagnostic baseline** (a bare `ty check`
+   reports 172 because it takes the wrong scope — that is the wrong command, not a
+   regression); vulture; file budgets; suppression owners; unit suite (~703-705 on
+   `-m "not integration"`); integration locally.
+7. `--no-verify` never used. PR opened, **never merged**.
+
+### Scope limits — state these, do not paper over them
+
+- This closes the **UA vector** for headless. It does not make the product
+  "undetectable"; W4's other signals and the §8 residual wall stand unchanged.
+- Headed mode is unaffected (it never leaked this token).
+- If D0 shows V3 (UA-CH) leaking and M-B proves out of budget, shipping M-A alone is
+  **permitted only if** the UA-CH residue is recorded as a new finding, routed, and W5's
+  contract qualifies the claim. Partial fix + honest claim is acceptable; partial fix
+  presented as complete is not.
+
+---
+
+## 7. Gates
+
+Same as FIX-A/B/C. Branch `audit/release-fix-d` stacked on `audit/release-4-w4`;
+PR opened against that base and held at the human merge gate. Commit messages end with
+`Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,8 @@ markers = [
     "integration: tests that spawn real browsers (need Chrome installed)",
     "characterization: pins CURRENT observable behavior (quirks/known bugs included) so an intended M5a/M4/M5b change surfaces as a failing test to update deliberately",
     "transport: real-stdio release-gate E2E (plan_RELEASE W1) — spawns the installed console launcher over stdio JSON-RPC and drives a real-Chrome journey via tools/call",
+    "stealth: deterministic offline stealth-invariant probes (plan_RELEASE W4) — the offline-stealth gate lane runs `stealth and not online`; W2 wires the empty edge, W4 lands the tests",
+    "online: opt-in NON-GATING live-detector observations (plan_RELEASE W4) — CreepJS + bot.incolumitas; excluded from every default run and the release gate; asserts only hard invariants and logs the rest",
 ]
 # Coverage is intentionally NOT in addopts: enabling it globally would slow
 # every single-file TDD run and trip --cov-fail-under on partial runs. CI turns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,11 @@ test = [
     "pytest-asyncio>=0.23",
     "pytest-timeout>=2.3",
     "pytest-cov>=5.0",
+    # plan_RELEASE W3: tests/test_release_workflows.py parses the workflow YAML
+    # to pin the release topology (publish never rebuilds; the aggregate never
+    # forgets an edge). Test-only; already present transitively via
+    # uvicorn[standard], declared here so the pin cannot vanish silently.
+    "pyyaml>=6.0",
 ]
 dev = [
     "ruff==0.15.20",

--- a/src/stealth_chrome_devtools_mcp/embedded/platform_utils.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/platform_utils.py
@@ -3,8 +3,11 @@
 import ctypes
 import os
 import platform
+import re
 import shutil
+import subprocess
 import sys
+from functools import lru_cache
 from pathlib import Path
 
 from stealth_chrome_devtools_mcp.embedded.debug_logger import debug_logger
@@ -183,10 +186,133 @@ def filter_stealth_args(user_args: list[str]) -> tuple:
     return clean, warnings
 
 
+# ── The masked default User-Agent (F-770) ───────────────────────────────────
+# Headless Chrome advertises itself in its own User-Agent:
+#     Mozilla/5.0 (...) HeadlessChrome/<major>.0.0.0 Safari/537.36
+# That single substring is the cheapest bot check in existence — one server-side
+# test, before a byte of JavaScript runs — so a default headless spawn must not
+# ship it.
+#
+# The mask is CONSTRUCTED rather than guessed because Chrome froze its
+# User-Agent in the reduced-UA rollout: the platform token, the WebKit build and
+# the Safari token are constants, and the only varying part is the browser's
+# MAJOR version, always rendered ``<major>.0.0.0``. The string built here is
+# therefore byte-identical to what the same binary emits headed — i.e. exactly
+# Chrome's own User-Agent with ``HeadlessChrome`` replaced by ``Chrome``. That
+# equality is pinned as a product-vs-control differential in tests/test_stealth.py:
+# consistency is itself a tell, and a UA that disagrees with ``sec-ch-ua`` or with
+# the real OS would be a WORSE signal than the honest headless one.
+_REDUCED_UA_PLATFORM_TOKEN = {
+    "Windows": "Windows NT 10.0; Win64; x64",
+    "Darwin": "Macintosh; Intel Mac OS X 10_15_7",
+    "Linux": "X11; Linux x86_64",
+}
+
+_USER_AGENT_ARG_PREFIX = "--user-agent="
+_BROWSER_VERSION_RE = re.compile(r"(\d+)\.\d+\.\d+\.\d+")
+_VERSION_PROBE_TIMEOUT_SECONDS = 10.0
+
+
+@lru_cache(maxsize=8)
+def resolve_browser_major_version(executable: str) -> str | None:
+    """Return the major version of a Chromium-family executable, or ``None``.
+
+    Cached per executable path: this runs on the spawn path, so an uncached
+    subprocess per spawn would be a real performance regression.
+
+    Windows deliberately does NOT shell out — ``chrome.exe --version`` hands the
+    argument to an already-running Chrome ("Opening in existing browser
+    session.") instead of printing anything, so the version is read from the
+    version-named directory every Chromium install keeps beside its binary.
+    Elsewhere ``<exe> --version`` prints e.g. ``Google Chrome 150.0.7871.186``.
+    """
+    if platform.system() == "Windows":
+        try:
+            names = [
+                entry.name
+                for entry in Path(executable).parent.iterdir()
+                if entry.is_dir()
+            ]
+        except OSError as error:
+            debug_logger.log_debug(
+                "platform_utils", "resolve_browser_major_version", str(error)
+            )
+            return None
+        majors = [m.group(1) for m in map(_BROWSER_VERSION_RE.fullmatch, names) if m]
+        return max(majors, key=int) if majors else None
+
+    try:
+        completed = subprocess.run(  # noqa: S603  RELEASE-FIX-D (F-770)
+            [executable, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=_VERSION_PROBE_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        debug_logger.log_debug(
+            "platform_utils", "resolve_browser_major_version", str(error)
+        )
+        return None
+    match = _BROWSER_VERSION_RE.search(completed.stdout or "")
+    return match.group(1) if match else None
+
+
+def build_reduced_user_agent(executable: str) -> str | None:
+    """Build this executable's own reduced User-Agent, without the headless token.
+
+    Returns ``None`` (meaning "do not mask") on an unrecognized platform or when
+    the version cannot be resolved — masking with a wrong version would be worse
+    than not masking at all.
+    """
+    platform_token = _REDUCED_UA_PLATFORM_TOKEN.get(platform.system())
+    if not platform_token:
+        return None
+    major = resolve_browser_major_version(executable)
+    if not major:
+        return None
+    agent = (
+        f"Mozilla/5.0 ({platform_token}) AppleWebKit/537.36 (KHTML, like Gecko) "
+        f"Chrome/{major}.0.0.0 Safari/537.36"
+    )
+    if "edge" in Path(executable).name.lower():
+        # Edge appends its own token after Safari/537.36. Dropping it while
+        # sec-ch-ua still advertises the "Microsoft Edge" brand would be a
+        # sharper tell than the headless token this mask removes.
+        agent += f" Edg/{major}.0.0.0"
+    return agent
+
+
+def _apply_default_user_agent(args: list[str]) -> list[str]:
+    """Append the masked default ``--user-agent=`` unless the caller supplied one.
+
+    An explicit caller ``user_agent`` reaches here already rendered as a
+    ``--user-agent=`` arg, so the presence check is what makes an explicit value
+    win. The flag is process-wide: unlike a per-target CDP override it covers
+    every tab, worker and subresource of the launched browser — including tabs
+    the page itself opens — and it reaches the real HTTP request header, which is
+    the vector a server-side bot check reads first.
+    """
+    if any(arg.lower().startswith(_USER_AGENT_ARG_PREFIX) for arg in args):
+        return args
+    executable = check_browser_executable()
+    agent = build_reduced_user_agent(executable) if executable else None
+    if not agent:
+        debug_logger.log_warning(
+            "platform_utils",
+            "default_user_agent",
+            f"could not derive a masked User-Agent for {executable!r}; a headless "
+            "launch will advertise HeadlessChrome (F-770)",
+        )
+        return args
+    return [*args, f"{_USER_AGENT_ARG_PREFIX}{agent}"]
+
+
 def merge_browser_args(user_args: list[str] | None = None) -> tuple:
     """
     Merge user-provided browser arguments with platform-specific required arguments.
-    Strips any args that would compromise stealth detection.
+    Strips any args that would compromise stealth detection, and supplies the
+    masked default User-Agent (F-770) when the caller did not choose one.
 
     Args:
         user_args: User-provided browser arguments
@@ -204,7 +330,7 @@ def merge_browser_args(user_args: list[str] | None = None) -> tuple:
         if arg not in combined_args:
             combined_args.append(arg)
 
-    return combined_args, stealth_warnings
+    return _apply_default_user_agent(combined_args), stealth_warnings
 
 
 def get_platform_info() -> dict:

--- a/tests/fixture_app/stealth_probe.html
+++ b/tests/fixture_app/stealth_probe.html
@@ -117,6 +117,39 @@
     obs.ua_client_hints_mobile = uad ? !!uad.mobile : null;
     obs.ua_client_hints_platform = uad ? (uad.platform || "") : "";
 
+    // F-770 vector V3 -- the UA client-hint high-entropy values. These are built
+    // from Chrome's own version info and are NOT affected by --user-agent=, so
+    // they are measured separately from navigator.userAgent (V1).
+    obs.ua_client_hints_high_entropy = null;
+    if (uad && typeof uad.getHighEntropyValues === "function") {
+      try {
+        obs.ua_client_hints_high_entropy = await uad.getHighEntropyValues([
+          "brands", "fullVersionList", "uaFullVersion", "platform",
+          "platformVersion", "architecture", "bitness", "model"
+        ]);
+      } catch (e) {
+        obs.ua_client_hints_high_entropy = "ERROR:" + String(e);
+      }
+    }
+
+    // F-770 vector V2 -- the HTTP User-Agent request header the SERVER actually
+    // received. A page cannot read its own request headers, so the probe issues
+    // one same-origin POST to the fixture app's /api/echo route, which reflects
+    // back the headers it read off the wire. This is the vector a server-side bot
+    // check reads first, and a page-level assertion alone can never prove it.
+    obs.http_request_headers = null;
+    obs.http_user_agent = null;
+    try {
+      var echoResp = await fetch("/api/echo", { method: "POST", body: "stealth-probe" });
+      var echoed = await echoResp.json();
+      obs.http_request_headers = (echoed && echoed.headers) ? echoed.headers : null;
+      obs.http_user_agent = obs.http_request_headers
+        ? (obs.http_request_headers["user-agent"] || "") : null;
+    } catch (e) {
+      obs.http_request_headers = "ERROR:" + String(e);
+      obs.http_user_agent = "ERROR:" + String(e);
+    }
+
     // Patched-builtin detection: native functions must serialize as native code,
     // and Function.prototype.toString itself must be native (a common patch hides
     // the patching by re-patching toString).

--- a/tests/fixture_app/stealth_probe.html
+++ b/tests/fixture_app/stealth_probe.html
@@ -1,0 +1,174 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>stealth-probe</title>
+</head>
+<body>
+<h1 id="probe-title">stealth-probe (armed)</h1>
+<!--
+  plan_RELEASE W4 -- passive stealth-signal collector.
+
+  This page is NOT its own judge: it collects RAW observations only and does no
+  pass/fail evaluation. The predicates live in tests/test_stealth.py. The page is
+  ARMED: it collects NOTHING until the test explicitly calls
+  window.__STEALTH_PROBE_START__() (a "released" state). This proves the observed
+  values come from real released CDP activity, not from a pristine idle page.
+
+  On release it publishes exactly ONE window.__STEALTH_PROBE_RESULT__ object with a
+  closed schema { schema_version, started_ms, finished_ms, complete, observations }
+  (monotonic performance.now() timestamps) and dispatches ONE 'stealth-probe-complete'
+  event. A second release call is a no-op (no duplicate result, no second event).
+-->
+<script>
+(function () {
+  "use strict";
+
+  var SCHEMA_VERSION = 1;
+
+  // Self-observed completion counter -- the test asserts exactly one dispatch.
+  window.__STEALTH_PROBE_EVENT_COUNT__ = 0;
+  window.addEventListener("stealth-probe-complete", function () {
+    window.__STEALTH_PROBE_EVENT_COUNT__ += 1;
+  });
+
+  // Exhaustive automation-leak global name policy (exact names + known prefixes).
+  // A real browser exposes NONE of these on window/document.
+  var LEAK_PREFIXES = [
+    "cdc_", "$cdc", "$chrome_asyncScriptInfo", "__$webdriverAsyncExecutor",
+    "__webdriver", "__driver_", "__driver_evaluate", "__webdriver_evaluate",
+    "__selenium_", "__fxdriver_", "__lastWatirAlert", "__lastWatirConfirm",
+    "__lastWatirPrompt", "_Selenium_IDE_Recorder", "_selenium", "calledSelenium",
+    "domAutomation", "domAutomationController", "__nightmare", "_phantom",
+    "callPhantom", "__phantomas", "webdriver", "__webdriverFunc",
+    "__driver_unwrapped", "__webdriver_script_fn", "__$webdriverAsyncExecutor",
+    "$wdc_"
+  ];
+
+  function scanLeakGlobals(target) {
+    var found = [];
+    var names;
+    try { names = Object.getOwnPropertyNames(target); } catch (e) { return found; }
+    for (var i = 0; i < names.length; i++) {
+      var n = names[i];
+      var low = String(n).toLowerCase();
+      for (var j = 0; j < LEAK_PREFIXES.length; j++) {
+        var p = LEAK_PREFIXES[j].toLowerCase();
+        if (low === p || low.indexOf(p) === 0) { found.push(n); break; }
+      }
+    }
+    return found;
+  }
+
+  function webglInfo() {
+    var out = { vendor: null, renderer: null, error: null };
+    try {
+      var c = document.createElement("canvas");
+      var gl = c.getContext("webgl") || c.getContext("experimental-webgl");
+      if (!gl) { out.error = "no-webgl-context"; return out; }
+      var dbg = gl.getExtension("WEBGL_debug_renderer_info");
+      if (dbg) {
+        out.vendor = gl.getParameter(dbg.UNMASKED_VENDOR_WEBGL);
+        out.renderer = gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL);
+      } else {
+        out.error = "no-debug-renderer-info";
+      }
+    } catch (e) { out.error = String(e); }
+    return out;
+  }
+
+  async function collect() {
+    var obs = {};
+
+    // navigator.webdriver -- THE core automation tell.
+    obs.webdriver = navigator.webdriver;
+    obs.webdriver_typeof = typeof navigator.webdriver;
+
+    // window.chrome required-member presence.
+    obs.window_chrome_present = (typeof window.chrome === "object" && window.chrome !== null);
+    obs.window_chrome_members = obs.window_chrome_present
+      ? Object.keys(window.chrome).sort() : [];
+
+    // plugins / mimeTypes (empty is a classic headless tell).
+    obs.plugins_count = navigator.plugins ? navigator.plugins.length : 0;
+    obs.mime_types_count = navigator.mimeTypes ? navigator.mimeTypes.length : 0;
+
+    // languages.
+    obs.languages = navigator.languages ? Array.prototype.slice.call(navigator.languages) : [];
+    obs.language = navigator.language || "";
+
+    // Notification.permission vs Permissions API (the denied/prompt mismatch leak).
+    obs.notification_permission = (typeof Notification !== "undefined")
+      ? Notification.permission : "NO_NOTIFICATION";
+    try {
+      var st = await navigator.permissions.query({ name: "notifications" });
+      obs.permissions_query_notifications = st.state;
+    } catch (e) {
+      obs.permissions_query_notifications = "ERROR:" + String(e);
+    }
+
+    // UA / platform / client hints.
+    obs.user_agent = navigator.userAgent || "";
+    obs.platform = navigator.platform || "";
+    var uad = navigator.userAgentData;
+    obs.ua_client_hints_present = !!uad;
+    obs.ua_client_hints_brands = uad && uad.brands
+      ? uad.brands.map(function (b) { return b.brand; }) : [];
+    obs.ua_client_hints_mobile = uad ? !!uad.mobile : null;
+    obs.ua_client_hints_platform = uad ? (uad.platform || "") : "";
+
+    // Patched-builtin detection: native functions must serialize as native code,
+    // and Function.prototype.toString itself must be native (a common patch hides
+    // the patching by re-patching toString).
+    obs.fn_tostring_alert = window.alert.toString();
+    obs.fn_tostring_meta = Function.prototype.toString.toString();
+
+    // Automation-revealing globals (exhaustive prefix/name policy).
+    obs.automation_globals_window = scanLeakGlobals(window);
+    obs.automation_globals_document = scanLeakGlobals(document);
+
+    // Window outer dimensions (0x0 is a headless tell).
+    obs.outer_width = window.outerWidth;
+    obs.outer_height = window.outerHeight;
+    obs.inner_width = window.innerWidth;
+    obs.inner_height = window.innerHeight;
+    obs.is_secure_context = window.isSecureContext;
+
+    // Informational (env-dependent -- NOT gated by the predicate table).
+    var wg = webglInfo();
+    obs.webgl_vendor = wg.vendor;
+    obs.webgl_renderer = wg.renderer;
+    obs.webgl_error = wg.error;
+    obs.hardware_concurrency = navigator.hardwareConcurrency;
+    obs.device_memory = ("deviceMemory" in navigator) ? navigator.deviceMemory : null;
+    obs.max_touch_points = navigator.maxTouchPoints;
+
+    return obs;
+  }
+
+  // Armed release entry point. Idempotent: a second call returns the same result
+  // and does NOT re-dispatch (no duplicate publication).
+  window.__STEALTH_PROBE_START__ = async function () {
+    if (window.__STEALTH_PROBE_RESULT__ && window.__STEALTH_PROBE_RESULT__.complete) {
+      return window.__STEALTH_PROBE_RESULT__;
+    }
+    var started = performance.now();
+    var observations = await collect();
+    var finished = performance.now();
+    var result = {
+      schema_version: SCHEMA_VERSION,
+      started_ms: started,
+      finished_ms: finished,
+      complete: true,
+      observations: observations
+    };
+    window.__STEALTH_PROBE_RESULT__ = result;
+    var title = document.getElementById("probe-title");
+    if (title) { title.textContent = "stealth-probe (released)"; }
+    window.dispatchEvent(new Event("stealth-probe-complete"));
+    return result;
+  };
+})();
+</script>
+</body>
+</html>

--- a/tests/release_gate_harness.py
+++ b/tests/release_gate_harness.py
@@ -72,6 +72,11 @@ from fastmcp.client.transports import StdioTransport
 _log = logging.getLogger("release_gate_harness")
 
 # ── Contract constants ──────────────────────────────────────────────────────
+# How far `run_release_gate_journey` runs. ONE journey, two declared extents —
+# never two journeys. See that function's docstring for what each one claims.
+FULL_JOURNEY = "full"
+HANDSHAKE_ONLY = "handshake"
+
 SERVER_NAME = "stealth-chrome-devtools-mcp"
 REGISTRY_TOOL_COUNT = 94  # remediation baseline (CLAUDE.md: derived == 94)
 RESULT_SCHEMA_VERSION = 1
@@ -865,13 +870,35 @@ async def run_release_gate_journey(
     launcher: str | os.PathLike[str],
     work_dir: str | os.PathLike[str],
     singleton_port: int | None = None,
+    stages: str = FULL_JOURNEY,
 ) -> dict[str, Any]:
     """Drive the canonical real-stdio journey against ``launcher`` and return a
     versioned, JSON-serializable result record (consumed unchanged by W3).
 
     ``work_dir`` is a throwaway directory (e.g. pytest ``tmp_path``) used for the
     isolated HOME (singleton state), session root, clone output, and logs.
+
+    ``stages`` selects how far the ONE journey runs — it never selects a
+    different journey:
+
+    ``"full"`` (default)
+        everything: handshake, registry, parity, cold-start warmup, and the
+        navigating canonical journey. This is what W1's transport test and
+        every non-macOS W3 smoke cell run.
+    ``"handshake"``
+        stops after the non-navigating prefix (initialize → ``tools/list`` →
+        ``list_instances`` → the representative parity call). W3 uses it for
+        the macOS/ARM64 install-smoke cells ONLY, because F-773 makes any
+        navigation through the detached backend hang on hosted macOS runners.
+        It is a genuinely reduced claim — "this artifact installs and serves"
+        — and the result record says so in ``stages`` so no consumer can read
+        it as the full journey. Not an xfail: nothing failing is being marked
+        as expected-to-fail; a smaller thing is being run and labelled.
     """
+    if stages not in (FULL_JOURNEY, HANDSHAKE_ONLY):
+        raise ValueError(
+            f"stages must be {FULL_JOURNEY!r} or {HANDSHAKE_ONLY!r}, got {stages!r}"
+        )
     launcher = Path(launcher)
     work_dir = Path(work_dir)
     home_dir = work_dir / "home"
@@ -891,6 +918,8 @@ async def run_release_gate_journey(
 
     record: dict[str, Any] = {
         "schema_version": RESULT_SCHEMA_VERSION,
+        "stages": stages,
+        "navigation_verified": stages == FULL_JOURNEY,
         "transport": "stdio",
         "launcher": str(launcher.resolve()),
         "singleton_port": port,
@@ -921,8 +950,9 @@ async def run_release_gate_journey(
                     async with Client(transport, init_timeout=INIT_TIMEOUT) as client:
                         await _foundation_proof(client, record)
                         await _representative_parity(client, record)
-                        await _cold_start_warmup(client, base_url, log_dir, record)
-                        await _canonical_journey(client, base_url, record)
+                        if stages == FULL_JOURNEY:
+                            await _cold_start_warmup(client, base_url, log_dir, record)
+                            await _canonical_journey(client, base_url, record)
                 except BaseException as exc:  # noqa: BLE001  PERMANENT(augment with child stderr + boot log, then re-raise)
                     err = exc
             child_stderr = cap["text"]

--- a/tests/release_gate_harness.py
+++ b/tests/release_gate_harness.py
@@ -87,7 +87,8 @@ INIT_TIMEOUT = 60.0  # initialize handshake (answered locally by the proxy)
 LIST_TIMEOUT = 130.0  # first backend-bound call — covers backend cold start
 SPAWN_TIMEOUT = 120.0  # first real Chrome launch
 WARMUP_TIMEOUT = 150.0  # cold Chrome + master-profile bootstrap (best-effort)
-WARMUP_ATTEMPTS = 2  # the cold launch intermittently fails outright, not just slowly
+WARMUP_ATTEMPTS = 4  # the cold launch intermittently fails outright, not just slowly
+WARMUP_BACKOFF_SECONDS = 3.0  # multiplied by the attempt number; see _cold_start_warmup
 NAV_TIMEOUT = 60.0
 CALL_TIMEOUT = 45.0
 CLOSE_TIMEOUT = 45.0
@@ -675,6 +676,15 @@ async def _cold_start_warmup(
     record["cold_start_warmup"] = warmup
     for attempt in range(1, WARMUP_ATTEMPTS + 1):
         warmup["attempts"] = attempt
+        if attempt > 1:
+            # BACK OFF before retrying. "Failed to connect to browser" is a fast
+            # connect failure, not a timeout — a bigger WARMUP_TIMEOUT cannot fix
+            # it, and an immediate retry meets exactly the resource contention
+            # that just failed. Observed defeating both attempts on Linux/X64
+            # runners simultaneously across two PRs, taking `transport` and
+            # `install-smoke (wheel)` down with it. Same shape as the backoff
+            # e2e_helpers.warmup_once already uses for the in-process warmup.
+            await asyncio.sleep(WARMUP_BACKOFF_SECONDS * attempt)
         iid: str | None = None
         try:
             # Chrome's OWN log, into log_dir so the failure dump picks it up with

--- a/tests/test_package_verify.py
+++ b/tests/test_package_verify.py
@@ -1,0 +1,351 @@
+"""Hermetic pins for the W3 artifact contract (plan_RELEASE §2.3, gap G-C).
+
+``tools/package_verify.py`` is the ONE home for "is this distribution the one we
+built, and does it carry what it must". These tests build synthetic wheels and
+sdists in a tmp dir — no network, no real ``uv build`` — so every rule can be
+proven to BITE, not just to pass. The same negative controls run as in-job bite
+proofs in CI against a throwaway copy of the real artifact; this file is what
+makes them cheap to keep honest.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "tools"))
+
+import package_verify as pv  # noqa: E402  PERMANENT(tools/ is not an importable package; the sys.path line above must run first)
+
+VERSION = "1.2.0"
+DIST_STEM = f"stealth_chrome_devtools_mcp-{VERSION}"
+
+
+def _js_body(name: str) -> str:
+    return f"// {name}\nexport const marker = '{name}';\n"
+
+
+def _metadata(version: str = VERSION, name: str = pv.DIST_NAME) -> str:
+    return (
+        "Metadata-Version: 2.3\n"
+        f"Name: {name}\n"
+        f"Version: {version}\n"
+        "Summary: synthetic fixture\n"
+        "\n"
+        "body\n"
+    )
+
+
+def _entry_points() -> str:
+    return (
+        "[console_scripts]\n"
+        "stealth-chrome-devtools = stealth_chrome_devtools_mcp.cli:main\n"
+        "stealth-chrome-devtools-mcp = stealth_chrome_devtools_mcp.server:main\n"
+    )
+
+
+def make_wheel(
+    path: Path,
+    *,
+    version: str = VERSION,
+    metadata_version: str | None = None,
+    js: dict[str, str] | None = None,
+    omit_modules: tuple[str, ...] = (),
+    entry_points: str | None = None,
+    extra: dict[str, str] | None = None,
+) -> Path:
+    js = js if js is not None else {n: _js_body(n) for n in pv.EXPECTED_JS}
+    dist_info = f"stealth_chrome_devtools_mcp-{version}.dist-info"
+    with zipfile.ZipFile(path, "w") as zf:
+        for module in pv.EXPECTED_MODULES:
+            if module in omit_modules:
+                continue
+            zf.writestr(f"{pv.PKG}/{module}", f"# {module}\n")
+        for name, body in js.items():
+            zf.writestr(f"{pv.PKG}/embedded/js/{name}", body)
+        zf.writestr(f"{dist_info}/METADATA", _metadata(metadata_version or version))
+        zf.writestr(f"{dist_info}/WHEEL", "Wheel-Version: 1.0\n")
+        if entry_points is not None:
+            zf.writestr(f"{dist_info}/entry_points.txt", entry_points)
+        else:
+            zf.writestr(f"{dist_info}/entry_points.txt", _entry_points())
+        for member, body in (extra or {}).items():
+            zf.writestr(member, body)
+    return path
+
+
+def make_sdist(
+    path: Path,
+    *,
+    version: str = VERSION,
+    pkg_info_version: str | None = None,
+    js: dict[str, str] | None = None,
+    omit_files: tuple[str, ...] = (),
+) -> Path:
+    js = js if js is not None else {n: _js_body(n) for n in pv.EXPECTED_JS}
+    root = f"stealth_chrome_devtools_mcp-{version}"
+    files: dict[str, str] = {
+        "PKG-INFO": _metadata(pkg_info_version or version),
+        "pyproject.toml": "[project]\nname = 'x'\n",
+        "README.md": "# readme\n",
+    }
+    for name, body in js.items():
+        files[f"src/{pv.PKG}/embedded/js/{name}"] = body
+    with tarfile.open(path, "w:gz") as tf:
+        for rel, body in files.items():
+            if rel in omit_files:
+                continue
+            data = body.encode("utf-8")
+            info = tarfile.TarInfo(f"{root}/{rel}")
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+    return path
+
+
+def make_dist(tmp_path: Path, **kwargs: object) -> Path:
+    """A dist/ dir holding one synthetic wheel + one synthetic sdist."""
+    dist = tmp_path / "dist"
+    dist.mkdir(exist_ok=True)
+    wheel_kwargs = {
+        k[len("wheel_") :]: v for k, v in kwargs.items() if k.startswith("wheel_")
+    }
+    sdist_kwargs = {
+        k[len("sdist_") :]: v for k, v in kwargs.items() if k.startswith("sdist_")
+    }
+    version = str(kwargs.get("version", VERSION))
+    make_wheel(
+        dist / f"{DIST_STEM.replace(VERSION, version)}-py3-none-any.whl",
+        version=version,
+        **wheel_kwargs,
+    )
+    make_sdist(
+        dist / f"{DIST_STEM.replace(VERSION, version)}.tar.gz",
+        version=version,
+        **sdist_kwargs,
+    )
+    return dist
+
+
+@pytest.fixture
+def good_dist(tmp_path: Path) -> Path:
+    return make_dist(tmp_path)
+
+
+@pytest.fixture
+def good_manifest(good_dist: Path) -> dict:
+    return pv.build_manifest(good_dist)
+
+
+# ---------------------------------------------------------------------------
+# The contract holds on a well-formed pair.
+# ---------------------------------------------------------------------------
+def test_manifest_records_version_hashes_and_package_data(good_dist, good_manifest):
+    assert good_manifest["version"] == VERSION
+    assert good_manifest["schema_version"] == pv.MANIFEST_SCHEMA_VERSION
+    kinds = {a["kind"] for a in good_manifest["artifacts"]}
+    assert kinds == {"wheel", "sdist"}
+    for entry in good_manifest["artifacts"]:
+        assert len(entry["sha256"]) == 64
+        assert entry["size"] == (good_dist / entry["filename"]).stat().st_size
+    assert set(good_manifest["package_data"]) == {
+        f"{pv.PKG}/embedded/js/{n}" for n in pv.EXPECTED_JS
+    }
+
+
+def test_verify_accepts_the_artifacts_it_described(good_dist, good_manifest):
+    assert pv.verify_dist(good_dist, good_manifest) == []
+
+
+# ---------------------------------------------------------------------------
+# Bite proofs: each rule must reject something.
+# ---------------------------------------------------------------------------
+def test_flipped_byte_is_rejected_by_hash(tmp_path, good_dist, good_manifest):
+    """The publish-path precondition: mutated bytes never pass as the built ones."""
+    wheel = next(good_dist.glob("*.whl"))
+    corrupt = tmp_path / "corrupt" / wheel.name
+    corrupt.parent.mkdir()
+    data = bytearray(wheel.read_bytes())
+    data[-1] ^= 0xFF
+    corrupt.write_bytes(bytes(data))
+
+    problems = pv.check_artifact_hash(corrupt, good_manifest)
+    assert problems, "a flipped byte must fail the hash check"
+    assert any("sha256" in p for p in problems)
+    # The original is untouched — a bite proof never damages the real artifact.
+    assert pv.check_artifact_hash(wheel, good_manifest) == []
+
+
+def test_removing_package_data_is_rejected_at_manifest_time(tmp_path):
+    js = {n: _js_body(n) for n in pv.EXPECTED_JS if n != "extract_styles.js"}
+    dist = make_dist(tmp_path, wheel_js=js)
+    with pytest.raises(pv.VerificationError, match="missing package data"):
+        pv.build_manifest(dist)
+
+
+def test_removing_package_data_is_rejected_by_verify(tmp_path, good_manifest):
+    """Even with matching hashes elsewhere, a missing member is a violation."""
+    js = {n: _js_body(n) for n in pv.EXPECTED_JS if n != "extract_events.js"}
+    dist = make_dist(tmp_path, wheel_js=js, sdist_js=js)
+    problems = pv.verify_dist(dist, good_manifest)
+    assert any("extract_events.js" in p for p in problems), problems
+
+
+def test_wheel_and_sdist_package_data_must_agree(tmp_path):
+    sdist_js = {n: _js_body(n) for n in pv.EXPECTED_JS}
+    sdist_js["extract_assets.js"] = "// tampered\n"
+    dist = make_dist(tmp_path, sdist_js=sdist_js)
+    manifest = pv.build_manifest(dist)
+    problems = pv.verify_dist(dist, manifest)
+    assert any("disagree" in p for p in problems), problems
+
+
+def test_missing_module_is_rejected(tmp_path):
+    dist = make_dist(tmp_path, wheel_omit_modules=("embedded/cdp_element_cloner.py",))
+    manifest = pv.build_manifest(dist)
+    problems = pv.verify_dist(dist, manifest)
+    assert any("cdp_element_cloner.py" in p for p in problems), problems
+
+
+def test_missing_entry_point_is_rejected(tmp_path):
+    only_one = (
+        "[console_scripts]\n"
+        "stealth-chrome-devtools = stealth_chrome_devtools_mcp.cli:main\n"
+    )
+    dist = make_dist(tmp_path, wheel_entry_points=only_one)
+    manifest = pv.build_manifest(dist)
+    problems = pv.verify_dist(dist, manifest)
+    assert any("stealth-chrome-devtools-mcp" in p for p in problems), problems
+
+
+def test_metadata_version_disagreeing_with_filename_is_rejected(tmp_path):
+    dist = make_dist(tmp_path, wheel_metadata_version="9.9.9")
+    manifest = pv.build_manifest(dist)
+    # build_manifest reads the version FROM metadata, so the filename disagrees.
+    problems = pv.verify_dist(dist, manifest)
+    assert any("filename version" in p for p in problems), problems
+
+
+def test_stray_js_outside_the_package_is_rejected(tmp_path):
+    dist = make_dist(tmp_path, wheel_extra={"data/extract_styles.js": "// dup\n"})
+    manifest = pv.build_manifest(dist)
+    problems = pv.verify_dist(dist, manifest)
+    assert any("outside" in p for p in problems), problems
+
+
+def test_sdist_missing_package_data_is_rejected(tmp_path):
+    dist = make_dist(
+        tmp_path, sdist_omit_files=(f"src/{pv.PKG}/embedded/js/extract_structure.js",)
+    )
+    manifest = pv.build_manifest(dist)
+    problems = pv.verify_dist(dist, manifest)
+    assert any("extract_structure.js" in p for p in problems), problems
+
+
+def test_two_wheels_in_dist_is_rejected(tmp_path, good_dist):
+    make_wheel(good_dist / "stealth_chrome_devtools_mcp-1.2.0-py2-none-any.whl")
+    with pytest.raises(pv.VerificationError, match="exactly 1 wheel"):
+        pv.find_artifacts(good_dist)
+
+
+# ---------------------------------------------------------------------------
+# Manifest loading + the tag precondition.
+# ---------------------------------------------------------------------------
+def test_manifest_schema_version_is_enforced(tmp_path, good_manifest):
+    path = tmp_path / "m.json"
+    good_manifest["schema_version"] = 99
+    path.write_text(json.dumps(good_manifest), encoding="utf-8")
+    with pytest.raises(pv.VerificationError, match="schema_version"):
+        pv.load_manifest(path)
+
+
+@pytest.mark.parametrize("tag", ["v1.2.0", "1.2.0", "refs/tags/v1.2.0"])
+def test_matching_tag_forms_are_accepted(good_manifest, tag):
+    assert pv.assert_tag_version(good_manifest, tag) == []
+
+
+@pytest.mark.parametrize("tag", ["v1.2.1", "v0.9.0", "refs/tags/v2.0.0"])
+def test_mismatched_tag_blocks_publication(good_manifest, tag):
+    problems = pv.assert_tag_version(good_manifest, tag)
+    assert problems and "disagree" in problems[0]
+
+
+def test_unknown_artifact_filename_is_rejected(tmp_path, good_manifest):
+    stranger = tmp_path / "stealth_chrome_devtools_mcp-9.9.9-py3-none-any.whl"
+    make_wheel(stranger, version="9.9.9")
+    problems = pv.check_artifact_hash(stranger, good_manifest)
+    assert problems and "not in the manifest" in problems[0]
+
+
+# ---------------------------------------------------------------------------
+# CLI exit codes (what the workflow steps actually depend on).
+# ---------------------------------------------------------------------------
+def test_cli_manifest_then_verify_round_trips(tmp_path, good_dist):
+    manifest_path = tmp_path / "out" / "release-manifest.json"
+    assert (
+        pv.main(["manifest", "--dist", str(good_dist), "--out", str(manifest_path)])
+        == 0
+    )
+    evidence = tmp_path / "out" / "package-verify.json"
+    assert (
+        pv.main(
+            [
+                "verify",
+                "--dist",
+                str(good_dist),
+                "--manifest",
+                str(manifest_path),
+                "--expect-version",
+                f"v{VERSION}",
+                "--out",
+                str(evidence),
+            ]
+        )
+        == 0
+    )
+    record = json.loads(evidence.read_text(encoding="utf-8"))
+    assert record["verified"] is True
+    assert record["violations"] == []
+
+
+def test_cli_hash_check_rejects_a_corrupted_copy(tmp_path, good_dist):
+    manifest_path = tmp_path / "release-manifest.json"
+    assert (
+        pv.main(["manifest", "--dist", str(good_dist), "--out", str(manifest_path)])
+        == 0
+    )
+    wheel = next(good_dist.glob("*.whl"))
+    copy = tmp_path / wheel.name
+    copy.write_bytes(wheel.read_bytes() + b"\x00")
+    assert (
+        pv.main(
+            [
+                "hash-check",
+                "--artifact",
+                str(copy),
+                "--manifest",
+                str(manifest_path),
+            ]
+        )
+        == 1
+    )
+
+
+def test_cli_assert_version_blocks_a_wrong_tag(tmp_path, good_dist):
+    manifest_path = tmp_path / "release-manifest.json"
+    pv.main(["manifest", "--dist", str(good_dist), "--out", str(manifest_path)])
+    assert (
+        pv.main(["assert-version", "--manifest", str(manifest_path), "--tag", "v9.9.9"])
+        == 1
+    )
+    assert (
+        pv.main(
+            ["assert-version", "--manifest", str(manifest_path), "--tag", f"v{VERSION}"]
+        )
+        == 0
+    )

--- a/tests/test_platform_utils.py
+++ b/tests/test_platform_utils.py
@@ -8,13 +8,31 @@ stealth-blocked. Sandbox detection is monkeypatched so the tests are
 deterministic across CI environments.
 """
 
+import subprocess
+
+import pytest
+
 from stealth_chrome_devtools_mcp.embedded import platform_utils
 from stealth_chrome_devtools_mcp.embedded.platform_utils import (
+    build_reduced_user_agent,
     filter_stealth_args,
     get_platform_info,
     get_required_sandbox_args,
     merge_browser_args,
+    resolve_browser_major_version,
 )
+
+
+@pytest.fixture(autouse=True)
+def _no_default_user_agent(monkeypatch):
+    """Neutralize the F-770 masked-UA default for the pre-existing arg tests.
+
+    ``merge_browser_args`` now also supplies a default ``--user-agent=`` derived
+    from the resolved browser, which would make these assertions depend on
+    whether the machine running them happens to have Chrome installed. The
+    F-770 behaviour has its own tests below, which opt back in explicitly.
+    """
+    monkeypatch.setattr(platform_utils, "check_browser_executable", lambda: None)
 
 
 class TestFilterStealthArgs:
@@ -91,3 +109,140 @@ class TestPlatformInfo:
         info = get_platform_info()
         for key in ("system", "is_root", "is_container", "required_sandbox_args"):
             assert key in info
+
+
+# ---------------------------------------------------------------------------
+# F-770 — the masked default User-Agent (plan_RELEASE_FIX_D D1).
+#
+# Headless Chrome advertises `HeadlessChrome/<major>.0.0.0` in its own UA, which
+# is the cheapest server-side bot check there is. The product now supplies a
+# masked default `--user-agent=` built from Chrome's frozen reduced-UA form. The
+# three platform tokens below are the exact strings measured on the three
+# qualified runners (D0), so a table typo cannot pass silently: a wrong token
+# would make the masked UA disagree with the real OS, which is a WORSE tell than
+# the headless token it replaces.
+# ---------------------------------------------------------------------------
+_REDUCED_UA_CELLS = [
+    ("Windows", "Windows NT 10.0; Win64; x64"),
+    ("Darwin", "Macintosh; Intel Mac OS X 10_15_7"),
+    ("Linux", "X11; Linux x86_64"),
+]
+
+
+@pytest.fixture(autouse=True)
+def _clear_version_cache():
+    """``resolve_browser_major_version`` is lru_cached (it runs on the spawn
+    path); clear it around every test so a fake never bleeds between them."""
+    resolve_browser_major_version.cache_clear()
+    yield
+    resolve_browser_major_version.cache_clear()
+
+
+class TestReducedUserAgent:
+    @pytest.mark.parametrize(("system", "token"), _REDUCED_UA_CELLS)
+    def test_masked_ua_matches_the_measured_platform_token(
+        self, monkeypatch, system, token
+    ):
+        monkeypatch.setattr(platform_utils.platform, "system", lambda: system)
+        monkeypatch.setattr(
+            platform_utils, "resolve_browser_major_version", lambda _exe: "150"
+        )
+        agent = build_reduced_user_agent("/opt/google/chrome/chrome")
+        assert agent == (
+            f"Mozilla/5.0 ({token}) AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/150.0.0.0 Safari/537.36"
+        )
+        assert "Headless" not in agent
+
+    def test_edge_keeps_its_own_token(self, monkeypatch):
+        # Dropping Edg/ while sec-ch-ua still says "Microsoft Edge" would be a
+        # sharper tell than the headless token being masked.
+        monkeypatch.setattr(platform_utils.platform, "system", lambda: "Linux")
+        monkeypatch.setattr(
+            platform_utils, "resolve_browser_major_version", lambda _exe: "150"
+        )
+        agent = build_reduced_user_agent("/usr/bin/microsoft-edge-stable")
+        assert agent.endswith("Chrome/150.0.0.0 Safari/537.36 Edg/150.0.0.0")
+
+    def test_unknown_platform_declines_to_mask(self, monkeypatch):
+        monkeypatch.setattr(platform_utils.platform, "system", lambda: "FreeBSD")
+        assert build_reduced_user_agent("/usr/local/bin/chrome") is None
+
+    def test_unresolvable_version_declines_to_mask(self, monkeypatch):
+        # Masking with a wrong version is worse than not masking: the UA would
+        # contradict sec-ch-ua.
+        monkeypatch.setattr(platform_utils.platform, "system", lambda: "Linux")
+        monkeypatch.setattr(
+            platform_utils, "resolve_browser_major_version", lambda _exe: None
+        )
+        assert build_reduced_user_agent("/usr/bin/google-chrome") is None
+
+
+class TestResolveBrowserMajorVersion:
+    def test_windows_reads_the_version_named_sibling_directory(
+        self, monkeypatch, tmp_path
+    ):
+        # Windows must NOT shell out: `chrome.exe --version` hands the flag to a
+        # running Chrome instead of printing anything.
+        monkeypatch.setattr(platform_utils.platform, "system", lambda: "Windows")
+
+        def _explode(*_args, **_kwargs):
+            raise AssertionError("must not run a subprocess on Windows")
+
+        monkeypatch.setattr(platform_utils.subprocess, "run", _explode)
+        (tmp_path / "150.0.7871.186").mkdir()
+        (tmp_path / "149.0.7000.1").mkdir()
+        (tmp_path / "SetupMetrics").mkdir()
+        assert resolve_browser_major_version(str(tmp_path / "chrome.exe")) == "150"
+
+    def test_posix_parses_the_version_subprocess(self, monkeypatch):
+        monkeypatch.setattr(platform_utils.platform, "system", lambda: "Linux")
+        monkeypatch.setattr(
+            platform_utils.subprocess,
+            "run",
+            lambda *_a, **_k: subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="Google Chrome 150.0.7871.186 \n"
+            ),
+        )
+        assert resolve_browser_major_version("/usr/bin/google-chrome") == "150"
+
+    def test_posix_probe_failure_is_not_fatal(self, monkeypatch):
+        monkeypatch.setattr(platform_utils.platform, "system", lambda: "Linux")
+
+        def _boom(*_a, **_k):
+            raise subprocess.TimeoutExpired(cmd="chrome", timeout=10)
+
+        monkeypatch.setattr(platform_utils.subprocess, "run", _boom)
+        assert resolve_browser_major_version("/usr/bin/google-chrome") is None
+
+
+class TestDefaultUserAgentInMergeBrowserArgs:
+    def _arm(self, monkeypatch):
+        monkeypatch.setattr(platform_utils, "is_running_as_root", lambda: False)
+        monkeypatch.setattr(platform_utils, "is_running_in_container", lambda: False)
+        monkeypatch.setattr(platform_utils.platform, "system", lambda: "Linux")
+        monkeypatch.setattr(
+            platform_utils, "check_browser_executable", lambda: "/usr/bin/google-chrome"
+        )
+        monkeypatch.setattr(
+            platform_utils, "resolve_browser_major_version", lambda _exe: "150"
+        )
+
+    def test_default_spawn_gets_a_masked_user_agent(self, monkeypatch):
+        self._arm(monkeypatch)
+        combined, _ = merge_browser_args([])
+        assert combined == [
+            "--user-agent=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36"
+        ]
+
+    def test_explicit_user_agent_always_wins(self, monkeypatch):
+        self._arm(monkeypatch)
+        combined, _ = merge_browser_args(["--user-agent=CallerChose/1.0"])
+        assert combined == ["--user-agent=CallerChose/1.0"]
+
+    def test_no_browser_means_no_masking(self, monkeypatch):
+        self._arm(monkeypatch)
+        monkeypatch.setattr(platform_utils, "check_browser_executable", lambda: None)
+        combined, _ = merge_browser_args(["--lang=en-US"])
+        assert combined == ["--lang=en-US"]

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -1,0 +1,215 @@
+"""Structural pins for the release topology (plan_RELEASE W3, gap G-C).
+
+The W3 claims that are easiest to lose are the ones nothing executes on a normal
+PR: *publish never rebuilds*, *the aggregate never forgets an edge*, and *the
+macOS smoke cells are partial on purpose*. A tag build happens rarely and cannot
+be dry-run here, so those properties are pinned by reading the workflow YAML
+instead of by hoping a reviewer notices.
+
+These are deliberately structural, not stylistic: they assert the shape the plan
+requires and say why, so a future workstream that adds a job (W5's
+``release-evidence``) is told to wire its edge rather than discovering months
+later that the required check was green while a lane never ran.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOWS = Path(__file__).resolve().parent.parent / ".github" / "workflows"
+RELEASE_GATE = WORKFLOWS / "release-gate.yml"
+PUBLISH = WORKFLOWS / "publish.yml"
+TEST_CALLER = WORKFLOWS / "test.yml"
+
+AGGREGATE = "release-gate"
+BUILD_COMMANDS = ("uv build", "python -m build", "hatchling build", "pip wheel")
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _jobs(path: Path) -> dict:
+    return _load(path)["jobs"]
+
+
+def _all_run_steps(job: dict) -> list[str]:
+    return [step["run"] for step in job.get("steps", []) if "run" in step]
+
+
+@pytest.fixture(scope="module")
+def gate_jobs() -> dict:
+    return _jobs(RELEASE_GATE)
+
+
+# ---------------------------------------------------------------------------
+# Build once.
+# ---------------------------------------------------------------------------
+def test_exactly_one_job_builds_the_distribution(gate_jobs):
+    """`uv build` may appear in build-dist and nowhere else in the gate."""
+    builders = {
+        name
+        for name, job in gate_jobs.items()
+        if any(cmd in run for run in _all_run_steps(job) for cmd in BUILD_COMMANDS)
+    }
+    assert builders == {"build-dist"}, (
+        f"the distribution must be built exactly once, in build-dist; "
+        f"these jobs build: {sorted(builders)}"
+    )
+
+
+def test_publish_never_builds_and_never_downloads_from_pypi():
+    """The publish job uploads the gated files; it does not make new ones."""
+    for name, job in _jobs(PUBLISH).items():
+        for run in _all_run_steps(job):
+            for cmd in BUILD_COMMANDS:
+                assert cmd not in run, (
+                    f"publish.yml job {name!r} runs {cmd!r} — publishing must "
+                    f"upload the artifact the gate tested, never a rebuild"
+                )
+            assert "pip install stealth-chrome-devtools-mcp" not in run, (
+                f"publish.yml job {name!r} re-downloads the package from PyPI"
+            )
+
+
+def test_publish_calls_the_reusable_gate_rather_than_reimplementing_it():
+    jobs = _jobs(PUBLISH)
+    assert "gate" in jobs, "publish.yml must qualify the tag through the gate"
+    assert jobs["gate"]["uses"].endswith("release-gate.yml"), (
+        "publish.yml must CALL the one reusable gate, not duplicate job semantics"
+    )
+    # The tag SHA and the tag itself are both handed to the gate, so the gate
+    # tests the commit it will publish and fails on a tag/version disagreement.
+    assert set(jobs["gate"]["with"]) == {"ref", "release_tag"}
+
+
+def test_publish_requires_the_green_gate_and_downloads_that_runs_artifact():
+    publish = _jobs(PUBLISH)["publish"]
+    needs = publish["needs"]
+    needs = [needs] if isinstance(needs, str) else needs
+    assert "gate" in needs, (
+        "publish must need the gate: a failed, skipped, or cancelled cell has to "
+        "prevent PyPI and the GitHub release"
+    )
+    downloads = [
+        step
+        for step in publish["steps"]
+        if "download-artifact" in str(step.get("uses", ""))
+    ]
+    assert len(downloads) == 1, "publish must download the one gated dist artifact"
+    assert downloads[0]["with"]["name"] == "dist"
+    # …and re-check it before uploading anything.
+    assert any("package_verify.py verify" in run for run in _all_run_steps(publish)), (
+        "publish must re-verify the downloaded artifact before uploading it"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The aggregate never forgets an edge.
+# ---------------------------------------------------------------------------
+def test_aggregate_directly_needs_every_other_job(gate_jobs):
+    """The one public required check must depend on every lane in the file.
+
+    A lane that exists but is not in `needs` is invisible to the required check:
+    it can fail while `release-gate` reports green. Adding a job to this
+    workflow therefore MUST add its edge here (W5's `release-evidence` next).
+    """
+    expected = set(gate_jobs) - {AGGREGATE}
+    actual = set(gate_jobs[AGGREGATE]["needs"])
+    assert actual == expected, (
+        f"release-gate is missing edges for {sorted(expected - actual)} and has "
+        f"stale edges for {sorted(actual - expected)}"
+    )
+
+
+def test_aggregate_checks_the_result_of_every_edge(gate_jobs):
+    """Listing a job in `needs` is not enough — its result must be asserted."""
+    script = "\n".join(_all_run_steps(gate_jobs[AGGREGATE]))
+    for edge in gate_jobs[AGGREGATE]["needs"]:
+        assert f"needs.{edge}.result" in script, (
+            f"the aggregate lists {edge!r} in needs but never checks its result"
+        )
+
+
+def test_aggregate_runs_even_when_a_dependency_fails(gate_jobs):
+    """Without always(), a failed dependency SKIPS the aggregate instead of
+    failing it — and a skipped required check does not block merge."""
+    assert gate_jobs[AGGREGATE]["if"] == "always()"
+
+
+def test_w3_edges_are_present(gate_jobs):
+    for job in ("build-dist", "package-verify", "install-smoke"):
+        assert job in gate_jobs, f"W3 edge {job!r} is missing from the gate"
+
+
+# ---------------------------------------------------------------------------
+# The declared macOS gap stays declared.
+# ---------------------------------------------------------------------------
+def test_install_smoke_covers_both_artifacts_on_all_three_cells(gate_jobs):
+    matrix = gate_jobs["install-smoke"]["strategy"]["matrix"]
+    assert set(matrix["kind"]) == {"wheel", "sdist"}
+    labels = {f"{c['runner_os']}/{c['runner_arch']}" for c in matrix["cell"]}
+    assert labels == {"Linux/X64", "Windows/X64", "macOS/ARM64"}
+
+
+def test_macos_smoke_is_partial_and_the_others_are_full(gate_jobs):
+    """F-773: macOS cells run `handshake` (no navigation) and MUST say so.
+
+    If F-773 closes, flip these cells to `full` and update this pin. If someone
+    quietly flips them to `full` while F-773 is open, the cells will simply hang
+    — this pin is what makes the intent explicit either way.
+    """
+    stages = {
+        f"{c['runner_os']}/{c['runner_arch']}": c["stages"]
+        for c in gate_jobs["install-smoke"]["strategy"]["matrix"]["cell"]
+    }
+    assert stages == {
+        "Linux/X64": "full",
+        "Windows/X64": "full",
+        "macOS/ARM64": "handshake",
+    }
+
+
+def test_partial_cells_are_labelled_in_the_check_name(gate_jobs):
+    """A reduced cell must be readable as reduced from the check list alone."""
+    name = gate_jobs["install-smoke"]["name"]
+    assert "NO-NAVIGATION partial" in name
+
+
+def test_the_gap_declaration_job_exists_and_is_required(gate_jobs):
+    assert "known-gaps" in gate_jobs, (
+        "gap declarations have ONE home; it must be a job so a reviewer reads it "
+        "in the check list rather than in a YAML comment"
+    )
+    assert "known-gaps" in gate_jobs[AGGREGATE]["needs"]
+    script = "\n".join(_all_run_steps(gate_jobs["known-gaps"]))
+    for lane in ("transport", "install-smoke"):
+        assert lane in script, f"known-gaps does not mention the {lane!r} gap"
+
+
+def test_no_gate_job_hides_failure(gate_jobs):
+    """continue-on-error anywhere would let a red lane report green."""
+    for name, job in gate_jobs.items():
+        assert not job.get("continue-on-error"), (
+            f"job {name!r} sets continue-on-error — a required gate may not "
+            f"absorb a failure"
+        )
+        for step in job.get("steps", []):
+            assert not step.get("continue-on-error"), (
+                f"job {name!r} has a continue-on-error step: {step.get('name')}"
+            )
+
+
+def test_pr_caller_runs_the_same_reusable_gate():
+    """Every PR gets the full gate — no dispatch-only or path-filtered substitute."""
+    caller = _load(TEST_CALLER)
+    assert caller["jobs"]["release-gate"]["uses"].endswith("release-gate.yml")
+    # `on:` parses as the boolean True in YAML 1.1; accept either spelling.
+    triggers = caller.get("on", caller.get(True))
+    assert "pull_request" in triggers
+    assert "paths" not in triggers["pull_request"], (
+        "path filtering may not omit packaging-relevant changes"
+    )

--- a/tests/test_stealth.py
+++ b/tests/test_stealth.py
@@ -1,0 +1,784 @@
+"""plan_RELEASE W4 (G-D) — deterministic offline stealth-invariant probe.
+
+The product's headline promise is "undetectable by anti-bot systems" (G-D), yet
+before this module that claim was asserted **nowhere**. This is the acceptance
+suite that makes a regression which reintroduces ``navigator.webdriver``, a CDP
+leak global, or a fingerprint tell fail the release gate.
+
+Two tiers (stealth is the one place determinism and realism genuinely conflict):
+
+* **Offline / deterministic (GATING)** — marker ``stealth`` (and ``integration``,
+  so the unit lane ``-m "not integration"`` excludes it). The release gate lane
+  selects ``-m "stealth and not online"``. It drives real headless Chrome against
+  the passive local fixture ``fixture_app/stealth_probe.html`` (served by the ONE
+  fixture mechanism, :func:`release_gate_harness.serve_fixture_app`), releases the
+  armed probe only after an ordered CDP prerequisite transcript, validates the
+  probe's closed schema, and runs a versioned predicate table. A deliberately
+  non-stealth **vanilla control** (the same product spawn path with the stealth
+  arg-filter neutralized — the single intentional treatment) must FAIL the probes,
+  proving the predicates have teeth.
+
+* **Online / informational (NON-GATING, opt-in)** — markers ``stealth`` +
+  ``online`` + ``integration``. Excluded from every default run and the release
+  gate (``not online``). Drives CreepJS and bot.incolumitas, asserts only the hard
+  invariants, logs the rest, and tolerates network flakiness by design.
+
+Design honesty (release-claim integrity): one product predicate — the headless UA
+still advertising ``HeadlessChrome`` — does NOT pass. It is pinned as a strict
+``xfail`` (F-770), NOT hidden by weakening a probe. An xfailed invariant cannot
+satisfy the stealth release claim; see :data:`XFAIL_SIGNALS` and the test docstring.
+
+No ``src/`` edits: both browsers spawn through the project's own
+``spawn_browser`` tool; the ordered transcript uses the project's own nodriver
+``tab.send(uc.cdp.*)`` CDP seam; the fixture and env-isolation reuse W1's homes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform as _platform
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import nodriver as uc
+import pytest
+
+from e2e_helpers import (
+    CAN_RUN,
+    get_fn,
+    integration_pytestmark,
+    navigate_and_settle,
+    sandbox_kwargs,
+    server_mod,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# Real-Chrome tier: mark the whole module ``stealth`` + ``integration`` (+ skip
+# when Chrome/the server is unavailable, via the shared e2e guard). The gate lane
+# is ``-m "stealth and not online"``; the unit lane ``-m "not integration"`` skips.
+_integration = integration_pytestmark()
+if not isinstance(_integration, list):
+    _integration = [_integration]
+pytestmark = [pytest.mark.stealth, *_integration]
+
+
+# ===========================================================================
+# Versioned signal specification (the ONE reviewed predicate table).
+#
+# Each row names a signal, the raw observation key(s) it reads, the predicate
+# (True == stealthy), the per-OS platform allowance, and a ``forbidden`` overlay
+# that introduces the forbidden observation for that collector family — the
+# deterministic sensitivity control that proves the predicate can detect a leak.
+#
+# "Truthy", "looks normal", and silently accepting unavailable values are NOT
+# predicates. A Chrome-major change that invalidates a platform allowance requires
+# a reviewed edit to this table.
+# ===========================================================================
+
+# Required members of a real ``window.chrome`` (present without an extension).
+_CHROME_REQUIRED_MEMBERS = frozenset({"app", "csi", "loadTimes"})
+
+# Per-OS ``navigator.platform`` allowance. os.uname-family -> accepted values.
+_PLATFORM_ALLOWANCE = {
+    "Windows": {"Win32", "Win64"},
+    "Linux": {"Linux x86_64", "Linux aarch64", "Linux armv8l", "Linux"},
+    "Darwin": {"MacIntel", "MacARM", "macOS"},
+}
+
+_NATIVE_SUFFIX = "{ [native code] }"
+
+
+def _os_family() -> str:
+    return _platform.system()
+
+
+@dataclass(frozen=True)
+class Signal:
+    """One reviewed stealth-signal row."""
+
+    name: str
+    obs_keys: tuple[str, ...]
+    predicate: Callable[[dict, str], bool]
+    forbidden: dict  # overlay onto a good baseline -> predicate must return False
+    description: str
+    platforms: tuple[str, ...] = ("*",)
+    finding_id: str | None = None  # set on xfail rows
+
+    def applies(self, os_family: str) -> bool:
+        return self.platforms == ("*",) or os_family in self.platforms
+
+
+# ── Predicates (pure; operate on the raw observation dict) ──────────────────
+def _p_webdriver_absent(obs: dict, _os: str) -> bool:
+    # navigator.webdriver must be exactly False (not True, not missing-as-true).
+    return obs.get("webdriver") is False
+
+
+def _p_window_chrome(obs: dict, _os: str) -> bool:
+    if obs.get("window_chrome_present") is not True:
+        return False
+    members = set(obs.get("window_chrome_members") or [])
+    return members >= _CHROME_REQUIRED_MEMBERS
+
+
+def _p_plugins_present(obs: dict, _os: str) -> bool:
+    return isinstance(obs.get("plugins_count"), int) and obs["plugins_count"] >= 1
+
+
+def _p_languages_present(obs: dict, _os: str) -> bool:
+    langs = obs.get("languages")
+    lang = obs.get("language")
+    return bool(isinstance(langs, list) and langs and isinstance(lang, str) and lang)
+
+
+def _p_leak_globals_absent(obs: dict, _os: str) -> bool:
+    return (
+        obs.get("automation_globals_window") == []
+        and obs.get("automation_globals_document") == []
+    )
+
+
+def _p_fn_tostring_native(obs: dict, _os: str) -> bool:
+    alert = obs.get("fn_tostring_alert") or ""
+    meta = obs.get("fn_tostring_meta") or ""
+    return alert.rstrip().endswith(_NATIVE_SUFFIX) and "[native code]" in meta
+
+
+def _p_notification_consistent(obs: dict, _os: str) -> bool:
+    perm = obs.get("notification_permission")
+    query = obs.get("permissions_query_notifications")
+    if perm not in {"default", "granted", "denied"}:
+        return False
+    # The classic headless leak: Notification.permission == 'denied' while the
+    # Permissions API reports 'prompt'. Consistent browsers never show that pair.
+    return not (perm == "denied" and query == "prompt")
+
+
+def _p_platform_present(obs: dict, os_family: str) -> bool:
+    plat = obs.get("platform")
+    if not (isinstance(plat, str) and plat):
+        return False
+    allowed = _PLATFORM_ALLOWANCE.get(os_family)
+    return plat in allowed if allowed else True
+
+
+def _p_ua_client_hints(obs: dict, _os: str) -> bool:
+    if obs.get("ua_client_hints_present") is not True:
+        return False
+    brands = obs.get("ua_client_hints_brands") or []
+    if not brands:
+        return False
+    return not any("headlesschrome" in str(b).lower() for b in brands)
+
+
+def _p_outer_dimensions(obs: dict, _os: str) -> bool:
+    return (
+        isinstance(obs.get("outer_width"), int)
+        and isinstance(obs.get("outer_height"), int)
+        and obs["outer_width"] > 0
+        and obs["outer_height"] > 0
+    )
+
+
+def _p_ua_no_headless(obs: dict, _os: str) -> bool:
+    return "headlesschrome" not in str(obs.get("user_agent") or "").lower()
+
+
+# ── Gating table: the product MUST pass every applicable row ────────────────
+GATE_SIGNALS: tuple[Signal, ...] = (
+    Signal(
+        "webdriver_absent",
+        ("webdriver",),
+        _p_webdriver_absent,
+        {"webdriver": True},
+        "navigator.webdriver is exactly False (not the automation-controlled true).",
+    ),
+    Signal(
+        "window_chrome_members",
+        ("window_chrome_present", "window_chrome_members"),
+        _p_window_chrome,
+        {"window_chrome_present": False, "window_chrome_members": []},
+        "window.chrome present with required members {app, csi, loadTimes}.",
+    ),
+    Signal(
+        "plugins_present",
+        ("plugins_count",),
+        _p_plugins_present,
+        {"plugins_count": 0},
+        "navigator.plugins is non-empty (empty is a classic headless tell).",
+    ),
+    Signal(
+        "languages_present",
+        ("languages", "language"),
+        _p_languages_present,
+        {"languages": [], "language": ""},
+        "navigator.languages / navigator.language are populated.",
+    ),
+    Signal(
+        "cdp_leak_globals_absent",
+        ("automation_globals_window", "automation_globals_document"),
+        _p_leak_globals_absent,
+        {"automation_globals_window": ["cdc_adoQpoasnfa76pfcZLmcfl_Array"]},
+        "No cdc_/$cdc/selenium/webdriver/phantom globals on window or document.",
+    ),
+    Signal(
+        "function_tostring_native",
+        ("fn_tostring_alert", "fn_tostring_meta"),
+        _p_fn_tostring_native,
+        {"fn_tostring_alert": "function alert() { return sneaky(); }"},
+        "Native builtins serialize as native code; Function.prototype.toString "
+        "is itself native (unpatched).",
+    ),
+    Signal(
+        "notification_permission_consistent",
+        ("notification_permission", "permissions_query_notifications"),
+        _p_notification_consistent,
+        {
+            "notification_permission": "denied",
+            "permissions_query_notifications": "prompt",
+        },
+        "Notification.permission is not the denied/prompt mismatch vs Permissions API.",
+    ),
+    Signal(
+        "platform_present",
+        ("platform",),
+        _p_platform_present,
+        {"platform": ""},
+        "navigator.platform matches the reviewed per-OS allowance.",
+    ),
+    Signal(
+        "ua_client_hints_present",
+        ("ua_client_hints_present", "ua_client_hints_brands"),
+        _p_ua_client_hints,
+        {"ua_client_hints_present": False, "ua_client_hints_brands": []},
+        "userAgentData present with brands, and no brand reveals HeadlessChrome.",
+    ),
+    Signal(
+        "outer_dimensions_nonzero",
+        ("outer_width", "outer_height"),
+        _p_outer_dimensions,
+        {"outer_width": 0, "outer_height": 0},
+        "window.outerWidth/outerHeight are non-zero (0x0 is a headless tell).",
+    ),
+)
+
+# ── xfail table: a KNOWN product stealth gap, pinned honestly (never weakened) ─
+# F-770: under headless (the configuration the offline gate runs), the product's
+# default User-Agent still advertises "HeadlessChrome". The product ships nodriver
+# and does NOT mask the UA token, so this basic bot tell leaks. Pinned as a strict
+# xfail — an xfailed invariant does NOT satisfy the stealth release claim.
+XFAIL_SIGNALS: tuple[Signal, ...] = (
+    Signal(
+        "ua_no_headless_token",
+        ("user_agent",),
+        _p_ua_no_headless,
+        {"user_agent": "Mozilla/5.0 ... HeadlessChrome/150.0.0.0 Safari/537.36"},
+        "navigator.userAgent does not advertise HeadlessChrome.",
+        finding_id="F-770",
+    ),
+)
+
+# The exact ordered CDP prerequisite transcript (spec §2.4). A pristine page that
+# never saw this real CDP activity must not be able to pass a leak check.
+CDP_PREREQUISITE_METHODS: tuple[str, ...] = (
+    "Runtime.enable",
+    "Page.enable",
+    "Network.enable",
+    "DOM.getDocument",
+    "Runtime.evaluate",  # nonce sentinel
+    "Page.captureScreenshot",
+)
+
+RESULT_SCHEMA_VERSION = 1
+_RESULT_SCHEMA_KEYS = frozenset(
+    {"schema_version", "started_ms", "finished_ms", "complete", "observations"}
+)
+
+
+# ===========================================================================
+# Closed-schema validation (with teeth — see the deterministic negative test).
+# ===========================================================================
+def validate_result_schema(obj: object) -> None:
+    """Raise AssertionError on an absent, extra, duplicate, or unserializable field.
+
+    The probe publishes exactly one closed object; this is the validator the gate
+    runs against the real result and the deterministic negative controls exercise.
+    """
+    assert isinstance(obj, dict), f"result must be an object, got {type(obj).__name__}"
+    keys = set(obj)
+    missing = _RESULT_SCHEMA_KEYS - keys
+    extra = keys - _RESULT_SCHEMA_KEYS
+    assert not missing, f"absent schema field(s): {sorted(missing)}"
+    assert not extra, f"extra schema field(s): {sorted(extra)}"
+    assert obj["schema_version"] == RESULT_SCHEMA_VERSION, obj["schema_version"]
+    assert obj["complete"] is True, obj["complete"]
+    assert isinstance(obj["started_ms"], (int, float)), obj["started_ms"]
+    assert isinstance(obj["finished_ms"], (int, float)), obj["finished_ms"]
+    assert obj["finished_ms"] >= obj["started_ms"], (
+        obj["started_ms"],
+        obj["finished_ms"],
+    )
+    assert isinstance(obj["observations"], dict) and obj["observations"], "observations"
+    # Unserializable -> raises TypeError, surfacing as a failure here.
+    json.dumps(obj)
+
+
+# ===========================================================================
+# Real-browser collection (spawn -> armed-check -> ordered CDP transcript ->
+# release -> read result). Runs inside its own asyncio.run in a sync module-scoped
+# fixture, so it returns plain data and never shares a live browser across the
+# function-scoped event loops pytest-asyncio hands each test (the cross-loop
+# nodriver hazard the e2e suite documents).
+# ===========================================================================
+_NONCE = "stealth-nonce-4d1f"
+
+
+async def _run_cdp_transcript(tab) -> list[dict]:
+    """Execute the exact ordered prerequisite CDP sequence via the project's own
+    nodriver ``tab.send(uc.cdp.*)`` seam; return an ordered method/result log."""
+    transcript: list[dict] = []
+
+    async def step(method: str, coro, checker=None):
+        entry = {"method": method}
+        try:
+            res = await tab.send(coro)
+            entry["ok"] = True if checker is None else bool(checker(res))
+        except Exception as exc:  # record, never swallow silently
+            entry["ok"] = False
+            entry["error"] = str(exc)
+        transcript.append(entry)
+
+    await step("Runtime.enable", uc.cdp.runtime.enable())
+    await step("Page.enable", uc.cdp.page.enable())
+    await step("Network.enable", uc.cdp.network.enable())
+    await step("DOM.getDocument", uc.cdp.dom.get_document())
+    await step(
+        "Runtime.evaluate",
+        uc.cdp.runtime.evaluate(expression=f"'{_NONCE}'", return_by_value=True),
+        checker=lambda r: bool(r and r[0] and r[0].value == _NONCE),
+    )
+    await step(
+        "Page.captureScreenshot",
+        uc.cdp.page.capture_screenshot(),
+        checker=lambda r: bool(r),
+    )
+    return transcript
+
+
+async def _collect_probe(base_url: str, *, control: bool) -> dict:
+    """Spawn (product or neutralized-filter control), release the armed probe after
+    the ordered transcript, and return a plain-data record."""
+    from stealth_chrome_devtools_mcp.embedded import browser_manager as _bm_mod
+    from stealth_chrome_devtools_mcp.embedded.platform_utils import (
+        check_browser_executable,
+    )
+
+    spawn = get_fn("spawn_browser")
+    close = get_fn("close_instance")
+    bm = server_mod.browser_manager
+
+    patched_orig = None
+    if control:
+        # THE single intentional treatment: neutralize the stealth arg-filter so
+        # --enable-automation survives to Chrome. Everything else is the identical
+        # product spawn path (BrowserManager.spawn_browser -> uc.start). Restored
+        # in finally — never leaks into the product run.
+        patched_orig = _bm_mod.merge_browser_args
+        _bm_mod.merge_browser_args = lambda args: (list(args or []), [])
+
+    iid = None
+    try:
+        browser_args = ["--enable-automation"] if control else []
+        spawned = await spawn(
+            headless=True,
+            viewport_width=1280,
+            viewport_height=800,
+            browser_args=browser_args,
+            **sandbox_kwargs(),
+        )
+        iid = spawned["instance_id"]
+        url = f"{base_url}/stealth_probe.html"
+        await navigate_and_settle(iid, url)
+        tab = await bm.get_tab(iid)
+
+        # Armed: the probe must NOT have collected before we release it.
+        armed = await tab.send(
+            uc.cdp.runtime.evaluate(
+                expression="typeof window.__STEALTH_PROBE_RESULT__",
+                return_by_value=True,
+            )
+        )
+        armed_before_start = bool(armed and armed[0] and armed[0].value == "undefined")
+
+        transcript = await _run_cdp_transcript(tab)
+
+        # One final Runtime.evaluate calls the armed probe's start function.
+        await tab.send(
+            uc.cdp.runtime.evaluate(
+                expression="window.__STEALTH_PROBE_START__()",
+                return_by_value=True,
+                await_promise=True,
+            )
+        )
+        raw = await tab.send(
+            uc.cdp.runtime.evaluate(
+                expression="JSON.stringify(window.__STEALTH_PROBE_RESULT__)",
+                return_by_value=True,
+            )
+        )
+        result = json.loads(raw[0].value)
+        evc = await tab.send(
+            uc.cdp.runtime.evaluate(
+                expression="window.__STEALTH_PROBE_EVENT_COUNT__", return_by_value=True
+            )
+        )
+        event_count = evc[0].value if (evc and evc[0]) else None
+
+        # Process-flag evidence: the actual launched Chrome command line + the
+        # exact binary identity (W2's resolver).
+        browser = await bm.get_browser(iid)
+        cmdline: list[str] = []
+        pid = None
+        proc = getattr(browser, "_process", None)
+        if proc is not None:
+            pid = getattr(proc, "pid", None)
+            try:
+                import psutil
+
+                cmdline = psutil.Process(pid).cmdline()
+            except Exception:  # best-effort evidence, no secrets kept
+                cmdline = []
+        binary = check_browser_executable()
+
+        return {
+            "result": result,
+            "observations": result.get("observations", {}),
+            "transcript": transcript,
+            "armed_before_start": armed_before_start,
+            "event_count": event_count,
+            "cmdline": cmdline,
+            "binary": binary,
+            "headless": True,
+        }
+    finally:
+        if iid is not None:
+            try:
+                await close(instance_id=iid)
+            except Exception:  # teardown best-effort
+                pass
+        if patched_orig is not None:
+            _bm_mod.merge_browser_args = patched_orig
+
+
+def _collect_sync(base_url: str, *, control: bool) -> dict:
+    import asyncio
+
+    return asyncio.run(_collect_probe(base_url, control=control))
+
+
+@pytest.fixture(scope="module")
+def product_probe(fixture_app_server) -> dict:
+    if not CAN_RUN:
+        pytest.skip("Chrome not available or server failed to load")
+    return _collect_sync(fixture_app_server, control=False)
+
+
+@pytest.fixture(scope="module")
+def control_probe(fixture_app_server) -> dict:
+    if not CAN_RUN:
+        pytest.skip("Chrome not available or server failed to load")
+    return _collect_sync(fixture_app_server, control=True)
+
+
+# ===========================================================================
+# Deterministic, browser-free sensitivity controls (run everywhere, gate-safe).
+# For each collector family: the predicate PASSES a good baseline and FAILS when
+# the forbidden observation is introduced — proving the probe has teeth.
+# ===========================================================================
+def _good_baseline() -> dict:
+    os_family = _os_family()
+    platform_value = next(iter(_PLATFORM_ALLOWANCE.get(os_family, {"Win32"})))
+    return {
+        "webdriver": False,
+        "webdriver_typeof": "boolean",
+        "window_chrome_present": True,
+        "window_chrome_members": ["app", "csi", "loadTimes"],
+        "plugins_count": 5,
+        "mime_types_count": 2,
+        "languages": ["en-US", "en"],
+        "language": "en-US",
+        "notification_permission": "default",
+        "permissions_query_notifications": "prompt",
+        "user_agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36"
+        ),
+        "platform": platform_value,
+        "ua_client_hints_present": True,
+        "ua_client_hints_brands": ["Chromium", "Google Chrome", "Not;A=Brand"],
+        "fn_tostring_alert": "function alert() { [native code] }",
+        "fn_tostring_meta": "function toString() { [native code] }",
+        "automation_globals_window": [],
+        "automation_globals_document": [],
+        "outer_width": 1280,
+        "outer_height": 800,
+    }
+
+
+def test_signal_table_is_reviewed_and_nonempty():
+    """The predicate table exists, is versioned, and has unique signal names."""
+    names = [s.name for s in (*GATE_SIGNALS, *XFAIL_SIGNALS)]
+    assert len(names) == len(set(names)), "duplicate signal names"
+    assert len(GATE_SIGNALS) >= 8, "expected a broad gating table"
+    for s in XFAIL_SIGNALS:
+        assert s.finding_id, f"xfail signal {s.name} must carry a finding id"
+
+
+@pytest.mark.parametrize("sig", GATE_SIGNALS, ids=lambda s: s.name)
+def test_gate_predicate_has_teeth(sig: Signal):
+    """Each gating predicate PASSES the good baseline and FAILS the forbidden one."""
+    os_family = _os_family()
+    if not sig.applies(os_family):
+        pytest.skip(f"{sig.name} not applicable on {os_family}")
+    baseline = _good_baseline()
+    assert sig.predicate(baseline, os_family) is True, (
+        f"{sig.name} should PASS a stealthy baseline"
+    )
+    forbidden = {**baseline, **sig.forbidden}
+    assert sig.predicate(forbidden, os_family) is False, (
+        f"{sig.name} did not detect the forbidden observation {sig.forbidden!r}"
+    )
+
+
+@pytest.mark.parametrize("sig", XFAIL_SIGNALS, ids=lambda s: s.name)
+def test_xfail_predicate_has_teeth(sig: Signal):
+    """The pinned-gap predicate is still a real predicate: it PASSES a clean sample
+    and FAILS the forbidden one (so the xfail below is a genuine gap, not a dead
+    assertion)."""
+    os_family = _os_family()
+    baseline = _good_baseline()
+    assert sig.predicate(baseline, os_family) is True
+    assert sig.predicate({**baseline, **sig.forbidden}, os_family) is False
+
+
+def test_result_schema_validator_rejects_bad_shapes():
+    """The closed-schema validator fails on absent, extra, wrong-type, and
+    unserializable fields (deterministic negative controls)."""
+    good = {
+        "schema_version": 1,
+        "started_ms": 1.0,
+        "finished_ms": 2.0,
+        "complete": True,
+        "observations": {"webdriver": False},
+    }
+    validate_result_schema(good)  # baseline passes
+
+    with pytest.raises(AssertionError):  # absent field
+        validate_result_schema({k: v for k, v in good.items() if k != "complete"})
+    with pytest.raises(AssertionError):  # extra field
+        validate_result_schema({**good, "surprise": 1})
+    with pytest.raises(AssertionError):  # not complete
+        validate_result_schema({**good, "complete": False})
+    with pytest.raises(AssertionError):  # wrong schema version
+        validate_result_schema({**good, "schema_version": 2})
+    with pytest.raises(AssertionError):  # finished before started
+        validate_result_schema({**good, "started_ms": 5.0, "finished_ms": 1.0})
+    with pytest.raises((AssertionError, TypeError)):  # unserializable field
+        validate_result_schema({**good, "observations": {"x": {1, 2, 3}}})
+
+
+# ===========================================================================
+# Offline GATING tier — real headless Chrome.
+# ===========================================================================
+def _chrome_version_from_ua(ua: str) -> str | None:
+    m = re.search(r"(?:Headless)?Chrome/([\d.]+)", ua or "")
+    return m.group(1) if m else None
+
+
+def _write_artifact(product: dict, control: dict, predicate_outcomes: dict, path):
+    """Write the redacted result artifact: schema version, OS/arch, exact Chrome
+    identity, raw observations, predicate outcomes, and control outcomes. No
+    secrets and no local profile contents (cmdline/profile paths are NOT included;
+    only the binary identity and derived booleans)."""
+    obs = product["observations"]
+    artifact = {
+        "schema_version": RESULT_SCHEMA_VERSION,
+        "os": _os_family(),
+        "architecture": _platform.machine(),
+        "chrome": {
+            "binary": product["binary"],
+            "version": _chrome_version_from_ua(obs.get("user_agent", "")),
+        },
+        "headless": product["headless"],
+        "observations": obs,
+        "predicate_outcomes": predicate_outcomes,
+        "control_outcomes": {
+            "vanilla_webdriver": control["observations"].get("webdriver"),
+            "vanilla_detected": _p_webdriver_absent(
+                control["observations"], _os_family()
+            )
+            is False,
+        },
+        "cdp_transcript": [e["method"] for e in product["transcript"]],
+    }
+    json.dumps(artifact)  # must be serializable
+    path.write_text(json.dumps(artifact, indent=2, sort_keys=True), encoding="utf-8")
+    return artifact
+
+
+def test_product_offline_stealth_gate(product_probe, control_probe, tmp_path):
+    """Product passes every gating predicate; schema/transcript/process evidence and
+    the vanilla-control sensitivity all validate; a redacted artifact is written."""
+    os_family = _os_family()
+    product = product_probe
+    obs = product["observations"]
+
+    # Closed-schema validation of the real published result.
+    validate_result_schema(product["result"])
+
+    # Armed-until-released + exactly one completion publication (no duplicate).
+    assert product["armed_before_start"] is True, "probe collected before release"
+    assert product["event_count"] == 1, product["event_count"]
+
+    # Ordered CDP prerequisite transcript: exact order, all successful.
+    methods = tuple(e["method"] for e in product["transcript"])
+    assert methods == CDP_PREREQUISITE_METHODS, methods
+    assert all(e.get("ok") for e in product["transcript"]), product["transcript"]
+
+    # Every applicable gating predicate must PASS on the product.
+    predicate_outcomes: dict[str, bool] = {}
+    failures = []
+    for sig in GATE_SIGNALS:
+        if not sig.applies(os_family):
+            continue
+        ok = sig.predicate(obs, os_family)
+        predicate_outcomes[sig.name] = ok
+        if not ok:
+            failures.append((sig.name, {k: obs.get(k) for k in sig.obs_keys}))
+    assert not failures, f"product failed gating stealth predicate(s): {failures}"
+
+    # Process-flag evidence: the launched Chrome must not carry automation-revealing
+    # flags, and its binary is W2's exact resolved executable.
+    cmdline = product["cmdline"]
+    assert cmdline, "no Chrome command line captured for process evidence"
+    assert cmdline[0] == product["binary"], (cmdline[0], product["binary"])
+    for forbidden_flag in ("--enable-automation", "--test-type"):
+        assert not any(a == forbidden_flag for a in cmdline), (forbidden_flag, cmdline)
+
+    # Vanilla-control sensitivity: the deliberately non-stealth spawn (same product
+    # path, stealth arg-filter neutralized) MUST be detected. If it is NOT detected,
+    # the probe is worthless — fail. Config identity: same binary, same headless
+    # mode; the only intentional difference is --enable-automation.
+    control = control_probe
+    cobs = control["observations"]
+    assert _p_webdriver_absent(cobs, os_family) is False, (
+        "vanilla control was NOT detected (navigator.webdriver not true) — "
+        "the probe has no teeth against a real non-stealth browser"
+    )
+    assert control["binary"] == product["binary"], "control/product binary identity"
+    assert control["headless"] == product["headless"], "control/product headless parity"
+    assert any(a == "--enable-automation" for a in control["cmdline"]), (
+        "control must carry the intentional automation treatment"
+    )
+    # Config identity also covers the ordered CDP sequence: the control ran the
+    # same armed-then-released prerequisite transcript before collection (§2.4:
+    # "for both the MCP browser and vanilla control, execute and assert this exact
+    # successful method sequence before release").
+    assert control["armed_before_start"] is True, "control probe collected pre-release"
+    control_methods = tuple(e["method"] for e in control["transcript"])
+    assert control_methods == CDP_PREREQUISITE_METHODS, control_methods
+    assert all(e.get("ok") for e in control["transcript"]), control["transcript"]
+
+    # Redacted result artifact (validates on re-read; contains no secrets/profile).
+    artifact_dir = os.environ.get("STEALTH_MCP_STEALTH_ARTIFACT_DIR")
+    out_dir = tmp_path if not artifact_dir else Path(artifact_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    artifact_path = out_dir / "stealth_probe_result_v1.json"
+    artifact = _write_artifact(product, control, predicate_outcomes, artifact_path)
+    reloaded = json.loads(artifact_path.read_text(encoding="utf-8"))
+    assert reloaded["schema_version"] == RESULT_SCHEMA_VERSION
+    assert reloaded["control_outcomes"]["vanilla_detected"] is True
+    assert reloaded["chrome"]["binary"] == product["binary"]
+    # No profile path / secret leaked into the artifact.
+    blob = json.dumps(artifact)
+    assert "user-data-dir" not in blob and "user_data_dir" not in blob
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="F-770: headless product UA advertises HeadlessChrome; nodriver's default "
+    "stealth does not mask the UA token. Pinned honestly — an xfailed invariant does "
+    "NOT satisfy the stealth release claim (the headless UA vector remains detectable).",
+)
+def test_product_ua_headless_token_pinned_gap(product_probe):
+    """PINNED GAP (F-770). The headless product still leaks 'HeadlessChrome' in its
+    User-Agent. This assertion is what a fully-stealthy product WOULD satisfy; it
+    fails today, so the strict xfail passes and records the gap without weakening
+    any probe."""
+    obs = product_probe["observations"]
+    assert _p_ua_no_headless(obs, _os_family()) is True, obs.get("user_agent")
+
+
+# ===========================================================================
+# Online / informational tier (NON-GATING) — marker ``online``.
+# Excluded from every default run and the release gate (``-m "... and not online"``).
+# Asserts ONLY hard invariants; logs the rest; tolerates network flakiness.
+# ===========================================================================
+async def _drive_online(url: str) -> dict:
+    spawn = get_fn("spawn_browser")
+    close = get_fn("close_instance")
+    bm = server_mod.browser_manager
+    spawned = await spawn(headless=True, **sandbox_kwargs())
+    iid = spawned["instance_id"]
+    try:
+        try:
+            await navigate_and_settle(iid, url, timeout=30.0)
+        except Exception as exc:
+            pytest.skip(f"online detector unreachable ({url}): {exc}")
+        tab = await bm.get_tab(iid)
+        await tab.send(uc.cdp.runtime.enable())
+        raw = await tab.send(
+            uc.cdp.runtime.evaluate(
+                expression=(
+                    "JSON.stringify({webdriver: navigator.webdriver, "
+                    "cdc_window: Object.getOwnPropertyNames(window)"
+                    ".filter(k=>/^cdc_|^\\$cdc|webdriver|selenium/i.test(k)), "
+                    "ua: navigator.userAgent})"
+                ),
+                return_by_value=True,
+                await_promise=True,
+            )
+        )
+        return json.loads(raw[0].value)
+    finally:
+        try:
+            await close(instance_id=iid)
+        except Exception:  # teardown best-effort
+            pass
+
+
+@pytest.mark.online
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://abrahamjuliot.github.io/creepjs/",
+        "https://bot.incolumitas.com/",
+    ],
+    ids=["creepjs", "incolumitas"],
+)
+async def test_online_detector_hard_invariants(url):
+    """Non-gating live observation: assert only the hard invariants (webdriver false,
+    no CDP-leak globals); log the rest. Never fails on a vendor detector score."""
+    if not CAN_RUN:
+        pytest.skip("Chrome not available or server failed to load")
+    signals = await _drive_online(url)
+    # Hard invariants only — the same ones the offline tier gates on.
+    assert signals.get("webdriver") is False, f"{url}: webdriver leaked"
+    assert signals.get("cdc_window") == [], f"{url}: CDP-leak global(s) present"
+    # Everything else is informational; surface it for human review, never gate.
+    print(f"[online:{url}] informational: ua={signals.get('ua')!r}")

--- a/tests/test_stealth.py
+++ b/tests/test_stealth.py
@@ -23,14 +23,23 @@ Two tiers (stealth is the one place determinism and realism genuinely conflict):
   gate (``not online``). Drives CreepJS and bot.incolumitas, asserts only the hard
   invariants, logs the rest, and tolerates network flakiness by design.
 
-Design honesty (release-claim integrity): one product predicate — the headless UA
-still advertising ``HeadlessChrome`` — does NOT pass. It is pinned as a strict
-``xfail`` (F-770), NOT hidden by weakening a probe. An xfailed invariant cannot
-satisfy the stealth release claim; see :data:`XFAIL_SIGNALS` and the test docstring.
+Design honesty (release-claim integrity): a known gap is pinned as a strict
+``xfail`` with a finding id, never hidden by weakening a probe — an xfailed
+invariant does NOT satisfy a release claim.
 
-No ``src/`` edits: both browsers spawn through the project's own
-``spawn_browser`` tool; the ordered transcript uses the project's own nodriver
-``tab.send(uc.cdp.*)`` CDP seam; the fixture and env-isolation reuse W1's homes.
+* **F-770 — CLOSED by RELEASE-FIX-D.** The headless User-Agent advertised
+  ``HeadlessChrome`` on every vector that reaches a site. ``src/`` now supplies a
+  masked default ``--user-agent`` from ``platform_utils.merge_browser_args``, so
+  the signal moved into the GATING table and the xfail was deleted rather than
+  relaxed. The four measured vectors are documented at :data:`F770_VECTORS`.
+* **F-774 — OPEN, opened by that fix.** A ``--user-agent`` override makes Chrome
+  blank the high-entropy UA client hints; the low-entropy ``sec-ch-ua*`` headers
+  on the wire stay correct. Recorded in :data:`XFAIL_SIGNALS` with the measured
+  before/after, not papered over.
+
+Both browsers spawn through the project's own ``spawn_browser`` tool; the ordered
+transcript uses the project's own nodriver ``tab.send(uc.cdp.*)`` CDP seam; the
+fixture and env-isolation reuse W1's homes.
 """
 
 from __future__ import annotations
@@ -190,6 +199,58 @@ def _p_ua_no_headless(obs: dict, _os: str) -> bool:
     return "headlesschrome" not in str(obs.get("user_agent") or "").lower()
 
 
+def _p_http_ua_no_headless(obs: dict, _os: str) -> bool:
+    # F-770 V2 — the header the fixture server actually READ off the wire. A
+    # page-level override can satisfy _p_ua_no_headless while this still leaks.
+    header = obs.get("http_user_agent")
+    if not isinstance(header, str) or not header or header.startswith("ERROR:"):
+        return False
+    return "headlesschrome" not in header.lower()
+
+
+def _p_ua_matches_http_header(obs: dict, _os: str) -> bool:
+    # Coherence: a page UA that disagrees with the wire UA is a mismatch no real
+    # browser produces — a sharper tell than the honest headless token.
+    page = obs.get("user_agent")
+    header = obs.get("http_user_agent")
+    return bool(page) and isinstance(header, str) and header == page
+
+
+def _ua_major(user_agent: object) -> str | None:
+    m = re.search(r"(?:Headless)?Chrome/(\d+)\.", str(user_agent or ""))
+    return m.group(1) if m else None
+
+
+def _p_ua_client_hints_high_entropy_populated(obs: dict, _os: str) -> bool:
+    # F-774: a real Chrome fills every high-entropy hint. Chrome blanks them
+    # whenever a --user-agent override is active, which is how the F-770 mask
+    # works — see XFAIL_SIGNALS.
+    high_entropy = obs.get("ua_client_hints_high_entropy")
+    if not isinstance(high_entropy, dict):
+        return False
+    return all(
+        bool(high_entropy.get(key))
+        for key in ("architecture", "bitness", "uaFullVersion", "fullVersionList")
+    )
+
+
+def _p_ua_major_matches_client_hints(obs: dict, _os: str) -> bool:
+    # Coherence: the UA's major version must be one the UA client hints agree
+    # with. Masking the token while claiming a version sec-ch-ua contradicts
+    # would replace one tell with a worse one.
+    major = _ua_major(obs.get("user_agent"))
+    high_entropy = obs.get("ua_client_hints_high_entropy")
+    if not major or not isinstance(high_entropy, dict):
+        return False
+    majors = {
+        str(brand.get("version", "")).split(".")[0]
+        for brand in (high_entropy.get("brands") or [])
+        if isinstance(brand, dict)
+    }
+    majors.discard("")
+    return bool(majors) and major in majors
+
+
 # ── Gating table: the product MUST pass every applicable row ────────────────
 GATE_SIGNALS: tuple[Signal, ...] = (
     Signal(
@@ -266,21 +327,89 @@ GATE_SIGNALS: tuple[Signal, ...] = (
         {"outer_width": 0, "outer_height": 0},
         "window.outerWidth/outerHeight are non-zero (0x0 is a headless tell).",
     ),
-)
-
-# ── xfail table: a KNOWN product stealth gap, pinned honestly (never weakened) ─
-# F-770: under headless (the configuration the offline gate runs), the product's
-# default User-Agent still advertises "HeadlessChrome". The product ships nodriver
-# and does NOT mask the UA token, so this basic bot tell leaks. Pinned as a strict
-# xfail — an xfailed invariant does NOT satisfy the stealth release claim.
-XFAIL_SIGNALS: tuple[Signal, ...] = (
+    # ── F-770, closed by RELEASE-FIX-D. These four rows were a strict xfail until
+    # the product supplied a masked default --user-agent; they are GATING now, so
+    # a regression that reintroduces the headless token fails the release gate.
+    # An xfailed invariant never satisfied the stealth claim; these do.
     Signal(
         "ua_no_headless_token",
         ("user_agent",),
         _p_ua_no_headless,
         {"user_agent": "Mozilla/5.0 ... HeadlessChrome/150.0.0.0 Safari/537.36"},
-        "navigator.userAgent does not advertise HeadlessChrome.",
-        finding_id="F-770",
+        "navigator.userAgent does not advertise HeadlessChrome (F-770 V1).",
+    ),
+    Signal(
+        "http_ua_no_headless_token",
+        ("http_user_agent",),
+        _p_http_ua_no_headless,
+        {"http_user_agent": "Mozilla/5.0 ... HeadlessChrome/150.0.0.0 Safari/537.36"},
+        "The User-Agent header the SERVER received does not advertise "
+        "HeadlessChrome (F-770 V2 — the vector a bot check reads first).",
+    ),
+    Signal(
+        "ua_matches_http_header",
+        ("user_agent", "http_user_agent"),
+        _p_ua_matches_http_header,
+        {"http_user_agent": "Mozilla/5.0 ... HeadlessChrome/150.0.0.0 Safari/537.36"},
+        "The page User-Agent and the wire User-Agent are the same string "
+        "(a page-only override that leaves the header leaking is a worse tell).",
+    ),
+    Signal(
+        "ua_major_matches_client_hints",
+        ("user_agent", "ua_client_hints_high_entropy"),
+        _p_ua_major_matches_client_hints,
+        {
+            "user_agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36"
+            )
+        },
+        "The masked User-Agent's major version is one the UA client hints agree "
+        "with (masking coherently, not swapping one tell for a worse one).",
+    ),
+)
+
+# ── xfail table: a KNOWN product stealth gap, pinned honestly (never weakened) ─
+# F-774 (opened by RELEASE-FIX-D, measured not assumed): whenever a --user-agent
+# override is active — which is exactly how the F-770 mask works — Chrome BLANKS
+# the high-entropy UA client hints it cannot derive from the override string.
+# Measured on Chrome 150, headless, with and without the mask:
+#
+#   architecture     "x86"              -> ""
+#   bitness          "64"               -> ""
+#   platformVersion  "19.0.0"           -> ""
+#   uaFullVersion    "150.0.7871.186"   -> ""
+#   fullVersionList  [3 brands]         -> []
+#   brands / mobile / platform          UNCHANGED and still correct
+#
+# So the LOW-entropy hints — the `sec-ch-ua`, `sec-ch-ua-mobile` and
+# `sec-ch-ua-platform` headers Chrome actually puts on the wire by default —
+# stay coherent with the masked UA; only the JS-only high-entropy set, which a
+# site must ask for explicitly, comes back empty. That is a strictly smaller and
+# strictly more expensive tell than the `HeadlessChrome` token it replaces (one
+# server-side substring test, before any JavaScript runs), but it IS a new tell
+# and is recorded here rather than papered over. Fixing it needs
+# Emulation.setUserAgentOverride's userAgentMetadata, which is per-target and
+# therefore a different mechanism with its own hazards — deliberately out of
+# FIX-D's scope. Strict xfail: if it is ever fixed, or Chrome changes, this
+# XPASSes and turns the suite red, forcing the review.
+XFAIL_SIGNALS: tuple[Signal, ...] = (
+    Signal(
+        "ua_client_hints_high_entropy_populated",
+        ("ua_client_hints_high_entropy",),
+        _p_ua_client_hints_high_entropy_populated,
+        {
+            "ua_client_hints_high_entropy": {
+                "brands": [{"brand": "Google Chrome", "version": "150"}],
+                "architecture": "",
+                "bitness": "",
+                "uaFullVersion": "",
+                "fullVersionList": [],
+            }
+        },
+        "getHighEntropyValues() returns populated architecture/bitness/"
+        "uaFullVersion/fullVersionList, as an unmasked Chrome does.",
+        finding_id="F-774",
     ),
 )
 
@@ -509,6 +638,97 @@ def control_probe(fixture_app_server) -> dict:
     return _collect_sync(fixture_app_server, control=True)
 
 
+# ── F-770 coverage facts: a LATER tab, and an explicit caller User-Agent ──────
+# The masked default is a launch flag, so it is process-wide by construction —
+# but "by construction" is exactly the reasoning FIX-C's re-arm defect punished,
+# so both properties are pinned against a real browser instead of argued.
+_EXPLICIT_UA = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/123.0.0.0 Safari/537.36 fix-d-explicit"
+)
+
+
+async def _read_tab_ua(tab) -> str:
+    raw = await tab.send(
+        uc.cdp.runtime.evaluate(expression="navigator.userAgent", return_by_value=True)
+    )
+    return raw[0].value if (raw and raw[0]) else ""
+
+
+async def _read_tab_http_ua(tab, base_url: str) -> str:
+    raw = await tab.send(
+        uc.cdp.runtime.evaluate(
+            expression=(
+                f"fetch('{base_url}/api/echo', {{method: 'POST', body: 'tab-probe'}})"
+                ".then(r => r.json()).then(j => j.headers['user-agent'])"
+            ),
+            return_by_value=True,
+            await_promise=True,
+        )
+    )
+    return raw[0].value if (raw and raw[0]) else ""
+
+
+async def _collect_ua_facts(base_url: str, *, user_agent: str | None) -> dict:
+    """Spawn once, then read the User-Agent from the spawn tab AND from a tab
+    created afterwards through the product's own ``new_tab`` tool."""
+    await warmup_once()
+    spawn = get_fn("spawn_browser")
+    close = get_fn("close_instance")
+    open_tab = get_fn("new_tab")
+    bm = server_mod.browser_manager
+
+    explicit = {"user_agent": user_agent} if user_agent else {}
+    url = f"{base_url}/stealth_probe.html"
+    iid = None
+    try:
+        spawned = await spawn(headless=True, **explicit, **sandbox_kwargs())
+        iid = spawned["instance_id"]
+        await navigate_and_settle(iid, url)
+        spawn_tab = await bm.get_tab(iid)
+        created = await open_tab(instance_id=iid, url=url)
+        browser = await bm.get_browser(iid)
+        later_tab = next(
+            (t for t in browser.tabs if str(t.target.target_id) == created["tab_id"]),
+            None,
+        )
+        assert later_tab is not None, (
+            created["tab_id"],
+            [str(t.target.target_id) for t in browser.tabs],
+        )
+        return {
+            "spawn_tab_ua": await _read_tab_ua(spawn_tab),
+            "new_tab_ua": await _read_tab_ua(later_tab),
+            "new_tab_http_ua": await _read_tab_http_ua(later_tab, base_url),
+        }
+    finally:
+        if iid is not None:
+            try:
+                await close(instance_id=iid)
+            except Exception:  # teardown best-effort
+                pass
+
+
+def _collect_ua_facts_sync(base_url: str, *, user_agent: str | None) -> dict:
+    import asyncio
+
+    return asyncio.run(_collect_ua_facts(base_url, user_agent=user_agent))
+
+
+@pytest.fixture(scope="module")
+def ua_default_facts(fixture_app_server) -> dict:
+    if not CAN_RUN:
+        pytest.skip("Chrome not available or server failed to load")
+    return _collect_ua_facts_sync(fixture_app_server, user_agent=None)
+
+
+@pytest.fixture(scope="module")
+def ua_explicit_facts(fixture_app_server) -> dict:
+    if not CAN_RUN:
+        pytest.skip("Chrome not available or server failed to load")
+    return _collect_ua_facts_sync(fixture_app_server, user_agent=_EXPLICIT_UA)
+
+
 # ===========================================================================
 # Deterministic, browser-free sensitivity controls (run everywhere, gate-safe).
 # For each collector family: the predicate PASSES a good baseline and FAILS when
@@ -532,9 +752,36 @@ def _good_baseline() -> dict:
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
             "(KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36"
         ),
+        "http_user_agent": (
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36"
+        ),
+        "http_request_headers": {
+            "user-agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36"
+            ),
+            "sec-ch-ua": '"Not;A=Brand";v="8", "Chromium";v="150", '
+            '"Google Chrome";v="150"',
+        },
         "platform": platform_value,
         "ua_client_hints_present": True,
         "ua_client_hints_brands": ["Chromium", "Google Chrome", "Not;A=Brand"],
+        "ua_client_hints_high_entropy": {
+            "brands": [
+                {"brand": "Not;A=Brand", "version": "8"},
+                {"brand": "Chromium", "version": "150"},
+                {"brand": "Google Chrome", "version": "150"},
+            ],
+            "fullVersionList": [
+                {"brand": "Google Chrome", "version": "150.0.7871.186"}
+            ],
+            "uaFullVersion": "150.0.7871.186",
+            "architecture": "x86",
+            "bitness": "64",
+            "platform": "Windows",
+            "platformVersion": "19.0.0",
+        },
         "fn_tostring_alert": "function alert() { [native code] }",
         "fn_tostring_meta": "function toString() { [native code] }",
         "automation_globals_window": [],
@@ -545,10 +792,18 @@ def _good_baseline() -> dict:
 
 
 def test_signal_table_is_reviewed_and_nonempty():
-    """The predicate table exists, is versioned, and has unique signal names."""
+    """The predicate table exists, is versioned, and has unique signal names.
+
+    Every row is GATING: RELEASE-FIX-D closed F-770, the last xfailed signal, so
+    the table no longer carries an xfail tier. A future known gap re-adds one
+    deliberately (with a finding id) — it is never created by weakening a row.
+    """
     names = [s.name for s in (*GATE_SIGNALS, *XFAIL_SIGNALS)]
     assert len(names) == len(set(names)), "duplicate signal names"
     assert len(GATE_SIGNALS) >= 8, "expected a broad gating table"
+    assert {"ua_no_headless_token", "http_ua_no_headless_token"} <= set(names), (
+        "F-770's page AND wire User-Agent signals must both gate"
+    )
     for s in XFAIL_SIGNALS:
         assert s.finding_id, f"xfail signal {s.name} must carry a finding id"
 
@@ -752,6 +1007,12 @@ def test_product_offline_stealth_gate(product_probe, control_probe, tmp_path):
     for forbidden_flag in ("--enable-automation", "--test-type"):
         assert not any(a == forbidden_flag for a in cmdline), (forbidden_flag, cmdline)
 
+    # F-770 vector V4 — the CDP-level User-Agent. Not a page observation, so it is
+    # asserted here rather than through the predicate table. The masked
+    # --user-agent= flag is process-wide, so it reaches this value too.
+    cdp_ua = product["cdp_user_agent"]
+    assert isinstance(cdp_ua, str) and "headlesschrome" not in cdp_ua.lower(), cdp_ua
+
     # Vanilla-control sensitivity: the deliberately non-stealth spawn (same product
     # path, stealth arg-filter neutralized) MUST be detected. If it is NOT detected,
     # the probe is worthless — fail. Config identity: same binary, same headless
@@ -834,9 +1095,14 @@ def test_f770_ua_vectors_are_measured(product_probe, control_probe):
         assert isinstance(v3["high_entropy"], dict), (
             f"{label}: getHighEntropyValues unmeasured: {v3['high_entropy']!r}"
         )
-        assert v3["high_entropy"].get("uaFullVersion") or v3["high_entropy"].get(
-            "fullVersionList"
-        ), v3["high_entropy"]
+        # ``brands`` is the part the V3 coherence gate reads and it is populated
+        # on both browsers. Whether the rest of the high-entropy set is populated
+        # is F-774's subject, not a measurability question — asserting it here
+        # would be judging, which this test deliberately does not do.
+        assert v3["high_entropy"].get("brands"), v3["high_entropy"]
+        assert v3["sec_ch_ua_header"], (
+            f"{label}: the fixture server saw no sec-ch-ua header: {v3!r}"
+        )
 
         v4 = readings["V4_cdp_browser_get_version"]["value"]
         assert isinstance(v4, str) and "Mozilla/5.0" in v4, v4
@@ -844,17 +1110,83 @@ def test_f770_ua_vectors_are_measured(product_probe, control_probe):
 
 @pytest.mark.xfail(
     strict=True,
-    reason="F-770: headless product UA advertises HeadlessChrome; nodriver's default "
-    "stealth does not mask the UA token. Pinned honestly — an xfailed invariant does "
-    "NOT satisfy the stealth release claim (the headless UA vector remains detectable).",
+    reason="F-774: Chrome blanks the high-entropy UA client hints (architecture, "
+    "bitness, platformVersion, uaFullVersion, fullVersionList) whenever a "
+    "--user-agent override is active, which is how the F-770 mask works. The "
+    "low-entropy sec-ch-ua* headers on the wire stay correct. Recorded honestly, "
+    "not papered over: fixing it needs Emulation.setUserAgentOverride's "
+    "userAgentMetadata, a per-target mechanism outside RELEASE-FIX-D's scope.",
 )
-def test_product_ua_headless_token_pinned_gap(product_probe):
-    """PINNED GAP (F-770). The headless product still leaks 'HeadlessChrome' in its
-    User-Agent. This assertion is what a fully-stealthy product WOULD satisfy; it
-    fails today, so the strict xfail passes and records the gap without weakening
-    any probe."""
+def test_product_ua_client_hints_high_entropy_pinned_gap(product_probe):
+    """PINNED GAP (F-774). This assertion is what a fully-coherent masked browser
+    WOULD satisfy. It fails today, so the strict xfail passes and records the
+    gap — no probe is weakened, and a future fix turns the suite red."""
     obs = product_probe["observations"]
-    assert _p_ua_no_headless(obs, _os_family()) is True, obs.get("user_agent")
+    assert _p_ua_client_hints_high_entropy_populated(obs, _os_family()) is True, (
+        obs.get("ua_client_hints_high_entropy")
+    )
+
+
+def test_f770_a_later_tab_is_covered(ua_default_facts):
+    """F-770: a tab created AFTER spawn is masked too, page and wire.
+
+    A per-target CDP override would satisfy the spawn tab and leak on the next
+    one (the failure mode that made FIX-C's ``create_hook`` re-arm necessary).
+    This is what makes the launch-flag mechanism the right one, so it is pinned.
+    """
+    facts = ua_default_facts
+    assert "HeadlessChrome" not in facts["spawn_tab_ua"], facts["spawn_tab_ua"]
+    assert "HeadlessChrome" not in facts["new_tab_ua"], facts["new_tab_ua"]
+    assert facts["new_tab_ua"] == facts["spawn_tab_ua"], facts
+    assert "HeadlessChrome" not in facts["new_tab_http_ua"], facts["new_tab_http_ua"]
+    assert facts["new_tab_http_ua"] == facts["new_tab_ua"], facts
+
+
+def test_f770_explicit_user_agent_still_wins(ua_explicit_facts):
+    """F-770: the masked default NEVER overrides a caller-supplied user_agent."""
+    facts = ua_explicit_facts
+    assert facts["spawn_tab_ua"] == _EXPLICIT_UA, facts["spawn_tab_ua"]
+    assert facts["new_tab_ua"] == _EXPLICIT_UA, facts["new_tab_ua"]
+    assert facts["new_tab_http_ua"] == _EXPLICIT_UA, facts["new_tab_http_ua"]
+
+
+def test_f770_product_masks_ua_while_control_still_leaks(product_probe, control_probe):
+    """F-770 D2 — the fix is real AND the suite that judges it is still sensitive.
+
+    W4's stealth suite is only worth anything because a deliberately non-stealth
+    control still FAILS the probes. The control is built by neutralizing
+    ``platform_utils.merge_browser_args``, which is exactly where FIX-D's masked
+    default ``--user-agent`` is applied — so the control genuinely does not get
+    it, and this differential proves that rather than assuming it:
+
+    * the control's User-Agent STILL advertises HeadlessChrome (so
+      ``vanilla_detected`` is not quietly going false, and the whole suite has
+      not become vacuous);
+    * the product's User-Agent is the control's with exactly the
+      ``HeadlessChrome`` token replaced by ``Chrome`` — byte-identical
+      otherwise. That equality is the coherence contract: the mask is Chrome's
+      own reduced User-Agent for this binary, not a plausible-looking string
+      that a platform-token or version mismatch would betray.
+    """
+    control_ua = control_probe["observations"]["user_agent"]
+    product_ua = product_probe["observations"]["user_agent"]
+
+    assert "HeadlessChrome" in control_ua, (
+        "the vanilla control no longer leaks the headless token — the masking was "
+        f"applied outside the seam the control neutralizes: {control_ua!r}"
+    )
+    assert control_ua.replace("HeadlessChrome", "Chrome") == product_ua, (
+        f"masked UA is not the browser's own UA minus the headless token\n"
+        f"  control: {control_ua!r}\n  product: {product_ua!r}"
+    )
+    # ...and the same differential holds on the wire, not just in the page.
+    assert "HeadlessChrome" in control_probe["observations"]["http_user_agent"]
+    assert (
+        control_probe["observations"]["http_user_agent"].replace(
+            "HeadlessChrome", "Chrome"
+        )
+        == product_probe["observations"]["http_user_agent"]
+    )
 
 
 # ===========================================================================

--- a/tests/test_stealth.py
+++ b/tests/test_stealth.py
@@ -455,6 +455,11 @@ async def _collect_probe(base_url: str, *, control: bool) -> dict:
                 cmdline = []
         binary = check_browser_executable()
 
+        # F-770 vector V4 -- the CDP-level User-Agent (Browser.getVersion). Not a
+        # page observation, so it is collected here alongside the process evidence.
+        version = await tab.send(uc.cdp.browser.get_version())
+        cdp_user_agent = version[3] if version and len(version) > 3 else None
+
         return {
             "result": result,
             "observations": result.get("observations", {}),
@@ -463,6 +468,7 @@ async def _collect_probe(base_url: str, *, control: bool) -> dict:
             "event_count": event_count,
             "cmdline": cmdline,
             "binary": binary,
+            "cdp_user_agent": cdp_user_agent,
             "headless": True,
         }
     finally:
@@ -600,6 +606,67 @@ def _chrome_version_from_ua(ua: str) -> str | None:
     return m.group(1) if m else None
 
 
+# ===========================================================================
+# F-770 — the four User-Agent leak vectors (plan_RELEASE_FIX_D D0).
+#
+# "the UA leaks" is not precise enough to fix: a pre-launch ``--user-agent=``
+# flag and a post-launch ``Emulation.setUserAgentOverride`` cover DIFFERENT
+# subsets of the surface, so each vector is measured separately on every OS cell
+# BEFORE a masking mechanism is chosen. (RELEASE-FIX-C shipped on a strongly
+# evidenced but unmeasured hypothesis and was wrong; D0 exists so FIX-D cannot
+# repeat that.)
+#
+#   V1  navigator.userAgent                       page
+#   V2  the HTTP ``User-Agent`` request header    wire — what the fixture server
+#       the fixture server actually received           READ, not what the page says
+#   V3  navigator.userAgentData brands +          page — built from Chrome's own
+#       getHighEntropyValues()                         version info
+#   V4  Browser.getVersion() -> userAgent         CDP
+#
+# The table is a MEASUREMENT, not a judgement: :func:`f770_vector_readings`
+# records each vector's raw value and whether it contains the ``HeadlessChrome``
+# token. The gating verdict lives in :data:`GATE_SIGNALS`.
+# ===========================================================================
+F770_VECTORS: tuple[str, ...] = (
+    "V1_navigator_user_agent",
+    "V2_http_request_header",
+    "V3_ua_client_hints",
+    "V4_cdp_browser_get_version",
+)
+
+_HEADLESS_TOKEN = "headlesschrome"
+
+
+def _leaks_headless(value: object) -> bool:
+    """True when the serialized reading contains the ``HeadlessChrome`` token."""
+    return _HEADLESS_TOKEN in json.dumps(value, default=str).lower()
+
+
+def f770_vector_readings(probe: dict) -> dict[str, dict]:
+    """Measure the four F-770 UA vectors on one collected probe.
+
+    Returns ``{vector: {"value": <raw reading>, "leaks": bool}}``. Pure — it
+    judges nothing beyond "does this reading contain the token".
+    """
+    obs = probe["observations"]
+    readings: dict[str, object] = {
+        "V1_navigator_user_agent": obs.get("user_agent"),
+        "V2_http_request_header": obs.get("http_user_agent"),
+        "V3_ua_client_hints": {
+            "brands": obs.get("ua_client_hints_brands"),
+            "high_entropy": obs.get("ua_client_hints_high_entropy"),
+            "sec_ch_ua_header": (obs.get("http_request_headers") or {}).get("sec-ch-ua")
+            if isinstance(obs.get("http_request_headers"), dict)
+            else None,
+        },
+        "V4_cdp_browser_get_version": probe.get("cdp_user_agent"),
+    }
+    return {
+        name: {"value": value, "leaks": _leaks_headless(value)}
+        for name, value in readings.items()
+    }
+
+
 def _write_artifact(product: dict, control: dict, predicate_outcomes: dict, path):
     """Write the redacted result artifact: schema version, OS/arch, exact Chrome
     identity, raw observations, predicate outcomes, and control outcomes. No
@@ -623,6 +690,13 @@ def _write_artifact(product: dict, control: dict, predicate_outcomes: dict, path
                 control["observations"], _os_family()
             )
             is False,
+        },
+        # F-770 D0: the per-vector UA measurement for BOTH browsers. The control's
+        # readings are what an unmasked headless Chrome emits on this exact cell,
+        # so the pair is also the differential that proves the fix is real.
+        "f770_ua_vectors": {
+            "product": f770_vector_readings(product),
+            "control": f770_vector_readings(control),
         },
         "cdp_transcript": [e["method"] for e in product["transcript"]],
     }
@@ -695,7 +769,12 @@ def test_product_offline_stealth_gate(product_probe, control_probe, tmp_path):
     assert all(e.get("ok") for e in control["transcript"]), control["transcript"]
 
     # Redacted result artifact (validates on re-read; contains no secrets/profile).
-    artifact_dir = os.environ.get("STEALTH_MCP_STEALTH_ARTIFACT_DIR")
+    # NOT a ``STEALTH_MCP_*`` name on purpose: ``settings._reject_unknown_prefixed_env``
+    # fails ``get_settings()`` for any unknown key in that namespace, so setting
+    # ``STEALTH_MCP_STEALTH_ARTIFACT_DIR`` (this knob's original W4 name) would
+    # detonate the whole backend the moment CI exported it. This is a test-only
+    # artifact path and deliberately lives outside the product's env namespace.
+    artifact_dir = os.environ.get("STEALTH_PROBE_ARTIFACT_DIR")
     out_dir = tmp_path if not artifact_dir else Path(artifact_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     artifact_path = out_dir / "stealth_probe_result_v1.json"
@@ -707,6 +786,52 @@ def test_product_offline_stealth_gate(product_probe, control_probe, tmp_path):
     # No profile path / secret leaked into the artifact.
     blob = json.dumps(artifact)
     assert "user-data-dir" not in blob and "user_data_dir" not in blob
+
+
+def _format_vector_table(label: str, readings: dict[str, dict]) -> str:
+    rows = [f"[F-770:{label}] {_os_family()}/{_platform.machine()}"]
+    for name in F770_VECTORS:
+        entry = readings[name]
+        verdict = "LEAK" if entry["leaks"] else "clean"
+        rows.append(f"  {name:<28} {verdict:<5} {json.dumps(entry['value'])[:220]}")
+    return "\n".join(rows)
+
+
+def test_f770_ua_vectors_are_measured(product_probe, control_probe):
+    """F-770 D0 (plan_RELEASE_FIX_D §2) — MEASURE all four UA vectors, judge none.
+
+    This test's contract is that every vector is actually OBSERVABLE on this cell:
+    a vector that silently stops being collected would make the F-770 gating
+    signals vacuous without turning anything red. It deliberately asserts nothing
+    about whether a vector leaks — that verdict belongs to :data:`GATE_SIGNALS`
+    (and, before RELEASE-FIX-D, to the strict xfail). The measured table is
+    printed and written into the release artifact for every OS cell.
+    """
+    for label, probe in (("product", product_probe), ("control", control_probe)):
+        readings = f770_vector_readings(probe)
+        print(_format_vector_table(label, readings))
+
+        v1 = readings["V1_navigator_user_agent"]["value"]
+        assert isinstance(v1, str) and "Mozilla/5.0" in v1, v1
+
+        v2 = readings["V2_http_request_header"]["value"]
+        assert isinstance(v2, str) and not v2.startswith("ERROR:"), (
+            f"{label}: the fixture server never reported a User-Agent header "
+            f"(V2 unmeasured, so a wire-level leak could not be detected): {v2!r}"
+        )
+        assert "Mozilla/5.0" in v2, v2
+
+        v3 = readings["V3_ua_client_hints"]["value"]
+        assert v3["brands"], f"{label}: userAgentData.brands unmeasured: {v3!r}"
+        assert isinstance(v3["high_entropy"], dict), (
+            f"{label}: getHighEntropyValues unmeasured: {v3['high_entropy']!r}"
+        )
+        assert v3["high_entropy"].get("uaFullVersion") or v3["high_entropy"].get(
+            "fullVersionList"
+        ), v3["high_entropy"]
+
+        v4 = readings["V4_cdp_browser_get_version"]["value"]
+        assert isinstance(v4, str) and "Mozilla/5.0" in v4, v4
 
 
 @pytest.mark.xfail(

--- a/tests/test_stealth.py
+++ b/tests/test_stealth.py
@@ -53,6 +53,7 @@ from e2e_helpers import (
     navigate_and_settle,
     sandbox_kwargs,
     server_mod,
+    warmup_once,
 )
 
 if TYPE_CHECKING:
@@ -377,6 +378,13 @@ async def _collect_probe(base_url: str, *, control: bool) -> dict:
     from stealth_chrome_devtools_mcp.embedded.platform_utils import (
         check_browser_executable,
     )
+
+    # The gate lane (``-m "stealth and not online"``) selects THIS module alone, so
+    # unlike the full integration lane no earlier E2E module has already paid for
+    # Chrome's cold start. nodriver gives the debug port only a few seconds, and a
+    # first launch on a cold Linux/macOS runner overruns it ("Failed to connect to
+    # browser"). Reuse the shared idempotent warmup rather than growing a timeout.
+    await warmup_once()
 
     spawn = get_fn("spawn_browser")
     close = get_fn("close_instance")

--- a/tests/test_stealth_args.py
+++ b/tests/test_stealth_args.py
@@ -6,10 +6,27 @@ before they reach the browser, preserving stealth.
 No browser or network required — pure function tests.
 """
 
+import pytest
+
+from stealth_chrome_devtools_mcp.embedded import platform_utils
 from stealth_chrome_devtools_mcp.embedded.platform_utils import (
     filter_stealth_args,
     merge_browser_args,
 )
+
+
+@pytest.fixture(autouse=True)
+def _no_default_user_agent(monkeypatch):
+    """Keep these arg-filter tests hermetic.
+
+    ``merge_browser_args`` also supplies the F-770 masked default
+    ``--user-agent=``, which resolves a real browser (and, off Windows, probes
+    its version through a subprocess). Neither belongs in a "no browser or
+    network required" unit file; the masked-default behaviour is covered in
+    tests/test_platform_utils.py.
+    """
+    monkeypatch.setattr(platform_utils, "check_browser_executable", lambda: None)
+
 
 # ---------------------------------------------------------------------------
 # filter_stealth_args

--- a/tools/corrupt_artifact.py
+++ b/tools/corrupt_artifact.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Make a DAMAGED COPY of a built artifact, for the W3 bite proofs.
+
+plan_RELEASE §2.3 requires proof that ``package-verify``/smoke and the publish
+precondition actually reject a bad artifact — a check nobody has ever seen fail
+is not evidence. This tool produces the damaged input for that negative test.
+
+It is deliberately copy-only: ``--source`` is opened read-only and ``--out`` must
+be a different path, so the run's real hashed artifact can never be mutated by a
+bite proof. No branch, commit, tag, or upload is involved.
+
+Damage modes
+------------
+``--flip-byte``       flip the last byte of the copy (hash changes, nothing else).
+``--drop-member M``   rewrite the copied wheel without member ``M`` (e.g. one
+                      ``embedded/js`` script), so the *membership* rule is tested
+                      independently of the hash rule.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import zipfile
+from pathlib import Path
+
+
+class CorruptionError(Exception):
+    """The requested damage could not be applied."""
+
+
+def flip_last_byte(source: Path, out: Path) -> None:
+    data = bytearray(source.read_bytes())
+    if not data:
+        raise CorruptionError(f"{source} is empty; nothing to flip")
+    data[-1] ^= 0xFF
+    out.write_bytes(bytes(data))
+
+
+def drop_wheel_member(source: Path, out: Path, member: str) -> None:
+    """Copy the wheel omitting ``member`` (and leaving everything else intact)."""
+    with zipfile.ZipFile(source) as src:
+        names = src.namelist()
+        if member not in names:
+            raise CorruptionError(
+                f"{member!r} is not in {source.name}; cannot drop it "
+                f"(the bite proof would prove nothing)"
+            )
+        with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as dst:
+            for info in src.infolist():
+                if info.filename == member:
+                    continue
+                dst.writestr(info, src.read(info.filename))
+
+
+def _guard_copy_only(source: Path, out: Path) -> None:
+    """Refuse anything that could damage the run's real, hashed artifact."""
+    if source == out:
+        raise CorruptionError(
+            "--out must differ from --source: a bite proof never damages "
+            "the run's real artifact"
+        )
+    if not source.is_file():
+        raise CorruptionError(f"source artifact not found: {source}")
+
+
+def _assert_source_intact(source: Path, size_before: int) -> None:
+    if source.stat().st_size != size_before:
+        raise CorruptionError(f"source artifact changed size: {source}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--flip-byte", action="store_true")
+    group.add_argument("--drop-member", default="")
+    args = parser.parse_args(argv)
+
+    source = args.source.absolute()
+    out = args.out.absolute()
+    try:
+        _guard_copy_only(source, out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+
+        before = source.stat().st_size
+        if args.flip_byte:
+            flip_last_byte(source, out)
+            damage = "flipped the last byte"
+        else:
+            drop_wheel_member(source, out, args.drop_member)
+            damage = f"dropped member {args.drop_member!r}"
+        _assert_source_intact(source, before)
+        print(f"corrupt_artifact: {damage} -> {out} (source {source} untouched)")
+    except (CorruptionError, OSError, zipfile.BadZipFile) as exc:
+        print(f"::error title=corrupt-artifact::{exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/install_smoke.py
+++ b/tools/install_smoke.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Install ONE built artifact into a fresh environment and drive W1's journey.
+
+plan_RELEASE W3 (gap G-C). The gate's other lanes test the *source tree*; this
+one tests the *files that will be uploaded to PyPI*. It:
+
+1. re-checks the downloaded artifact's sha256 against the build manifest
+   (``tools/package_verify.py hash-check`` — same code the publish job runs);
+2. creates a fresh virtual environment and installs that artifact **by absolute
+   path with caches disabled**, so nothing can be satisfied from a wheel cache,
+   a site-packages left over from the checkout, or a PyPI download of the same
+   version;
+3. proves the installed distribution is the artifact's: version matches the
+   manifest, the package imports from *that environment's* site-packages, and
+   every ``embedded/js`` script on disk is byte-identical to the hash recorded
+   from the wheel;
+4. resolves that environment's console launcher through W1's existing
+   ``resolve_launcher`` (which uses ``Path.absolute()``, never ``.resolve()`` —
+   resolving would follow a POSIX venv's ``bin/python`` symlink out of the venv);
+5. runs ``tests/release_gate_harness.run_release_gate_journey`` **unchanged**.
+   There is exactly one canonical journey and this is not a second one.
+
+Run from the repository root under an environment that has the test extra
+installed (the harness needs ``fastmcp`` and ``psutil`` client-side); the
+artifact under test supplies its own copies inside the fresh venv.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+# The harness and its e2e_helpers seam live in tests/ (not an installed package).
+for _extra_path in (REPO_ROOT, REPO_ROOT / "tests"):
+    if str(_extra_path) not in sys.path:
+        sys.path.insert(0, str(_extra_path))
+
+import package_verify  # noqa: E402  PERMANENT(sys.path bootstrap above must run first)
+
+from release_gate_harness import (  # noqa: E402  PERMANENT(sys.path bootstrap above must run first)
+    gate_work_dir,
+    resolve_launcher,
+    run_release_gate_journey,
+)
+
+RESULT_SCHEMA_VERSION = 1
+INSTALL_TIMEOUT = 900
+PROBE_TIMEOUT = 180
+
+# Printed by the in-venv probe as one JSON line; keeping the marker explicit
+# means arbitrary installer chatter on stdout cannot be mistaken for the result.
+_PROBE_MARKER = "__INSTALL_SMOKE_PROBE__"
+
+_PROBE_SOURCE = f"""
+import hashlib, importlib.metadata, json, sys
+from pathlib import Path
+
+import stealth_chrome_devtools_mcp as pkg
+
+root = Path(pkg.__file__).parent
+js_dir = root / "embedded" / "js"
+payload = {{
+    "version": importlib.metadata.version("{package_verify.DIST_NAME}"),
+    "package_root": str(root),
+    "executable": sys.executable,
+    "js": {{
+        p.name: hashlib.sha256(p.read_bytes()).hexdigest()
+        for p in sorted(js_dir.glob("*.js"))
+    }},
+}}
+print("{_PROBE_MARKER}" + json.dumps(payload))
+"""
+
+
+class SmokeError(Exception):
+    """A smoke precondition failed; the message is the human-readable reason."""
+
+
+def _run(cmd: list[str], *, timeout: int, cwd: Path | None = None) -> str:
+    """Run a fully-resolved command, echoing it, and return stdout."""
+    print(f"$ {' '.join(cmd)}")
+    completed = subprocess.run(  # noqa: S603  PERMANENT(CI tool; argv is built from resolved absolute paths, never a shell string)
+        cmd,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd=str(cwd) if cwd else None,
+    )
+    if completed.stdout:
+        print(completed.stdout)
+    if completed.stderr:
+        print(completed.stderr, file=sys.stderr)
+    if completed.returncode != 0:
+        raise SmokeError(
+            f"command failed (exit {completed.returncode}): {' '.join(cmd)}"
+        )
+    return completed.stdout
+
+
+def _uv() -> str:
+    uv = shutil.which("uv")
+    if uv is None:
+        raise SmokeError("uv is not on PATH; the smoke needs it to build the fresh env")
+    return uv
+
+
+def venv_python(venv_dir: Path) -> Path:
+    """The interpreter inside ``venv_dir`` (absolute, not symlink-resolved)."""
+    if sys.platform == "win32":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+def create_fresh_env(venv_dir: Path, python_version: str) -> Path:
+    if venv_dir.exists():
+        shutil.rmtree(venv_dir)
+    _run([_uv(), "venv", "--python", python_version, str(venv_dir)], timeout=300)
+    interpreter = venv_python(venv_dir)
+    if not interpreter.is_file():
+        raise SmokeError(f"fresh environment has no interpreter at {interpreter}")
+    return interpreter
+
+
+def install_artifact(interpreter: Path, artifact: Path) -> None:
+    """Install the LOCAL artifact by absolute path with every cache disabled."""
+    if not artifact.is_absolute():
+        raise SmokeError(f"artifact path must be absolute, got {artifact}")
+    _run(
+        [
+            _uv(),
+            "pip",
+            "install",
+            "--no-cache",
+            "--python",
+            str(interpreter),
+            str(artifact),
+        ],
+        timeout=INSTALL_TIMEOUT,
+    )
+
+
+def probe_installation(interpreter: Path, cwd: Path) -> dict[str, object]:
+    """Ask the fresh environment what it actually installed.
+
+    Runs with ``cwd`` outside the repository so an accidental import of the
+    checkout (rather than site-packages) cannot pass for the installed package.
+    """
+    stdout = _run(
+        [str(interpreter), "-c", _PROBE_SOURCE], timeout=PROBE_TIMEOUT, cwd=cwd
+    )
+    for line in stdout.splitlines():
+        if line.startswith(_PROBE_MARKER):
+            return json.loads(line[len(_PROBE_MARKER) :])
+    raise SmokeError("in-venv probe produced no result line")
+
+
+def check_installation(
+    probe: dict[str, object], manifest: dict[str, object], venv_dir: Path
+) -> list[str]:
+    """Violations of "what is installed IS the artifact" (empty == ok)."""
+    problems: list[str] = []
+    expected_version = str(manifest["version"])
+    if probe.get("version") != expected_version:
+        problems.append(
+            f"installed version {probe.get('version')!r} != artifact "
+            f"{expected_version!r}"
+        )
+
+    package_root = Path(str(probe.get("package_root", "")))
+    try:
+        inside = package_root.is_relative_to(venv_dir)
+    except ValueError:  # pragma: no cover - differing drives on Windows
+        inside = False
+    if not inside:
+        problems.append(
+            f"package imports from {package_root} which is OUTSIDE the fresh "
+            f"environment {venv_dir} — the smoke would have tested the checkout"
+        )
+
+    recorded = manifest["package_data"]
+    if not isinstance(recorded, dict):
+        return [*problems, "manifest 'package_data' is not an object"]
+    expected_js = {member.rsplit("/", 1)[-1]: h for member, h in recorded.items()}
+    installed_js = probe.get("js")
+    if not isinstance(installed_js, dict):
+        return [*problems, "probe returned no package-data hashes"]
+    if set(installed_js) != set(expected_js):
+        problems.append(
+            f"installed embedded/js {sorted(installed_js)} != artifact "
+            f"{sorted(expected_js)}"
+        )
+    for name, expected_hash in sorted(expected_js.items()):
+        actual = installed_js.get(name)
+        if actual is None:
+            problems.append(f"package data missing after install: embedded/js/{name}")
+        elif actual != expected_hash:
+            problems.append(
+                f"embedded/js/{name}: installed sha256 {actual} != artifact "
+                f"{expected_hash}"
+            )
+    return problems
+
+
+def select_artifact(dist_dir: Path, kind: str) -> Path:
+    """The one wheel or the one sdist in ``dist_dir``, as an ABSOLUTE path.
+
+    Resolved here rather than in the workflow so no shell has to glob a
+    version-dependent filename and quote a native absolute path on three OSes.
+    """
+    wheel, sdist = package_verify.find_artifacts(dist_dir)
+    return (wheel if kind == "wheel" else sdist).absolute()
+
+
+def smoke(
+    *,
+    dist_dir: Path,
+    manifest_path: Path,
+    kind: str,
+    work_dir: Path,
+    python_version: str,
+) -> dict[str, object]:
+    artifact = select_artifact(dist_dir, kind)
+    manifest = package_verify.load_manifest(manifest_path)
+
+    # (1) The downloaded bytes are the built bytes — the same precondition the
+    # publish job re-runs before it uploads anything.
+    hash_problems = package_verify.check_artifact_hash(artifact, manifest)
+    if hash_problems:
+        raise SmokeError("; ".join(hash_problems))
+
+    work_dir.mkdir(parents=True, exist_ok=True)
+    venv_dir = work_dir / "venv"
+    probe_cwd = work_dir / "probe-cwd"
+    probe_cwd.mkdir(exist_ok=True)
+
+    # (2) fresh env + local install, caches off.
+    interpreter = create_fresh_env(venv_dir, python_version)
+    install_artifact(interpreter, artifact)
+
+    # (3) what landed IS the artifact.
+    probe = probe_installation(interpreter, probe_cwd)
+    problems = check_installation(probe, manifest, venv_dir)
+    if problems:
+        raise SmokeError("; ".join(problems))
+
+    # (4) that environment's console launcher, absolute and unfollowed.
+    launcher = resolve_launcher(interpreter)
+    if not launcher.is_relative_to(venv_dir):
+        raise SmokeError(
+            f"resolved launcher {launcher} is outside the fresh environment {venv_dir}"
+        )
+
+    # (5) W1's canonical journey, unchanged, against that launcher.
+    journey_dir = gate_work_dir(work_dir / "gate")
+    journey_dir.mkdir(parents=True, exist_ok=True)
+    record = asyncio.run(
+        run_release_gate_journey(launcher=launcher, work_dir=journey_dir)
+    )
+    return {
+        "schema_version": RESULT_SCHEMA_VERSION,
+        "artifact": artifact.name,
+        "artifact_kind": kind,
+        "artifact_sha256": package_verify.sha256_file(artifact),
+        "version": manifest["version"],
+        "installed_version": probe.get("version"),
+        "package_root": probe.get("package_root"),
+        "launcher": str(launcher),
+        "venv": str(venv_dir),
+        "python_version": python_version,
+        "journey": record,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Install one built artifact into a fresh env and run W1's journey."
+    )
+    parser.add_argument("--dist-dir", type=Path, default=Path("dist"))
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--kind", choices=("wheel", "sdist"), required=True)
+    parser.add_argument("--work-dir", type=Path, required=True)
+    parser.add_argument("--python", default="3.12")
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    try:
+        result = smoke(
+            dist_dir=args.dist_dir,
+            manifest_path=args.manifest,
+            kind=args.kind,
+            work_dir=args.work_dir,
+            python_version=args.python,
+        )
+    except (SmokeError, package_verify.VerificationError) as exc:
+        print(f"::error title=install-smoke::{exc}", file=sys.stderr)
+        return 1
+
+    text = json.dumps(result, indent=2, sort_keys=True, default=str)
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(text + "\n", encoding="utf-8")
+    print(text)
+    print(f"install-smoke {args.kind}: OK ({result['artifact']})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/install_smoke.py
+++ b/tools/install_smoke.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import dataclasses
 import json
 import shutil
 import subprocess
@@ -44,6 +45,8 @@ for _extra_path in (REPO_ROOT, REPO_ROOT / "tests"):
 import package_verify  # noqa: E402  PERMANENT(sys.path bootstrap above must run first)
 
 from release_gate_harness import (  # noqa: E402  PERMANENT(sys.path bootstrap above must run first)
+    FULL_JOURNEY,
+    HANDSHAKE_ONLY,
     gate_work_dir,
     resolve_launcher,
     run_release_gate_journey,
@@ -218,16 +221,22 @@ def select_artifact(dist_dir: Path, kind: str) -> Path:
     return (wheel if kind == "wheel" else sdist).absolute()
 
 
-def smoke(
-    *,
-    dist_dir: Path,
-    manifest_path: Path,
-    kind: str,
-    work_dir: Path,
-    python_version: str,
-) -> dict[str, object]:
-    artifact = select_artifact(dist_dir, kind)
-    manifest = package_verify.load_manifest(manifest_path)
+@dataclasses.dataclass(frozen=True)
+class SmokeSpec:
+    """Everything that identifies ONE smoke cell: which artifact, how far."""
+
+    dist_dir: Path
+    manifest_path: Path
+    kind: str
+    work_dir: Path
+    python_version: str = "3.12"
+    stages: str = FULL_JOURNEY
+
+
+def smoke(spec: SmokeSpec) -> dict[str, object]:
+    artifact = select_artifact(spec.dist_dir, spec.kind)
+    manifest = package_verify.load_manifest(spec.manifest_path)
+    work_dir = spec.work_dir
 
     # (1) The downloaded bytes are the built bytes — the same precondition the
     # publish job re-runs before it uploads anything.
@@ -241,7 +250,7 @@ def smoke(
     probe_cwd.mkdir(exist_ok=True)
 
     # (2) fresh env + local install, caches off.
-    interpreter = create_fresh_env(venv_dir, python_version)
+    interpreter = create_fresh_env(venv_dir, spec.python_version)
     install_artifact(interpreter, artifact)
 
     # (3) what landed IS the artifact.
@@ -261,19 +270,23 @@ def smoke(
     journey_dir = gate_work_dir(work_dir / "gate")
     journey_dir.mkdir(parents=True, exist_ok=True)
     record = asyncio.run(
-        run_release_gate_journey(launcher=launcher, work_dir=journey_dir)
+        run_release_gate_journey(
+            launcher=launcher, work_dir=journey_dir, stages=spec.stages
+        )
     )
     return {
         "schema_version": RESULT_SCHEMA_VERSION,
         "artifact": artifact.name,
-        "artifact_kind": kind,
+        "artifact_kind": spec.kind,
+        "stages": spec.stages,
+        "navigation_verified": spec.stages == FULL_JOURNEY,
         "artifact_sha256": package_verify.sha256_file(artifact),
         "version": manifest["version"],
         "installed_version": probe.get("version"),
         "package_root": probe.get("package_root"),
         "launcher": str(launcher),
         "venv": str(venv_dir),
-        "python_version": python_version,
+        "python_version": spec.python_version,
         "journey": record,
     }
 
@@ -287,16 +300,29 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--kind", choices=("wheel", "sdist"), required=True)
     parser.add_argument("--work-dir", type=Path, required=True)
     parser.add_argument("--python", default="3.12")
+    parser.add_argument(
+        "--stages",
+        choices=(FULL_JOURNEY, HANDSHAKE_ONLY),
+        default=FULL_JOURNEY,
+        help=(
+            "how far W1's ONE journey runs. 'handshake' stops before any "
+            "navigation and therefore makes a strictly smaller claim "
+            "(installs and serves, NOT navigates)."
+        ),
+    )
     parser.add_argument("--out", type=Path, default=None)
     args = parser.parse_args(argv)
 
     try:
         result = smoke(
-            dist_dir=args.dist_dir,
-            manifest_path=args.manifest,
-            kind=args.kind,
-            work_dir=args.work_dir,
-            python_version=args.python,
+            SmokeSpec(
+                dist_dir=args.dist_dir,
+                manifest_path=args.manifest,
+                kind=args.kind,
+                work_dir=args.work_dir,
+                python_version=args.python,
+                stages=args.stages,
+            )
         )
     except (SmokeError, package_verify.VerificationError) as exc:
         print(f"::error title=install-smoke::{exc}", file=sys.stderr)
@@ -307,7 +333,14 @@ def main(argv: list[str] | None = None) -> int:
         args.out.parent.mkdir(parents=True, exist_ok=True)
         args.out.write_text(text + "\n", encoding="utf-8")
     print(text)
-    print(f"install-smoke {args.kind}: OK ({result['artifact']})")
+    if args.stages == FULL_JOURNEY:
+        print(f"install-smoke {args.kind}: OK ({result['artifact']}) — full journey")
+    else:
+        print(
+            f"install-smoke {args.kind}: OK ({result['artifact']}) — PARTIAL: "
+            f"install + launcher + handshake only. This cell verified NO "
+            f"navigation and must not be reported as full-journey coverage."
+        )
     return 0
 
 

--- a/tools/package_verify.py
+++ b/tools/package_verify.py
@@ -1,0 +1,594 @@
+#!/usr/bin/env python3
+"""The ONE home for distribution-artifact facts (plan_RELEASE W3, gap G-C).
+
+Every job that needs to know something about the built distribution asks this
+tool — ``build-dist`` (write the manifest), ``package-verify`` (re-check it),
+``install-smoke`` (hash-check the cell's own download), and ``publish.yml``
+(re-check + tag/version precondition). There is deliberately no second copy of
+these rules in YAML: a check that lives in one workflow's shell block cannot be
+unit-tested and cannot be reused by the publish path.
+
+Subcommands
+-----------
+``manifest``      hash + describe ``dist/`` once, right after the single build.
+``verify``        re-check a ``dist/`` against a manifest (hashes, metadata,
+                  version agreement, wheel/sdist membership, package data).
+``hash-check``    re-check ONE artifact file against the manifest (the cheap
+                  precondition an install cell or the publish job runs).
+``assert-version`` manifest version == a release tag (``v1.2.0`` or ``1.2.0``).
+
+Package data
+------------
+``embedded/js/*.js`` are real package data: the cloner engine reads them at
+runtime, so a wheel that omits them installs and imports fine and then fails on
+first use. ``manifest`` records the sha256 of every one of them, ``verify``
+proves the wheel and the sdist carry BYTE-IDENTICAL copies, and
+``tools/install_smoke.py`` proves the files that land in a fresh site-packages
+are those same bytes. Comparing the two artifacts to each other (rather than to
+the git checkout) keeps the check hermetic — no line-ending policy of a
+particular runner's checkout can make it lie.
+
+Stdlib only. Exit 0 == every checked property holds; exit 1 == at least one
+violation, each printed as a GitHub error annotation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+import tarfile
+import zipfile
+from email.parser import Parser
+from pathlib import Path
+
+MANIFEST_SCHEMA_VERSION = 1
+DIST_NAME = "stealth-chrome-devtools-mcp"
+PKG = "stealth_chrome_devtools_mcp"
+
+# The browser-side extraction scripts (CLAUDE.md: the cloner subsystem's `js/`).
+EXPECTED_JS: tuple[str, ...] = (
+    "comprehensive_element_extractor.js",
+    "extract_animations.js",
+    "extract_assets.js",
+    "extract_events.js",
+    "extract_related_files.js",
+    "extract_structure.js",
+    "extract_styles.js",
+)
+
+# Python modules whose absence would mean a structurally broken wheel.
+EXPECTED_MODULES: tuple[str, ...] = (
+    "__init__.py",
+    "server.py",
+    "cli.py",
+    "settings.py",
+    "embedded/server.py",
+    "embedded/singleton.py",
+    "embedded/cdp_element_cloner.py",
+)
+
+# Both console scripts (pyproject [project.scripts]). install-smoke resolves the
+# first one out of a fresh environment, so a missing entry point must be caught
+# here rather than as a confusing "launcher not found" three jobs later.
+EXPECTED_ENTRY_POINTS: tuple[str, ...] = (
+    "stealth-chrome-devtools-mcp",
+    "stealth-chrome-devtools",
+)
+
+_CHUNK = 1024 * 1024
+# "<name>-<version>[-<build/python/abi/platform>…]" — anything shorter than
+# name+version cannot be a distribution filename.
+_MIN_FILENAME_PARTS = 2
+
+
+class VerificationError(Exception):
+    """A checked property does not hold. Message is the human-readable reason."""
+
+
+# ---------------------------------------------------------------------------
+# Hashing + artifact discovery.
+# ---------------------------------------------------------------------------
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(_CHUNK):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _normalize(name: str) -> str:
+    """PEP 503 normalization, so ``foo_bar`` and ``Foo-Bar`` compare equal."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def find_artifacts(dist_dir: Path) -> tuple[Path, Path]:
+    """Return ``(wheel, sdist)``; exactly one of each must be present."""
+    wheels = sorted(dist_dir.glob("*.whl"))
+    sdists = sorted(dist_dir.glob("*.tar.gz"))
+    if len(wheels) != 1:
+        raise VerificationError(
+            f"expected exactly 1 wheel in {dist_dir}, found {len(wheels)}: "
+            f"{[w.name for w in wheels]}"
+        )
+    if len(sdists) != 1:
+        raise VerificationError(
+            f"expected exactly 1 sdist in {dist_dir}, found {len(sdists)}: "
+            f"{[s.name for s in sdists]}"
+        )
+    return wheels[0], sdists[0]
+
+
+# ---------------------------------------------------------------------------
+# Reading inside the artifacts.
+# ---------------------------------------------------------------------------
+def wheel_members(wheel: Path) -> list[str]:
+    with zipfile.ZipFile(wheel) as zf:
+        return zf.namelist()
+
+
+def sdist_members(sdist: Path) -> list[str]:
+    with tarfile.open(sdist, "r:gz") as tf:
+        return tf.getnames()
+
+
+def _read_wheel(wheel: Path, member: str) -> bytes:
+    with zipfile.ZipFile(wheel) as zf:
+        return zf.read(member)
+
+
+def _read_sdist(sdist: Path, member: str) -> bytes:
+    with tarfile.open(sdist, "r:gz") as tf:
+        extracted = tf.extractfile(member)
+        if extracted is None:
+            raise VerificationError(f"sdist member is not a regular file: {member}")
+        with extracted:
+            return extracted.read()
+
+
+def _metadata_fields(text: str) -> tuple[str, str]:
+    """``(Name, Version)`` from a core-metadata document (METADATA / PKG-INFO)."""
+    message = Parser().parsestr(text)
+    name = message.get("Name") or ""
+    version = message.get("Version") or ""
+    if not name or not version:
+        raise VerificationError(
+            f"core metadata is missing Name/Version (name={name!r} version={version!r})"
+        )
+    return name, version
+
+
+def _dist_info_dir(members: list[str]) -> str:
+    dirs = {
+        m.split("/", 1)[0] for m in members if m.split("/", 1)[0].endswith(".dist-info")
+    }
+    if len(dirs) != 1:
+        raise VerificationError(
+            f"wheel must contain exactly one .dist-info directory, found {sorted(dirs)}"
+        )
+    return next(iter(dirs))
+
+
+def _sdist_root(members: list[str]) -> str:
+    roots = {m.split("/", 1)[0] for m in members if "/" in m}
+    if len(roots) != 1:
+        raise VerificationError(
+            f"sdist must contain exactly one top-level directory, found {sorted(roots)}"
+        )
+    return next(iter(roots))
+
+
+def _version_from_filename(filename: str, *, wheel: bool) -> str:
+    """The version segment of a PEP 427 wheel / PEP 625 sdist filename."""
+    stem = filename[: -len(".whl")] if wheel else filename[: -len(".tar.gz")]
+    parts = stem.split("-")
+    if len(parts) < _MIN_FILENAME_PARTS:
+        raise VerificationError(f"cannot parse a version out of {filename!r}")
+    return parts[1]
+
+
+# ---------------------------------------------------------------------------
+# manifest
+# ---------------------------------------------------------------------------
+def build_manifest(dist_dir: Path) -> dict[str, object]:
+    """Describe ``dist/`` once: hashes, sizes, version, and package-data hashes.
+
+    The package-data hashes come from the WHEEL (the artifact whose layout is
+    what actually lands in site-packages); ``verify`` then proves the sdist
+    agrees, and ``install_smoke`` proves site-packages agrees.
+    """
+    wheel, sdist = find_artifacts(dist_dir)
+    members = wheel_members(wheel)
+    dist_info = _dist_info_dir(members)
+    name, version = _metadata_fields(
+        _read_wheel(wheel, f"{dist_info}/METADATA").decode("utf-8")
+    )
+
+    package_data: dict[str, str] = {}
+    with zipfile.ZipFile(wheel) as zf:
+        for js in EXPECTED_JS:
+            member = f"{PKG}/embedded/js/{js}"
+            if member not in members:
+                raise VerificationError(f"wheel is missing package data: {member}")
+            package_data[member] = hashlib.sha256(zf.read(member)).hexdigest()
+
+    return {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "name": name,
+        "version": version,
+        "artifacts": [
+            {
+                "filename": path.name,
+                "kind": kind,
+                "sha256": sha256_file(path),
+                "size": path.stat().st_size,
+            }
+            for path, kind in ((wheel, "wheel"), (sdist, "sdist"))
+        ],
+        "package_data": package_data,
+    }
+
+
+def load_manifest(path: Path) -> dict[str, object]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise VerificationError(f"manifest {path} is not a JSON object")
+    if data.get("schema_version") != MANIFEST_SCHEMA_VERSION:
+        raise VerificationError(
+            f"manifest schema_version {data.get('schema_version')!r} "
+            f"!= expected {MANIFEST_SCHEMA_VERSION}"
+        )
+    for key in ("name", "version", "artifacts", "package_data"):
+        if key not in data:
+            raise VerificationError(f"manifest {path} is missing {key!r}")
+    return data
+
+
+def manifest_entry(manifest: dict[str, object], filename: str) -> dict[str, object]:
+    artifacts = manifest["artifacts"]
+    if not isinstance(artifacts, list):
+        raise VerificationError("manifest 'artifacts' is not a list")
+    for entry in artifacts:
+        if isinstance(entry, dict) and entry.get("filename") == filename:
+            return entry
+    raise VerificationError(
+        f"{filename!r} is not in the manifest (manifest lists "
+        f"{[e.get('filename') for e in artifacts if isinstance(e, dict)]})"
+    )
+
+
+def check_artifact_hash(artifact: Path, manifest: dict[str, object]) -> list[str]:
+    """Violations for ONE artifact file against its manifest entry."""
+    problems: list[str] = []
+    try:
+        entry = manifest_entry(manifest, artifact.name)
+    except VerificationError as exc:
+        return [str(exc)]
+    actual = sha256_file(artifact)
+    if actual != entry.get("sha256"):
+        problems.append(
+            f"{artifact.name}: sha256 {actual} != manifest {entry.get('sha256')}"
+        )
+    actual_size = artifact.stat().st_size
+    if actual_size != entry.get("size"):
+        problems.append(
+            f"{artifact.name}: size {actual_size} != manifest {entry.get('size')}"
+        )
+    return problems
+
+
+# ---------------------------------------------------------------------------
+# verify
+# ---------------------------------------------------------------------------
+def verify_dist(dist_dir: Path, manifest: dict[str, object]) -> list[str]:
+    """Every violation found in ``dist_dir`` relative to ``manifest`` (empty == ok).
+
+    Collects rather than raises: one run should report every problem, not just
+    the first, so a broken build costs one CI round instead of five.
+    """
+    problems: list[str] = []
+    try:
+        wheel, sdist = find_artifacts(dist_dir)
+    except VerificationError as exc:
+        return [str(exc)]
+
+    version = str(manifest["version"])
+    manifest_files = {
+        e.get("filename") for e in manifest["artifacts"] if isinstance(e, dict)
+    }
+    if manifest_files != {wheel.name, sdist.name}:
+        problems.append(
+            f"dist contents {sorted({wheel.name, sdist.name})} != manifest "
+            f"{sorted(str(f) for f in manifest_files)}"
+        )
+
+    # 1. Byte identity with what was built.
+    problems.extend(check_artifact_hash(wheel, manifest))
+    problems.extend(check_artifact_hash(sdist, manifest))
+
+    # 2. Name/version agreement across manifest, both filenames, and both
+    #    core-metadata documents. A single disagreeing source is a red gate.
+    problems.extend(_check_identity(wheel, sdist, manifest, version))
+
+    # 3. Structural membership + package data.
+    problems.extend(_check_wheel_members(wheel))
+    problems.extend(_check_sdist_members(sdist))
+    problems.extend(_check_package_data(wheel, sdist, manifest))
+    return problems
+
+
+def _check_identity(
+    wheel: Path, sdist: Path, manifest: dict[str, object], version: str
+) -> list[str]:
+    problems: list[str] = []
+    if _normalize(str(manifest["name"])) != _normalize(DIST_NAME):
+        problems.append(f"manifest name {manifest['name']!r} != expected {DIST_NAME!r}")
+    for path, is_wheel in ((wheel, True), (sdist, False)):
+        try:
+            filename_version = _version_from_filename(path.name, wheel=is_wheel)
+        except VerificationError as exc:
+            problems.append(str(exc))
+            continue
+        if filename_version != version:
+            problems.append(
+                f"{path.name}: filename version {filename_version!r} "
+                f"!= manifest version {version!r}"
+            )
+    try:
+        members = wheel_members(wheel)
+        w_name, w_version = _metadata_fields(
+            _read_wheel(wheel, f"{_dist_info_dir(members)}/METADATA").decode("utf-8")
+        )
+        if _normalize(w_name) != _normalize(DIST_NAME):
+            problems.append(f"wheel METADATA Name {w_name!r} != {DIST_NAME!r}")
+        if w_version != version:
+            problems.append(
+                f"wheel METADATA Version {w_version!r} != manifest {version!r}"
+            )
+    except (VerificationError, KeyError) as exc:
+        problems.append(f"wheel METADATA unreadable: {exc}")
+    try:
+        s_members = sdist_members(sdist)
+        s_name, s_version = _metadata_fields(
+            _read_sdist(sdist, f"{_sdist_root(s_members)}/PKG-INFO").decode("utf-8")
+        )
+        if _normalize(s_name) != _normalize(DIST_NAME):
+            problems.append(f"sdist PKG-INFO Name {s_name!r} != {DIST_NAME!r}")
+        if s_version != version:
+            problems.append(
+                f"sdist PKG-INFO Version {s_version!r} != manifest {version!r}"
+            )
+    except (VerificationError, KeyError) as exc:
+        problems.append(f"sdist PKG-INFO unreadable: {exc}")
+    return problems
+
+
+def _check_wheel_members(wheel: Path) -> list[str]:
+    problems: list[str] = []
+    try:
+        members = wheel_members(wheel)
+    except (OSError, zipfile.BadZipFile) as exc:
+        return [f"wheel is unreadable: {exc}"]
+    member_set = set(members)
+    problems.extend(
+        f"wheel is missing module: {PKG}/{module}"
+        for module in EXPECTED_MODULES
+        if f"{PKG}/{module}" not in member_set
+    )
+    problems.extend(
+        f"wheel is missing package data: {PKG}/embedded/js/{js}"
+        for js in EXPECTED_JS
+        if f"{PKG}/embedded/js/{js}" not in member_set
+    )
+    # No stray copy of the js scripts outside the package (the duplicate-file
+    # trap pyproject.toml warns about — a force-include would land them twice).
+    stray = sorted(
+        m
+        for m in member_set
+        if m.endswith(".js") and not m.startswith(f"{PKG}/embedded/js/")
+    )
+    if stray:
+        problems.append(f"wheel carries .js outside {PKG}/embedded/js/: {stray}")
+    try:
+        dist_info = _dist_info_dir(members)
+    except VerificationError as exc:
+        return [*problems, str(exc)]
+    entry_points_member = f"{dist_info}/entry_points.txt"
+    if entry_points_member not in member_set:
+        problems.append(f"wheel is missing {entry_points_member}")
+    else:
+        text = _read_wheel(wheel, entry_points_member).decode("utf-8")
+        problems.extend(
+            f"wheel entry_points.txt is missing {script!r}"
+            for script in EXPECTED_ENTRY_POINTS
+            if f"{script} =" not in text and f"{script}=" not in text
+        )
+    return problems
+
+
+def _check_sdist_members(sdist: Path) -> list[str]:
+    problems: list[str] = []
+    try:
+        members = sdist_members(sdist)
+        root = _sdist_root(members)
+    except (OSError, tarfile.TarError, VerificationError) as exc:
+        return [f"sdist is unreadable: {exc}"]
+    member_set = set(members)
+    problems.extend(
+        f"sdist is missing {required}"
+        for required in ("pyproject.toml", "README.md")
+        if f"{root}/{required}" not in member_set
+    )
+    problems.extend(
+        f"sdist is missing package data: src/{PKG}/embedded/js/{js}"
+        for js in EXPECTED_JS
+        if f"{root}/src/{PKG}/embedded/js/{js}" not in member_set
+    )
+    return problems
+
+
+def _check_package_data(
+    wheel: Path, sdist: Path, manifest: dict[str, object]
+) -> list[str]:
+    """Wheel js == manifest js == sdist js, byte for byte."""
+    problems: list[str] = []
+    recorded = manifest["package_data"]
+    if not isinstance(recorded, dict):
+        return ["manifest 'package_data' is not an object"]
+    expected_keys = {f"{PKG}/embedded/js/{js}" for js in EXPECTED_JS}
+    if set(recorded) != expected_keys:
+        problems.append(
+            f"manifest package_data keys {sorted(recorded)} != expected "
+            f"{sorted(expected_keys)}"
+        )
+    try:
+        sdist_root = _sdist_root(sdist_members(sdist))
+    except (OSError, tarfile.TarError, VerificationError) as exc:
+        return [*problems, f"sdist is unreadable: {exc}"]
+
+    wheel_names = set(wheel_members(wheel))
+    for member, expected_hash in sorted(recorded.items()):
+        if member not in wheel_names:
+            problems.append(f"wheel is missing recorded package data: {member}")
+            continue
+        actual = hashlib.sha256(_read_wheel(wheel, member)).hexdigest()
+        if actual != expected_hash:
+            problems.append(
+                f"{member}: wheel sha256 {actual} != manifest {expected_hash}"
+            )
+        js_name = member.rsplit("/", 1)[-1]
+        sdist_member = f"{sdist_root}/src/{PKG}/embedded/js/{js_name}"
+        try:
+            sdist_hash = hashlib.sha256(_read_sdist(sdist, sdist_member)).hexdigest()
+        except (KeyError, VerificationError) as exc:
+            problems.append(f"sdist package data unreadable ({sdist_member}): {exc}")
+            continue
+        if sdist_hash != expected_hash:
+            problems.append(
+                f"{js_name}: sdist sha256 {sdist_hash} != wheel/manifest "
+                f"{expected_hash} (the two publishable artifacts disagree)"
+            )
+    return problems
+
+
+# ---------------------------------------------------------------------------
+# assert-version
+# ---------------------------------------------------------------------------
+def assert_tag_version(manifest: dict[str, object], tag: str) -> list[str]:
+    """``v1.2.0``/``refs/tags/v1.2.0``/``1.2.0`` must equal the built version."""
+    bare = tag.removeprefix("refs/tags/").removeprefix("v")
+    version = str(manifest["version"])
+    if bare != version:
+        return [
+            f"release tag {tag!r} (version {bare!r}) != built artifact version "
+            f"{version!r} — the tag and the distribution disagree"
+        ]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def _emit(problems: list[str], *, context: str) -> int:
+    if problems:
+        print(f"{context}: {len(problems)} violation(s)")
+        for problem in problems:
+            print(f"::error title={context}::{problem}", file=sys.stderr)
+            print(f"  - {problem}")
+        return 1
+    print(f"{context}: OK")
+    return 0
+
+
+def _cmd_manifest(args: argparse.Namespace) -> int:
+    manifest = build_manifest(args.dist)
+    text = json.dumps(manifest, indent=2, sort_keys=True)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(text + "\n", encoding="utf-8")
+    print(text)
+    return 0
+
+
+def _cmd_verify(args: argparse.Namespace) -> int:
+    manifest = load_manifest(args.manifest)
+    problems = verify_dist(args.dist, manifest)
+    if args.expect_version:
+        problems.extend(assert_tag_version(manifest, args.expect_version))
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(
+            json.dumps(
+                {
+                    "schema_version": MANIFEST_SCHEMA_VERSION,
+                    "dist_dir": str(args.dist),
+                    "version": manifest["version"],
+                    "artifacts": manifest["artifacts"],
+                    "violations": problems,
+                    "verified": not problems,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+    return _emit(problems, context="package-verify")
+
+
+def _cmd_hash_check(args: argparse.Namespace) -> int:
+    manifest = load_manifest(args.manifest)
+    if not args.artifact.is_file():
+        return _emit([f"artifact not found: {args.artifact}"], context="hash-check")
+    return _emit(
+        check_artifact_hash(args.artifact, manifest),
+        context=f"hash-check {args.artifact.name}",
+    )
+
+
+def _cmd_assert_version(args: argparse.Namespace) -> int:
+    manifest = load_manifest(args.manifest)
+    return _emit(assert_tag_version(manifest, args.tag), context="assert-version")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_manifest = sub.add_parser("manifest", help="hash dist/ and write the manifest")
+    p_manifest.add_argument("--dist", type=Path, default=Path("dist"))
+    p_manifest.add_argument("--out", type=Path, required=True)
+    p_manifest.set_defaults(func=_cmd_manifest)
+
+    p_verify = sub.add_parser("verify", help="re-check dist/ against a manifest")
+    p_verify.add_argument("--dist", type=Path, default=Path("dist"))
+    p_verify.add_argument("--manifest", type=Path, required=True)
+    p_verify.add_argument("--expect-version", default="")
+    p_verify.add_argument("--out", type=Path, default=None)
+    p_verify.set_defaults(func=_cmd_verify)
+
+    p_hash = sub.add_parser("hash-check", help="re-check one artifact file")
+    p_hash.add_argument("--artifact", type=Path, required=True)
+    p_hash.add_argument("--manifest", type=Path, required=True)
+    p_hash.set_defaults(func=_cmd_hash_check)
+
+    p_tag = sub.add_parser("assert-version", help="manifest version == release tag")
+    p_tag.add_argument("--manifest", type=Path, required=True)
+    p_tag.add_argument("--tag", required=True)
+    p_tag.set_defaults(func=_cmd_assert_version)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        return int(args.func(args))
+    except VerificationError as exc:
+        return _emit([str(exc)], context=args.command)
+    except (OSError, ValueError, zipfile.BadZipFile, tarfile.TarError) as exc:
+        return _emit([f"{type(exc).__name__}: {exc}"], context=args.command)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -1624,6 +1624,7 @@ test = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
+    { name = "pyyaml" },
 ]
 transpiler = [
     { name = "py2js" },
@@ -1644,6 +1645,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=5.0" },
     { name = "pytest-timeout", marker = "extra == 'test'", specifier = ">=2.3" },
     { name = "python-dotenv", specifier = "==1.1.1" },
+    { name = "pyyaml", marker = "extra == 'test'", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.32.0,<4" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.20" },
     { name = "sentry-sdk", marker = "extra == 'sentry'", specifier = "==2.64.0" },


### PR DESCRIPTION
## ⚠️ STAGING BRANCH — DO NOT MERGE. Not part of the release PR queue.

This exists for one reason: **plan_RELEASE W5 generates a release contract from
current-SHA evidence, and that evidence is currently spread across nine unmerged
branches.** W5 needs one tree to describe. This branch is that tree; it is not a
competing path to `main`.

The human merge queue is unchanged and still authoritative:
`#42 → #43 → #44 → #46 → #49 → #50`, with `#45 → #47` on the W4 line and `#48`
behind `#46`.

## What it is

True merge commits (never squash) of the three live lines:

```
audit/release-fix-f   (W1 → FIX-B → W2 → FIX-C → FIX-E → FIX-F)
  ← audit/release-3-w3   (W3 packaging, PR #48)
  ← audit/release-fix-d  (W4 → FIX-D stealth, PRs #45/#47)
```

One conflict, in `pyproject.toml`: W3 added `pyyaml` to the `test` extra, FIX-D
added the `online` pytest marker. Independent additions in different sections;
both kept.

## Two false-greens the merge surfaced

Both were *correct* on their own branch and only became wrong once the lines met.
Neither was reachable from any single branch, which is the argument for doing this
integration at all.

**1. `offline-stealth` treated pytest exit 5 (zero collected) as success.** Right
while W4's stealth tests were absent; the selector now collects **23 tests**. Left
alone, any future marker rename would have produced a permanently green lane
asserting nothing. Removed — any non-zero now fails the job and the gate.

**2. That lane had no Chrome support at all** — no Xvfb, no `DISPLAY`, timeout 180
— because an empty lane never launches a browser. FIX-D's deliberately temporary
`fix-d-stealth-cells.yml` scaffolding *did* have all of it. Dropping the
scaffolding (its stated exit condition — `release-gate.yml` is now in this
history) without porting those would have broken the Linux stealth cell. Ported
Xvfb, the Linux-only `DISPLAY`, the Chrome-identity step, and the 300s timeout,
mirroring the `integration` cell.

`DISPLAY` is set at **step** level, not job level: the `runner` context is not
available in job-level `env:` and evaluates to empty there. `actionlint` clean on
all three workflows.

## Verification

- Pre-push hook (`pytest -m "not integration"`) green on the merged tree.
- Merge completeness checked explicitly — W3's packaging tools, W4's stealth
  suite, FIX-D's UA mask, FIX-E's `list_tabs` fix and FIX-F's `_find_tab` are all
  present; the scaffolding is gone; all six FIX plans are in place.
- This PR exists so the **full three-OS gate** runs on the integrated tree, which
  no individual branch has ever exercised.

## What this branch does NOT claim

Unchanged from the individual branches, and W5 must reproduce these bounds rather
than soften them:

- **transport is Linux/X64 + Windows/X64 only.** The macOS cell is *excluded*, not
  xfailed (F-773). An xfail would let green imply macOS coverage.
- **The two macOS install-smoke cells are `NO-NAVIGATION partial`** — handshake
  prefix only, `navigation_verified: false` in the journey record. The claim is
  "this artifact installs and serves", not "the journey passes on macOS".
- **Headless stealth is not "undetectable".** F-770 is closed on the UA string,
  the wire header, and CDP; F-774 (blanked high-entropy client hints) is open and
  must be qualified in the contract.
- `get_cookies` is still unresolved, so **no 94-tool claim** is licensed yet.
