### PR TITLE
CI: stop install-smoke from shipping launch failures to Sentry

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -965,6 +965,10 @@ jobs:
           --out "install-smoke-${{ matrix.kind }}.json"
         env:
           DISPLAY: ${{ runner.os == 'Linux' && ':99' || '' }}
+          # install_smoke.py is invoked directly (not via pytest), so the
+          # conftest.py Sentry mute never loads; the spawned backend inherits
+          # this env, keeping CI launch failures out of production telemetry.
+          STEALTH_MCP_NO_ERROR_REPORTING: "true"
       - name: Upload smoke result + identity
         if: always()
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3


### PR DESCRIPTION
## What

One env line: `STEALTH_MCP_NO_ERROR_REPORTING: "true"` on the install-smoke job's journey step in `release-gate.yml`.

## Why

`tools/install_smoke.py` is invoked directly (`uv run python tools/install_smoke.py`), not under pytest — so `tests/conftest.py`'s Sentry mute (added in 2.0.4) never loads for this job. Its `_run()` calls `subprocess.run` with no env override, so the freshly-installed backend inherits the raw runner environment and ships every real browser-launch failure to the production Sentry DSN as a `production`-environment event.

Measured impact: 26 of Sentry issue STEALTH-CHROME-DEVTOOLS-MCP-K's 82 events over the last 7 days came from GitHub runners (`runnervmvrwv9`, `runnervmhisb5`) via this exact path (sys.argv shows `.../install-smoke-sdist/venv/...`).

## What this deliberately does NOT do

The underlying Linux-runner "Failed to connect to browser" failure is a real signal and stays fully visible in the job output and evidence records — this only stops it from masquerading as production telemetry. The launch failure itself (and the larger 68% share of issue -K coming from non-CI machines) is tracked separately.

🤖 Generated with Claude Code