### PR TITLE
RELEASE W5-prep: real-transport get_cookies success path

### DIFF
--- a/tests/release_gate_harness.py
+++ b/tests/release_gate_harness.py
@@ -60,6 +60,7 @@ import sys
 import tempfile
 import threading
 import time
+import uuid
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
@@ -72,10 +73,13 @@ from fastmcp.client.transports import StdioTransport
 _log = logging.getLogger("release_gate_harness")
 
 # ── Contract constants ──────────────────────────────────────────────────────
-# How far `run_release_gate_journey` runs. ONE journey, two declared extents —
-# never two journeys. See that function's docstring for what each one claims.
+# Which declared segment of the ONE gate mechanism `run_release_gate_journey`
+# runs. These are extents/segments, never duplicated machinery: every value
+# below shares the same launcher resolution, isolated env, fixture app, stdio
+# client, and teardown. See that function's docstring for what each claims.
 FULL_JOURNEY = "full"
 HANDSHAKE_ONLY = "handshake"
+COOKIE_ROUND_TRIP = "cookies"
 
 SERVER_NAME = "stealth-chrome-devtools-mcp"
 REGISTRY_TOOL_COUNT = 94  # remediation baseline (CLAUDE.md: derived == 94)
@@ -748,6 +752,128 @@ async def _cold_start_warmup(
                     )
 
 
+async def _cookie_round_trip(
+    client: Client, iid: str, page_url: str, journey: dict[str, Any]
+) -> None:
+    """plan_RELEASE W5 — the real success path for ``get_cookies``.
+
+    W5's ``get_cookies`` hard block (§2.5) requires a real Chrome + real
+    transport test that **sets a cookie, retrieves it, and asserts its value**;
+    a schema check, a mock, a missing-instance error, or a characterization
+    explicitly cannot satisfy it. This does the full round trip through
+    ``tools/call`` only:
+
+    ``set_cookie`` → ``get_cookies(urls=[page_url])`` → **assert the value** →
+    ``get_cookies()`` (the no-argument default, a different CDP call) →
+    ``document.cookie`` cross-check → ``clear_cookies`` → assert it is gone.
+
+    The value is unique per run, so a stale cookie from an earlier run in a
+    reused profile cannot forge the assertion, and the ``document.cookie``
+    cross-check proves the cookie really reached the browser rather than
+    ``get_cookies`` merely echoing what ``set_cookie`` was handed.
+
+    ``get_cookies`` is declared ``-> list[dict[str, Any]]`` but returns nodriver
+    ``cdp.network.Cookie`` **dataclasses**. pydantic serializes those to correct
+    JSON objects, so ``structuredContent`` — what ``_call`` returns, and what a
+    user's client receives — is a list of cookie dicts. Asserting through
+    fastmcp's ``result.data`` instead would see an opaque ``[Root()]``; that is
+    a property of the reconstruction, not a product defect.
+    """
+    name = "release_gate_cookie"
+    value = f"w5-{uuid.uuid4().hex}"
+    cookies: dict[str, Any] = {"name": name, "value": value}
+    journey["cookies"] = cookies
+
+    assert await _call(
+        client,
+        "set_cookie",
+        {"instance_id": iid, "name": name, "value": value, "url": page_url},
+        CALL_TIMEOUT,
+    ), "set_cookie did not report success"
+
+    # Retrieval #1 — scoped to the page URL (CDP Network.getCookies).
+    scoped = await _call(
+        client, "get_cookies", {"instance_id": iid, "urls": [page_url]}, CALL_TIMEOUT
+    )
+    assert isinstance(scoped, list) and scoped, (
+        f"get_cookies(urls=…) returned {scoped!r}"
+    )
+    assert all(isinstance(c, dict) for c in scoped), (
+        f"get_cookies did not serialize to dicts: {[type(c).__name__ for c in scoped]}"
+    )
+    scoped_hit = next((c for c in scoped if c.get("name") == name), None)
+    assert scoped_hit is not None, f"{name!r} absent from get_cookies(urls=…): {scoped}"
+    # THE assertion W5's hard block turns on.
+    assert scoped_hit.get("value") == value, (scoped_hit.get("value"), value)
+    cookies["scoped_value"] = scoped_hit["value"]
+    cookies["scoped_count"] = len(scoped)
+    cookies["field_names"] = sorted(scoped_hit)
+
+    # Retrieval #2 — the no-argument default (CDP Network.getAllCookies).
+    every = await _call(client, "get_cookies", {"instance_id": iid}, CALL_TIMEOUT)
+    assert isinstance(every, list), f"get_cookies() returned {every!r}"
+    all_hit = next(
+        (c for c in every if isinstance(c, dict) and c.get("name") == name), None
+    )
+    assert all_hit is not None, f"{name!r} absent from get_cookies(): {every}"
+    assert all_hit.get("value") == value, (all_hit.get("value"), value)
+    cookies["all_value"] = all_hit["value"]
+
+    # Ground truth: the cookie is really in the browser, not just in our reply.
+    document_cookie = await _eval(client, iid, "document.cookie")
+    assert f"{name}={value}" in str(document_cookie), document_cookie
+    cookies["document_cookie_confirms"] = True
+
+    # clear_cookies is part of the same real path — prove removal by re-reading,
+    # not by trusting its return value.
+    assert await _call(
+        client, "clear_cookies", {"instance_id": iid, "url": page_url}, CALL_TIMEOUT
+    ), "clear_cookies did not report success"
+    after = await _call(
+        client, "get_cookies", {"instance_id": iid, "urls": [page_url]}, CALL_TIMEOUT
+    )
+    assert isinstance(after, list), after
+    assert not any(isinstance(c, dict) and c.get("name") == name for c in after), (
+        f"{name!r} survived clear_cookies: {after}"
+    )
+    cookies["cleared"] = True
+
+
+async def _cookie_journey(
+    client: Client, base_url: str, record: dict[str, Any]
+) -> None:
+    """W5's segment: spawn → navigate → cookie round trip → close.
+
+    Deliberately minimal — everything here exists to make the cookie assertions
+    meaningful, so a failure reads as a cookie failure rather than as "the
+    journey" failing. A real page (not ``about:blank``) is required because
+    cookies need a real http:// origin, and the fixture app is that origin.
+    """
+    spawn = await _call(
+        client, "spawn_browser", _headless_spawn_kwargs(), SPAWN_TIMEOUT
+    )
+    assert isinstance(spawn, dict) and spawn.get("instance_id"), spawn
+    iid = spawn["instance_id"]
+    journey: dict[str, Any] = {"instance_id": iid}
+    record["journey"] = journey
+    try:
+        url = f"{base_url}/interact.html"
+        await _call(client, "navigate", {"instance_id": iid, "url": url}, NAV_TIMEOUT)
+        journey["navigated_url"] = url
+        await _settle_dom(client, iid)
+
+        await _cookie_round_trip(client, iid, url, journey)
+    finally:
+        await _call(
+            client,
+            "close_instance",
+            {"instance_id": iid},
+            CLOSE_TIMEOUT,
+            raise_on_error=False,
+            allow_fail=True,
+        )
+
+
 async def _canonical_journey(
     client: Client, base_url: str, record: dict[str, Any]
 ) -> None:
@@ -878,8 +1004,9 @@ async def run_release_gate_journey(
     ``work_dir`` is a throwaway directory (e.g. pytest ``tmp_path``) used for the
     isolated HOME (singleton state), session root, clone output, and logs.
 
-    ``stages`` selects how far the ONE journey runs — it never selects a
-    different journey:
+    ``stages`` selects which declared segment runs on top of the ONE shared
+    mechanism (launcher resolution, isolated env, fixture app, stdio client,
+    teardown). It never duplicates that machinery:
 
     ``"full"`` (default)
         everything: handshake, registry, parity, cold-start warmup, and the
@@ -894,11 +1021,19 @@ async def run_release_gate_journey(
         — and the result record says so in ``stages`` so no consumer can read
         it as the full journey. Not an xfail: nothing failing is being marked
         as expected-to-fail; a smaller thing is being run and labelled.
+    ``"cookies"``
+        the prefix plus warmup, then the focused ``set_cookie`` →
+        ``get_cookies`` → ``clear_cookies`` round trip (``_cookie_journey``)
+        instead of the canonical journey. plan_RELEASE §2.5 rules that a
+        *representative journey* cannot carry a per-tool success claim, so W5's
+        ``get_cookies`` evidence needs its own collected node
+        (``tests/test_e2e_transport_cookies.py``); this segment is what that
+        node drives. It navigates, so ``navigation_verified`` is true, but it
+        makes no canonical-journey claim.
     """
-    if stages not in (FULL_JOURNEY, HANDSHAKE_ONLY):
-        raise ValueError(
-            f"stages must be {FULL_JOURNEY!r} or {HANDSHAKE_ONLY!r}, got {stages!r}"
-        )
+    valid_stages = (FULL_JOURNEY, HANDSHAKE_ONLY, COOKIE_ROUND_TRIP)
+    if stages not in valid_stages:
+        raise ValueError(f"stages must be one of {valid_stages!r}, got {stages!r}")
     launcher = Path(launcher)
     work_dir = Path(work_dir)
     home_dir = work_dir / "home"
@@ -919,7 +1054,7 @@ async def run_release_gate_journey(
     record: dict[str, Any] = {
         "schema_version": RESULT_SCHEMA_VERSION,
         "stages": stages,
-        "navigation_verified": stages == FULL_JOURNEY,
+        "navigation_verified": stages in (FULL_JOURNEY, COOKIE_ROUND_TRIP),
         "transport": "stdio",
         "launcher": str(launcher.resolve()),
         "singleton_port": port,
@@ -950,9 +1085,12 @@ async def run_release_gate_journey(
                     async with Client(transport, init_timeout=INIT_TIMEOUT) as client:
                         await _foundation_proof(client, record)
                         await _representative_parity(client, record)
-                        if stages == FULL_JOURNEY:
+                        if stages in (FULL_JOURNEY, COOKIE_ROUND_TRIP):
                             await _cold_start_warmup(client, base_url, log_dir, record)
+                        if stages == FULL_JOURNEY:
                             await _canonical_journey(client, base_url, record)
+                        elif stages == COOKIE_ROUND_TRIP:
+                            await _cookie_journey(client, base_url, record)
                 except BaseException as exc:  # noqa: BLE001  PERMANENT(augment with child stderr + boot log, then re-raise)
                     err = exc
             child_stderr = cap["text"]

--- a/tests/test_e2e_functions_hooks.py
+++ b/tests/test_e2e_functions_hooks.py
@@ -358,9 +358,19 @@ E2E_COVERED = {
     "execute_script",
     "get_page_content",
     "take_screenshot",
-    # cookies-storage (2 of 3; get_cookies is exempt below) — test_e2e_interaction
+    # cookies-storage (3) — set_cookie/clear_cookies: test_e2e_interaction.py.
+    # get_cookies: tests/test_e2e_transport_cookies.py, which sets a cookie,
+    # retrieves it, and asserts its VALUE over real Chrome + real stdio
+    # (plan_RELEASE W5's option (a)). It is covered there rather than here
+    # because it is reachable only over the transport: through the in-process
+    # `.fn` seam these E2E modules use, Network.getCookies/getAllCookies never
+    # returns and poisons the tab's CDP connection. Same tool, same Chrome —
+    # only the seam differs, so this is a harness limitation, not a gap in the
+    # product's user-facing path. Routed as a finding; do NOT call get_cookies
+    # from a `.fn`-seam test (see test_e2e_interaction.test_cookies_lifecycle).
     "set_cookie",
     "clear_cookies",
+    "get_cookies",
     # tabs (5) — test_e2e_interaction.py
     "list_tabs",
     "switch_tab",
@@ -443,16 +453,16 @@ E2E_COVERED = {
 }
 
 # Tools intentionally left to another tier, each with a reason.
-E2E_EXEMPT: dict[str, str] = {
-    "get_cookies": (
-        "hangs against real Chrome — the CDP Network.getCookies/getAllCookies "
-        "command never returns in the installed nodriver (get_all_cookies is "
-        "deprecated since 1.3) and poisons the tab's CDP connection so every "
-        "later call times out. Exercising it in E2E would risk leaking a Chrome "
-        "tree; the finding is reported for routing. set_cookie and clear_cookies "
-        "ARE E2E-covered (asserted via document.cookie)."
-    ),
-}
+#
+# Empty as of plan_RELEASE W5-prep: `get_cookies` was the sole exemption, on the
+# grounds that it "hangs against real Chrome". That reason turned out to be
+# seam-specific rather than product-wide — it hangs through the in-process `.fn`
+# seam, but over the real stdio transport it sets, retrieves, and clears cookies
+# correctly (tests/test_e2e_transport_cookies.py asserts the retrieved VALUE).
+# So it moved to E2E_COVERED and nothing remains exempt. Keep this dict: it is
+# half of the partition tripwire below, and a future exemption belongs here WITH
+# a reason, never as a silent deletion from E2E_COVERED.
+E2E_EXEMPT: dict[str, str] = {}
 
 
 def test_e2e_coverage_manifest():

--- a/tests/test_e2e_interaction.py
+++ b/tests/test_e2e_interaction.py
@@ -339,11 +339,17 @@ async def test_get_element_state_pins_current_shape(fixture_app_server):
 async def test_cookies_lifecycle(fixture_app_server):
     """set_cookie + clear_cookies, verified via the live ``document.cookie``.
 
-    get_cookies is deliberately NOT called here — it hangs (the CDP
-    Network.getCookies / deprecated getAllCookies never returns in the installed
-    nodriver) and, worse, poisons the tab's CDP connection so every subsequent
-    call times out. It is E2E_EXEMPT with that finding; cookies are read via
-    document.cookie (non-httpOnly) instead, which is exact ground truth.
+    get_cookies is deliberately NOT called here — through the in-process ``.fn``
+    seam this module uses, the CDP Network.getCookies / deprecated
+    getAllCookies never returns and, worse, poisons the tab's CDP connection so
+    every subsequent call times out. Cookies are read via document.cookie
+    (non-httpOnly) instead, which is exact ground truth.
+
+    That hang is specific to this seam, NOT to the product: over the real stdio
+    transport the same tool against the same Chrome sets, retrieves, and clears
+    cookies correctly. ``tests/test_e2e_transport_cookies.py`` is where
+    get_cookies is covered (plan_RELEASE W5 requires the retrieved value be
+    asserted), which is why it is E2E_COVERED rather than E2E_EXEMPT.
     """
     base = fixture_app_server
     spawn = get_fn("spawn_browser")

--- a/tests/test_e2e_transport_cookies.py
+++ b/tests/test_e2e_transport_cookies.py
@@ -1,0 +1,105 @@
+"""plan_RELEASE W5-prep — the real-transport ``get_cookies`` success path.
+
+W5's **``get_cookies`` hard block** (plan_RELEASE §2.5): at W5 start, successful
+real-browser cookie *retrieval* had never been proved, so the contract generator
+refuses a 94-release-qualified-tool statement. The block clears only via option
+(a) — "a real Chrome + real transport success test sets a cookie, retrieves it,
+and asserts its value". A mock-only success, a missing-instance error, a schema
+check, or a characterization explicitly **cannot** satisfy it.
+
+This module is that test, and it is a **dedicated collected node** on purpose.
+§2.5 rules that a *representative journey* cannot satisfy a per-tool success
+claim, and §2.1 names ``test_real_stdio_release_gate_journey`` as exactly that —
+so folding these assertions into the canonical journey would have produced
+evidence W5 must reject. The machinery is still the one harness (absolute
+installed launcher, isolated HOME/session root, fixture app, stdio
+``tools/call``, bounded teardown); only the steps differ.
+
+Covers three tools on the one real path — ``set_cookie``, ``get_cookies``,
+``clear_cookies``.
+
+Marked ``integration`` + ``transport``; skipped when Chrome / the server is
+unavailable (same guard as the other e2e modules). macOS transport is excluded
+under F-773, so this node's evidence is Linux/X64 + Windows/X64.
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from e2e_helpers import CAN_RUN
+from release_gate_harness import (
+    COOKIE_ROUND_TRIP,
+    RESULT_SCHEMA_VERSION,
+    gate_work_dir,
+    resolve_launcher,
+    run_release_gate_journey,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.transport]
+
+if not CAN_RUN:
+    pytestmark.append(pytest.mark.skip("Chrome not available or server failed to load"))
+
+
+async def test_real_transport_cookie_round_trip(tmp_path):
+    """set_cookie → get_cookies → **assert the value** → clear_cookies, over real
+    headless Chrome and real stdio JSON-RPC.
+
+    Note the assertions read the harness record, which is built from
+    ``result.structured_content`` — the raw wire shape a user's client receives.
+    fastmcp's ``result.data`` reconstruction is deliberately NOT used: this tool
+    is declared ``-> list[dict[str, Any]]`` but returns nodriver
+    ``cdp.network.Cookie`` dataclasses, and while pydantic serializes those to
+    correct JSON objects on the wire, ``.data`` rebuilds them as an opaque
+    ``[Root()]``. Asserting through ``.data`` would look like a product failure
+    when it is only an artifact of the reconstruction.
+    """
+    launcher = resolve_launcher()  # this env's absolute installed console launcher
+    work_dir = gate_work_dir(tmp_path)  # RUNNER_TEMP on CI (see helper docstring)
+
+    try:
+        record = await run_release_gate_journey(
+            launcher=launcher, work_dir=work_dir, stages=COOKIE_ROUND_TRIP
+        )
+    finally:
+        if work_dir != tmp_path:  # pytest cleans its own; this one is ours
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+    assert record["schema_version"] == RESULT_SCHEMA_VERSION
+    assert record["transport"] == "stdio"
+    assert record["stages"] == COOKIE_ROUND_TRIP
+    assert record["navigation_verified"] is True  # a real page, not about:blank
+    assert record["launcher"].endswith(
+        ("stealth-chrome-devtools-mcp.exe", "stealth-chrome-devtools-mcp")
+    )
+
+    journey = record["journey"]
+    assert journey["instance_id"]
+    # A real http:// origin, not about:blank — cookies need one.
+    assert journey["navigated_url"].startswith("http://127.0.0.1:")
+
+    cookies = journey["cookies"]
+    expected = cookies["value"]
+    assert expected.startswith("w5-")  # unique per run; a stale cookie cannot forge it
+
+    # THE assertion the hard block turns on: the value we set came back, from
+    # both retrieval paths (Network.getCookies and Network.getAllCookies).
+    assert cookies["scoped_value"] == expected
+    assert cookies["all_value"] == expected
+
+    # Retrieval returned real, populated cookie objects — not empty shells.
+    assert cookies["scoped_count"] >= 1
+    assert {"name", "value", "domain", "path"} <= set(cookies["field_names"])
+
+    # The cookie really reached the browser; get_cookies did not merely echo us.
+    assert cookies["document_cookie_confirms"] is True
+
+    # clear_cookies removed it (proved by re-reading, not by its return value).
+    assert cookies["cleared"] is True
+
+    # Teardown left nothing running.
+    assert record["backend_gone"] is True
+    assert record["no_child_remaining"] is True


### PR DESCRIPTION
## Option (a) — the `get_cookies` hard block clears

plan_RELEASE §2.5's `get_cookies` hard block is satisfied by **option (a)**: a real
Chrome + real transport test sets a cookie, retrieves it, and **asserts its value**.
W5 may claim **94 release-qualified tools**; option (b) is not needed.

**Evidence node for W5's ledger (verbatim):**

```
tests/test_e2e_transport_cookies.py::test_real_transport_cookie_round_trip
```

Real cookie value asserted: `release_gate_cookie` = `w5-<uuid4-hex>`, freshly generated
per run (e.g. `w5-352c36fc058b43bcb67b6eb9e9cde0b7`). Uniqueness is load-bearing — a
stale cookie left in a reused profile cannot forge the assertion.

## What the node proves

Entirely through `tools/call` over real stdio JSON-RPC against real headless Chrome:

```
set_cookie -> get_cookies(urls=[url]) -> ASSERT VALUE -> get_cookies()
  -> document.cookie cross-check -> clear_cookies -> assert gone
```

- Both retrieval paths are exercised: `Network.getCookies` (scoped) and
  `Network.getAllCookies` (the no-argument default a user actually calls).
- The `document.cookie` cross-check proves the cookie really reached the browser,
  rather than `get_cookies` echoing back what `set_cookie` was handed.
- `clear_cookies` removal is proved by **re-reading**, not by trusting its return value.
- **Mutation-verified**: tampering with the value passed to `set_cookie` makes the node
  fail on the value assertion with a clear message. The assertion has teeth.

Per-tool status for W5: **`set_cookie`, `get_cookies`, `clear_cookies` — all three
release-qualified-success on this node.**

## Why a dedicated node

§2.5 rules that a *representative journey* cannot carry a per-tool success claim, and
§2.1 names `test_real_stdio_release_gate_journey` as exactly that. Folding these
assertions into `_canonical_journey` would have produced evidence W5 must reject.

The machinery is still the **one** harness — absolute installed launcher, isolated
HOME/session root, fixture app, stdio client, bounded teardown. `stages="cookies"` adds
a third declared segment on top of it, alongside `"full"` and `"handshake"`. No second
journey mechanism and no second fixture, so `release_gate_harness`'s standing rule holds.

Bound worth recording in the ledger: macOS transport is excluded under F-773, so this
node's evidence is **Linux/X64 + Windows/X64**.

## The exemption's reason was false — and why that matters

`get_cookies` was the sole `E2E_EXEMPT` name, on the grounds that it *"hangs against
real Chrome ... and poisons the tab's CDP connection"*. That reason is **seam-specific,
not product-wide**. Measured on this base — same tool, same Chrome, only the seam differs:

| Path | Result |
|---|---|
| in-process `.fn` seam | `Network.getCookies` **and** `getAllCookies` both hang (30s, no return); the next call on that tab dies with a 10s CDP timeout. The exemption's *symptom* was accurate. |
| real stdio transport + detached backend | both retrieval paths return; `document.cookie` agrees; `clear_cookies` works; later calls fine. |

The transport path is the one users actually have. The tool works; the in-process E2E
suite simply could not reach it. So `get_cookies` moves from `E2E_EXEMPT` to
`E2E_COVERED` (covered by the transport node), and **`E2E_EXEMPT` is now empty** — the
set-equality tripwire is 94 covered, 0 exempt, and still passes.

The seam hang is **recorded at both call sites, not erased**, and is routed as a finding
below rather than fixed — plan_RELEASE is zero-`src`.

## Findings routed, not fixed (zero `src/` edits in this PR)

1. **`get_cookies` is unusable through the in-process `.fn` seam** — hangs indefinitely
   and poisons the tab's CDP connection for all subsequent calls. Only reachable over
   the transport. Worth a tracking id: it constrains how any future E2E test may cover
   this tool, and the connection-poisoning blast radius is larger than the one tool.
2. **Cosmetic type mismatch** — `get_cookies` is declared `-> list[dict[str, Any]]` but
   returns nodriver `cdp.network.Cookie` dataclasses. pydantic serializes those
   correctly, so the wire shape a user receives is right and nothing is broken. But
   fastmcp's `result.data` reconstructs them as an opaque `[Root()]`, which is why this
   node asserts on `structured_content` (the raw wire shape) — a future test written
   against `.data` would look broken for the wrong reason. Called out in the test
   docstring so nobody loses a debugging cycle to it.

## Gates

- ruff format + check: clean
- `ty check --exit-zero-on-warning src/stealth_chrome_devtools_mcp/`: **76 diagnostics**
  (matches baseline)
- vulture, suppression owners, file budgets: clean
- unit lane (`-m "not integration"`): **821 passed, 1 skipped**
- W1's canonical journey re-verified green alongside the new node (`2 passed`), so the
  `stages` change did not regress W1 or W3's smoke path.
- Pre-commit and pre-push hooks ran in full; `--no-verify` not used.
