### PR TITLE
F-809: a clean backend stop stops shipping ERROR noise to Sentry

### DIFF
--- a/src/stealth_chrome_devtools_mcp/embedded/process_cleanup.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/process_cleanup.py
@@ -117,16 +117,19 @@ class ProcessCleanup:
         what lets ``_signal_handler`` hand the signal back (F-809) — under HTTP
         that is uvicorn's ``handle_exit``, installed first by ``capture_signals``
         and so REPLACED by ours, never coexisting. SIGBREAK exists on Windows
-        only, so ``getattr`` is the whole platform gate.
+        only, so ``getattr`` is the whole platform gate. A re-install is skipped
+        (runpy double-loads the server module): re-recording would make
+        ``previous`` OUR handler, i.e. ``_signal_handler`` delegating to itself.
         """
         atexit.register(self._cleanup_all_tracked)
 
         for name in ("SIGTERM", "SIGINT", "SIGBREAK"):
             signum = getattr(signal, name, None)
-            if signum is not None:
-                self._previous_signal_handlers[signum] = signal.signal(
-                    signum, self._signal_handler
-                )
+            if signum is None or signum in self._previous_signal_handlers:
+                continue
+            self._previous_signal_handlers[signum] = signal.signal(
+                signum, self._signal_handler
+            )
 
     def _signal_handler(self, signum, frame):
         """Clean up tracked browsers, then hand the signal back (F-809)."""

--- a/src/stealth_chrome_devtools_mcp/embedded/process_cleanup.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/process_cleanup.py
@@ -10,6 +10,7 @@ import tempfile
 import time
 from collections.abc import Callable
 from pathlib import Path
+from types import FrameType
 from typing import Any
 
 import psutil
@@ -19,6 +20,10 @@ from stealth_chrome_devtools_mcp.embedded.browser_pid_registry import Entries
 from stealth_chrome_devtools_mcp.embedded.debug_logger import debug_logger
 from stealth_chrome_devtools_mcp.embedded.singleton import STATE_DIR
 from stealth_chrome_devtools_mcp.settings import get_settings
+
+# What ``signal.signal`` returns: the disposition it displaced (a handler, or
+# one of the SIG_DFL / SIG_IGN ints, or None for one it cannot describe).
+SignalDisposition = Callable[[int, FrameType | None], object] | int | None
 
 
 def _owner_identity() -> tuple[int, float | None]:
@@ -50,6 +55,8 @@ class ProcessCleanup:
             get_settings().browser_orphan_profile_max_age
         )
         self._init_time = time.time()
+        self._previous_signal_handlers: dict[int, SignalDisposition] = {}
+        self._shutdown_in_progress = False
 
     def activate(self) -> None:
         """Install cleanup handlers and run orphan recovery once at serve startup."""
@@ -75,15 +82,7 @@ class ProcessCleanup:
 
     @staticmethod
     def _is_browser_process_name(process_name: str) -> bool:
-        """
-        Determine whether a process name belongs to a supported browser.
-
-        Args:
-            process_name (str): Process executable name.
-
-        Returns:
-            bool: True when the process looks like a Chromium-family browser.
-        """
+        """Whether a process name belongs to a Chromium-family browser."""
         normalized_name = (process_name or "").lower()
         return any(
             marker in normalized_name
@@ -112,40 +111,56 @@ class ProcessCleanup:
         return None
 
     def _setup_cleanup_handlers(self):
-        """
-        Register process cleanup hooks for normal interpreter shutdown and signals.
+        """Register cleanup hooks for interpreter exit and termination signals.
 
-        Returns:
-            None
+        ``signal.signal`` returns the disposition it displaces; recording it is
+        what lets ``_signal_handler`` hand the signal back (F-809) — under HTTP
+        that is uvicorn's ``handle_exit``, installed first by ``capture_signals``
+        and so REPLACED by ours, never coexisting. SIGBREAK exists on Windows
+        only, so ``getattr`` is the whole platform gate.
         """
         atexit.register(self._cleanup_all_tracked)
 
-        if hasattr(signal, "SIGTERM"):
-            signal.signal(signal.SIGTERM, self._signal_handler)
-        if hasattr(signal, "SIGINT"):
-            signal.signal(signal.SIGINT, self._signal_handler)
+        for name in ("SIGTERM", "SIGINT", "SIGBREAK"):
+            signum = getattr(signal, name, None)
+            if signum is not None:
+                self._previous_signal_handlers[signum] = signal.signal(
+                    signum, self._signal_handler
+                )
 
-        if sys.platform == "win32" and hasattr(signal, "SIGBREAK"):
-            signal.signal(signal.SIGBREAK, self._signal_handler)
-
-    def _signal_handler(self, signum, _frame):
-        """
-        Handle interpreter termination signals by cleaning tracked browser resources.
-
-        Args:
-            signum: Signal number.
-            frame: Current stack frame.
-
-        Returns:
-            None
-        """
+    def _signal_handler(self, signum, frame):
+        """Clean up tracked browsers, then hand the signal back (F-809)."""
         debug_logger.log_info(
             "process_cleanup",
             "signal_handler",
             f"Received signal {signum}, initiating cleanup...",
         )
-        self._cleanup_all_tracked()
-        sys.exit(0)
+        previous = self._previous_signal_handlers.get(signum)
+        # SIG_DFL / SIG_IGN are ints and nothing recorded is None — neither is a
+        # loop to hand back to. ``default_int_handler`` is excluded deliberately:
+        # under standalone stdio it IS SIGINT's prior disposition, and delegating
+        # would swap today's clean exit 0 for a KeyboardInterrupt unwind.
+        default_int = signal.default_int_handler
+        if previous is None or isinstance(previous, int) or previous is default_int:
+            self._run_shutdown_cleanup()  # verbatim 1.x standalone behaviour
+            sys.exit(0)
+        # Delegate FIRST (a cheap flag set — a slow or failing cleanup must not
+        # strand the server), then RETURN into the interrupted frame so the
+        # server's own graceful path unwinds the loop, instead of ``sys.exit``
+        # tearing it down from inside ``select()``.
+        previous(signum, frame)
+        self._run_shutdown_cleanup()
+
+    def _run_shutdown_cleanup(self) -> None:
+        """Run the tracked-browser cleanup at most once per shutdown (a second
+        SIGTERM must not re-enter it mid-``rmtree``)."""
+        if self._shutdown_in_progress:
+            return
+        self._shutdown_in_progress = True
+        try:
+            self._cleanup_all_tracked()
+        except Exception as error:
+            debug_logger.log_error("process_cleanup", "shutdown_cleanup", error)
 
     def _load_tracked_pids(self) -> dict[str, dict[str, Any]]:
         """Every browser recorded in the shared PID file, ours and other
@@ -943,12 +958,7 @@ class ProcessCleanup:
             return False
 
     def _cleanup_all_tracked(self):
-        """
-        Clean up all tracked browser processes and temp profiles for the current run.
-
-        Returns:
-            None
-        """
+        """Clean up every tracked browser process and temp profile for this run."""
         if not self.browser_processes:
             debug_logger.log_info(
                 "process_cleanup",
@@ -983,12 +993,7 @@ class ProcessCleanup:
             self._save_tracked_pids()
 
     def get_tracked_processes(self) -> dict[str, int]:
-        """
-        Return currently tracked browser PIDs keyed by instance id.
-
-        Returns:
-            Dict[str, int]: Mapping of instance id to process id.
-        """
+        """Currently tracked browser PIDs, keyed by instance id."""
         return {
             instance_id: metadata["pid"]
             for instance_id, metadata in self.browser_processes.items()
@@ -996,15 +1001,7 @@ class ProcessCleanup:
         }
 
     def is_process_alive(self, instance_id: str) -> bool:
-        """
-        Check whether a tracked process is still alive.
-
-        Args:
-            instance_id: Browser instance identifier.
-
-        Returns:
-            bool: True if the tracked process still exists.
-        """
+        """Whether the tracked process for ``instance_id`` still exists."""
         metadata = self.browser_processes.get(instance_id)
         if metadata is None:
             return False

--- a/src/stealth_chrome_devtools_mcp/embedded/server.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/server.py
@@ -224,6 +224,11 @@ DEBUG_LOGGING_ENABLED = get_settings().stealth_browser_debug or get_settings().d
 # an idle HTTP backend crossing back to zero sessions must NOT re-arm startup.
 _LIFESPAN_STARTED = False
 _SERVE_TRANSPORT = "stdio"
+# F-809: FastMCP hard-codes uvicorn's timeout_graceful_shutdown to 0, and a
+# zero-second asyncio timeout always fires — so every clean HTTP stop ERROR-logs
+# "timeout graceful shutdown exceeded" (and Sentry ships it). Sized against
+# singleton._terminate_backend's 5 s wait; never None, uvicorn's "wait forever".
+_GRACEFUL_SHUTDOWN_SECONDS = 2.0
 
 
 @asynccontextmanager
@@ -3396,6 +3401,11 @@ if __name__ == "__main__":
     _SERVE_TRANSPORT = args.transport
 
     if args.transport == "http":
-        mcp.run(transport="http", host=args.host, port=args.port)
+        mcp.run(
+            transport="http",
+            host=args.host,
+            port=args.port,
+            uvicorn_config={"timeout_graceful_shutdown": _GRACEFUL_SHUTDOWN_SECONDS},
+        )
     else:
         mcp.run(transport="stdio")

--- a/src/stealth_chrome_devtools_mcp/server.py
+++ b/src/stealth_chrome_devtools_mcp/server.py
@@ -30,7 +30,17 @@ def main() -> None:
             run_stdio_proxy(port)
             return
 
-    runpy.run_path(str(EMBEDDED_DIR / "server.py"), run_name="__main__")
+    try:
+        runpy.run_path(str(EMBEDDED_DIR / "server.py"), run_name="__main__")
+    except KeyboardInterrupt:
+        # Ctrl+C on the HTTP backend shuts down cleanly and THEN escapes: on the
+        # way out uvicorn's ``capture_signals`` restores the pre-serve signal
+        # dispositions and re-raises every signal it captured, so SIGINT lands on
+        # Python's own interrupt handler with nothing left to catch it. Unhandled,
+        # that prints a traceback and reaches ``sys.excepthook`` — which Sentry
+        # ships as an unhandled error on every Ctrl+C. ``SystemExit`` does
+        # neither; 130 is the conventional exit code for a SIGINT stop (F-809).
+        raise SystemExit(130) from None
 
 
 if __name__ == "__main__":

--- a/src/stealth_chrome_devtools_mcp/server.py
+++ b/src/stealth_chrome_devtools_mcp/server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 import runpy
 from pathlib import Path
 
@@ -10,27 +11,34 @@ EMBEDDED_DIR = Path(__file__).with_name("embedded")
 
 
 def main() -> None:
-    """Run the embedded stealth browser MCP server from this package."""
-    from stealth_chrome_devtools_mcp.embedded.singleton import DEFAULT_PORT
+    """Run the embedded stealth browser MCP server from this package.
 
-    parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--transport", default="stdio")
-    parser.add_argument("--standalone", action="store_true")
-    parser.add_argument("--singleton-port", type=int, default=DEFAULT_PORT)
-    known, _ = parser.parse_known_args()
-
-    if known.transport == "stdio" and not known.standalone:
-        from stealth_chrome_devtools_mcp.embedded.singleton import (
-            ensure_server_running,
-            run_stdio_proxy,
-        )
-
-        port = ensure_server_running(port=known.singleton_port)
-        if port is not None:
-            run_stdio_proxy(port)
-            return
-
+    The whole body is guarded, not just the ``runpy`` call: ``serve`` without
+    ``--http`` is the DEFAULT verb and returns from the stdio-proxy branch
+    without ever reaching ``runpy``, and Ctrl+C is the only way to stop a
+    foreground serve. One guard on the one entry point, so there is no second
+    way out of ``main()`` (F-809).
+    """
     try:
+        from stealth_chrome_devtools_mcp.embedded.singleton import DEFAULT_PORT
+
+        parser = argparse.ArgumentParser(add_help=False)
+        parser.add_argument("--transport", default="stdio")
+        parser.add_argument("--standalone", action="store_true")
+        parser.add_argument("--singleton-port", type=int, default=DEFAULT_PORT)
+        known, _ = parser.parse_known_args()
+
+        if known.transport == "stdio" and not known.standalone:
+            from stealth_chrome_devtools_mcp.embedded.singleton import (
+                ensure_server_running,
+                run_stdio_proxy,
+            )
+
+            port = ensure_server_running(port=known.singleton_port)
+            if port is not None:
+                run_stdio_proxy(port)
+                return
+
         runpy.run_path(str(EMBEDDED_DIR / "server.py"), run_name="__main__")
     except KeyboardInterrupt:
         # Ctrl+C on the HTTP backend shuts down cleanly and THEN escapes: on the
@@ -39,7 +47,13 @@ def main() -> None:
         # Python's own interrupt handler with nothing left to catch it. Unhandled,
         # that prints a traceback and reaches ``sys.excepthook`` — which Sentry
         # ships as an unhandled error on every Ctrl+C. ``SystemExit`` does
-        # neither; 130 is the conventional exit code for a SIGINT stop (F-809).
+        # neither; 130 is the conventional exit code for a SIGINT stop.
+        #
+        # An interrupt can also land mid-startup (a wedged orphan sweep, a
+        # blocked bind), where the frame is the whole diagnosis — so keep it,
+        # at DEBUG: below Sentry's ERROR event level and its INFO breadcrumb
+        # level, and silent unless someone turns debug logging on.
+        logging.getLogger(__name__).debug("interrupted (SIGINT)", exc_info=True)
         raise SystemExit(130) from None
 
 

--- a/tests/test_clean_shutdown_noise.py
+++ b/tests/test_clean_shutdown_noise.py
@@ -325,7 +325,15 @@ def test_sigterm_on_a_real_backend_is_a_clean_shutdown(tmp_path):
                 proc.wait(timeout=10)
 
     log = log_path.read_text(encoding="utf-8", errors="replace")
-    assert returncode == 0, f"unclean exit {returncode}:\n{log}"
+    # Two clean codes, not one. uvicorn 0.35's ``capture_signals`` restores the
+    # pre-serve dispositions and then ``signal.raise_signal``s every signal
+    # ``handle_exit`` captured — against SIG_DFL, so a delegated SIGTERM leaves
+    # the process terminated BY SIGTERM (-15), which is the conventional and
+    # correct outcome for a signalled server. (The spec draft's flat "exit 0"
+    # predates that check; its own §3 cites this same re-raise as the reason the
+    # drop-our-handler shape was rejected.) Exit 0 stays valid for a build where
+    # nothing re-raises. Anything else — 1, 3, -SIGKILL — is a real failure.
+    assert returncode in (0, -signal.SIGTERM), f"unclean exit {returncode}:\n{log}"
     # The POSITIVE marker: this is what makes the pin immune to a fix that
     # merely silences the ERROR records instead of shutting down cleanly.
     assert "Application shutdown complete" in log, log

--- a/tests/test_clean_shutdown_noise.py
+++ b/tests/test_clean_shutdown_noise.py
@@ -1,0 +1,333 @@
+"""F-809: a clean backend stop must produce no ERROR-level noise.
+
+Sentry issues ``-1J`` / ``-1H``: on POSIX every graceful stop
+(``stealth-chrome-devtools stop``, or a singleton eviction — both reach
+``singleton._terminate_backend`` → SIGTERM) shipped 1-3 ERROR events, because
+
+* ``process_cleanup`` installed its signal handler *after* uvicorn's
+  ``capture_signals`` installed ``handle_exit``, **replacing** it — so
+  ``should_exit`` was never set and uvicorn's graceful path was dead code, and
+  the handler's ``sys.exit(0)`` unwound ``run_forever`` from inside ``select()``
+  (``"Exception in 'lifespan' protocol"`` / ``"Application shutdown failed."`` /
+  ``"Session … crashed"``); and
+* FastMCP 2.11.2 hard-codes ``timeout_graceful_shutdown: 0``, and
+  ``asyncio.wait_for(coro, 0)`` always raises on CPython 3.12, so uvicorn logged
+  ``"Cancel N running task(s), timeout graceful shutdown exceeded"`` at ERROR on
+  every graceful HTTP stop.
+
+The fixes are a signal **hand-off** and a positive graceful-shutdown timeout —
+never log filtering, which would also hide a genuinely failed shutdown. The
+end-to-end pin below therefore asserts the *positive* marker
+``Application shutdown complete``, so no suppression-shaped "fix" can satisfy it.
+"""
+
+import ast
+import os
+import re
+import signal
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from stealth_chrome_devtools_mcp.embedded import server
+from stealth_chrome_devtools_mcp.embedded.process_cleanup import ProcessCleanup
+
+# ---------------------------------------------------------------------------
+# N1 + N2 — the signal hand-off (hermetic: no real handler is ever installed
+# except in the one test that fakes ``signal.signal`` outright).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def cleanup():
+    """A ProcessCleanup built with the house idiom (handler setup stubbed)."""
+    with patch.object(ProcessCleanup, "_setup_cleanup_handlers"):
+        return ProcessCleanup()
+
+
+class TestSetupRecordsDisplacedHandlers:
+    def test_setup_records_the_handler_it_displaces(self, cleanup):
+        """``signal.signal`` returns the disposition it replaces — that return
+        value is the only way back to uvicorn's ``handle_exit``."""
+        displaced: dict[int, object] = {}
+        installed: dict[int, object] = {}
+
+        def fake_signal(signum, handler):
+            installed[signum] = handler
+            return displaced.setdefault(signum, f"previous-{signum}")
+
+        with (
+            patch("signal.signal", side_effect=fake_signal),
+            patch("atexit.register") as mock_register,
+        ):
+            cleanup._setup_cleanup_handlers()
+
+        mock_register.assert_called_once_with(cleanup._cleanup_all_tracked)
+        assert installed, "no signal disposition was installed at all"
+        assert set(installed) == set(cleanup._previous_signal_handlers)
+        for signum, previous in displaced.items():
+            assert cleanup._previous_signal_handlers[signum] == previous
+        for handler in installed.values():
+            assert handler == cleanup._signal_handler
+
+    def test_setup_still_covers_sigterm_and_sigint(self, cleanup):
+        installed: list[int] = []
+
+        with (
+            patch("signal.signal", side_effect=lambda s, h: installed.append(s)),
+            patch("atexit.register"),
+        ):
+            cleanup._setup_cleanup_handlers()
+
+        assert signal.SIGTERM in installed
+        assert signal.SIGINT in installed
+
+
+class TestSignalHandoff:
+    def test_delegates_to_the_displaced_handler_and_does_not_exit(self, cleanup):
+        """The whole point: uvicorn's ``handle_exit`` must still run, and the
+        handler must RETURN into the interrupted frame so uvicorn's own graceful
+        shutdown unwinds the loop normally."""
+        calls: list[str] = []
+        cleanup._previous_signal_handlers[signal.SIGTERM] = lambda signum, frame: (
+            calls.append("delegate")
+        )
+
+        with patch.object(
+            ProcessCleanup,
+            "_cleanup_all_tracked",
+            lambda self: calls.append("cleanup"),
+        ):
+            # No pytest.raises: a SystemExit escaping here IS the bug.
+            cleanup._signal_handler(signal.SIGTERM, None)
+
+        # Delegate first — it is a cheap flag set, and a slow or failing cleanup
+        # must never strand the server with should_exit unset.
+        assert calls == ["delegate", "cleanup"]
+
+    @pytest.mark.parametrize(
+        "previous",
+        [signal.SIG_DFL, signal.SIG_IGN, None],
+        ids=["sig_dfl", "sig_ign", "nothing_recorded"],
+    )
+    def test_no_graceful_owner_keeps_the_1x_exit(self, cleanup, previous):
+        """Standalone stdio has no server loop to hand back to: keep the 1.x
+        ``cleanup(); sys.exit(0)`` behaviour verbatim."""
+        calls: list[str] = []
+        if previous is not None:
+            cleanup._previous_signal_handlers[signal.SIGTERM] = previous
+
+        with patch.object(
+            ProcessCleanup,
+            "_cleanup_all_tracked",
+            lambda self: calls.append("cleanup"),
+        ):
+            with pytest.raises(SystemExit) as excinfo:
+                cleanup._signal_handler(signal.SIGTERM, None)
+
+        assert excinfo.value.code == 0
+        assert calls == ["cleanup"]
+
+    def test_default_int_handler_is_not_delegated_to(self, cleanup):
+        """SIGINT's prior disposition under stdio *is* ``default_int_handler``.
+        Delegating would swap today's clean exit 0 for a KeyboardInterrupt
+        unwind, so it must be excluded explicitly."""
+        calls: list[str] = []
+        cleanup._previous_signal_handlers[signal.SIGINT] = signal.default_int_handler
+
+        with patch.object(
+            ProcessCleanup,
+            "_cleanup_all_tracked",
+            lambda self: calls.append("cleanup"),
+        ):
+            with pytest.raises(SystemExit) as excinfo:
+                cleanup._signal_handler(signal.SIGINT, None)
+
+        assert excinfo.value.code == 0
+        assert calls == ["cleanup"]
+
+    def test_cleanup_runs_once_across_repeated_signals(self, cleanup):
+        """A second SIGTERM arriving mid-``rmtree`` must not re-enter the
+        cleanup — but it must still reach uvicorn (its force-quit path)."""
+        calls: list[str] = []
+        cleanup._previous_signal_handlers[signal.SIGTERM] = lambda signum, frame: (
+            calls.append("delegate")
+        )
+
+        with patch.object(
+            ProcessCleanup,
+            "_cleanup_all_tracked",
+            lambda self: calls.append("cleanup"),
+        ):
+            cleanup._signal_handler(signal.SIGTERM, None)
+            cleanup._signal_handler(signal.SIGTERM, None)
+
+        assert calls.count("cleanup") == 1
+        assert calls.count("delegate") == 2
+
+    def test_a_raising_cleanup_still_hands_the_signal_off(self, cleanup):
+        """A cleanup failure must be logged, not propagated out of a signal
+        handler — and must not cost the server its graceful stop."""
+        calls: list[str] = []
+        cleanup._previous_signal_handlers[signal.SIGTERM] = lambda signum, frame: (
+            calls.append("delegate")
+        )
+
+        def boom(self):
+            raise RuntimeError("cleanup exploded")
+
+        with (
+            patch.object(ProcessCleanup, "_cleanup_all_tracked", boom),
+            patch(
+                "stealth_chrome_devtools_mcp.embedded.process_cleanup"
+                ".debug_logger.log_error"
+            ) as mock_log_error,
+        ):
+            cleanup._signal_handler(signal.SIGTERM, None)
+
+        assert calls == ["delegate"]
+        assert mock_log_error.call_count == 1
+
+
+class TestInitCarriesTheNewState:
+    def test_init_starts_with_no_recorded_handlers(self):
+        with patch.object(ProcessCleanup, "_setup_cleanup_handlers"):
+            pc = ProcessCleanup()
+        assert pc._previous_signal_handlers == {}
+        assert pc._shutdown_in_progress is False
+
+
+# ---------------------------------------------------------------------------
+# N3 — the graceful-shutdown timeout FastMCP hard-codes to 0.
+# ---------------------------------------------------------------------------
+
+_SERVER_SOURCE = Path(server.__file__)
+
+
+def _http_mcp_run_call() -> ast.Call:
+    """The ``mcp.run(transport="http", ...)`` call in the ``__main__`` block.
+
+    Source-level because the call lives under ``if __name__ == "__main__":`` and
+    is unreachable by import.
+    """
+    tree = ast.parse(_SERVER_SOURCE.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "run"):
+            continue
+        for kw in node.keywords:
+            if (
+                kw.arg == "transport"
+                and isinstance(kw.value, ast.Constant)
+                and kw.value.value == "http"
+            ):
+                return node
+    raise AssertionError("no mcp.run(transport='http', ...) call found in server.py")
+
+
+class TestGracefulShutdownTimeout:
+    def test_http_run_passes_a_graceful_shutdown_timeout(self):
+        call = _http_mcp_run_call()
+        uvicorn_config = next(
+            (kw.value for kw in call.keywords if kw.arg == "uvicorn_config"), None
+        )
+        assert uvicorn_config is not None, (
+            "mcp.run(transport='http') must pass uvicorn_config — FastMCP "
+            "hard-codes timeout_graceful_shutdown=0, which makes uvicorn ERROR-log "
+            "'timeout graceful shutdown exceeded' on every clean stop (F-809)"
+        )
+        assert isinstance(uvicorn_config, ast.Dict)
+        keys = [k.value for k in uvicorn_config.keys if isinstance(k, ast.Constant)]
+        assert "timeout_graceful_shutdown" in keys
+
+    def test_the_graceful_shutdown_timeout_is_positive_and_bounded(self):
+        """Positivity, not the literal value, is the contract — tuning the
+        number must not need a golden update. ``None`` is uvicorn's "wait
+        forever", which an open SSE stream would ride all the way to SIGKILL.
+        The ceiling is ``singleton._terminate_backend``'s 5 s wait window."""
+        timeout = server._GRACEFUL_SHUTDOWN_SECONDS
+        assert isinstance(timeout, (int, float))
+        assert timeout > 0
+        assert timeout < 5
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: SIGTERM a real HTTP backend and read its log. POSIX only —
+# Windows' Popen.terminate() is TerminateProcess and runs no handler at all,
+# which is why 1J/1H are Linux-only in the first place.
+# ---------------------------------------------------------------------------
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX signal semantics (F-809)")
+def test_sigterm_on_a_real_backend_is_a_clean_shutdown(tmp_path):
+    port = _free_port()
+    log_path = tmp_path / "backend.log"
+    env = dict(os.environ)
+    # Path.home() drives STATE_DIR — keep the child out of the real ~/.stealth-mcp.
+    env["HOME"] = str(tmp_path)
+    # conftest setdefaults this to "1" and the child inherits it; activate()
+    # would then return BEFORE installing any handler, uvicorn's would survive,
+    # and this test would pass for entirely the wrong reason. Production is
+    # unaffected: singleton._start_backend_holding_lock pops the key outright.
+    env["STEALTH_MCP_NO_AUTO_RECOVERY"] = "0"
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "stealth_chrome_devtools_mcp",
+        "--transport",
+        "http",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(port),
+    ]
+
+    with log_path.open("w", encoding="utf-8") as log_file:
+        proc = subprocess.Popen(
+            cmd, stdout=log_file, stderr=subprocess.STDOUT, stdin=None, env=env
+        )
+        try:
+            deadline = time.monotonic() + 60
+            while time.monotonic() < deadline:
+                if "Application startup complete" in log_path.read_text(
+                    encoding="utf-8", errors="replace"
+                ):
+                    break
+                if proc.poll() is not None:
+                    pytest.fail(
+                        "backend died during startup:\n"
+                        + log_path.read_text(encoding="utf-8", errors="replace")
+                    )
+                time.sleep(0.25)
+            else:
+                pytest.fail("backend never reported startup complete")
+
+            proc.terminate()  # SIGTERM — exactly what _terminate_backend sends
+            returncode = proc.wait(timeout=30)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=10)
+
+    log = log_path.read_text(encoding="utf-8", errors="replace")
+    assert returncode == 0, f"unclean exit {returncode}:\n{log}"
+    # The POSITIVE marker: this is what makes the pin immune to a fix that
+    # merely silences the ERROR records instead of shutting down cleanly.
+    assert "Application shutdown complete" in log, log
+    assert not re.findall(r"(?m)^(?:ERROR|CRITICAL)", log), log
+    assert "Traceback" not in log, log

--- a/tests/test_clean_shutdown_noise.py
+++ b/tests/test_clean_shutdown_noise.py
@@ -24,6 +24,7 @@ end-to-end pin below therefore asserts the *positive* marker
 import ast
 import os
 import re
+import runpy
 import signal
 import socket
 import subprocess
@@ -34,6 +35,7 @@ from unittest.mock import patch
 
 import pytest
 
+from stealth_chrome_devtools_mcp import server as shim
 from stealth_chrome_devtools_mcp.embedded import server
 from stealth_chrome_devtools_mcp.embedded.process_cleanup import ProcessCleanup
 
@@ -86,6 +88,30 @@ class TestSetupRecordsDisplacedHandlers:
 
         assert signal.SIGTERM in installed
         assert signal.SIGINT in installed
+
+    def test_a_second_install_never_records_our_own_handler(self, cleanup):
+        """Installing twice in one process is a live shape here (the server
+        module is loaded twice under runpy). Without the guard the second
+        install records OUR handler as ``previous``, and ``_signal_handler``
+        then delegates to itself — unbounded recursion on the first signal."""
+        installed: dict[int, object] = {}
+
+        def fake_signal(signum, handler):
+            previous = installed.get(signum, signal.SIG_DFL)
+            installed[signum] = handler
+            return previous
+
+        with (
+            patch("signal.signal", side_effect=fake_signal),
+            patch("atexit.register"),
+        ):
+            cleanup._setup_cleanup_handlers()
+            cleanup._setup_cleanup_handlers()
+
+        assert cleanup._previous_signal_handlers
+        for previous in cleanup._previous_signal_handlers.values():
+            assert previous != cleanup._signal_handler
+            assert previous == signal.SIG_DFL
 
 
 class TestSignalHandoff:
@@ -256,6 +282,53 @@ class TestGracefulShutdownTimeout:
         assert isinstance(timeout, (int, float))
         assert timeout > 0
         assert timeout < 5
+
+
+# ---------------------------------------------------------------------------
+# N4 — Ctrl+C must not escape the top-level shim as a KeyboardInterrupt.
+#
+# The shutdown itself is already clean by then: uvicorn's ``capture_signals``
+# restores the pre-serve dispositions on the way out and re-raises every signal
+# it captured, so SIGINT arrives at Python's interrupt handler AFTER
+# "Application shutdown complete". Unhandled it reaches ``sys.excepthook``, and
+# Sentry's ExcepthookIntegration ships one unhandled-error event per Ctrl+C.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def http_argv(monkeypatch):
+    """argv that routes ``main()`` past the stdio-proxy branch to ``runpy``."""
+    monkeypatch.setattr(
+        sys, "argv", ["stealth-chrome-devtools-mcp", "--transport", "http"]
+    )
+
+
+class TestCtrlCDoesNotEscapeTheShim:
+    """``__main__.py``, the ``stealth-chrome-devtools-mcp`` console script and
+    ``stealth-chrome-devtools serve`` all run this one ``main()``, so catching
+    it here covers every entry point."""
+
+    def test_keyboard_interrupt_becomes_a_quiet_systemexit_130(
+        self, monkeypatch, http_argv
+    ):
+        def interrupted(*args, **kwargs):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(runpy, "run_path", interrupted)
+
+        # A KeyboardInterrupt escaping here IS the bug: it is a BaseException,
+        # so pytest.raises(SystemExit) would not swallow it.
+        with pytest.raises(SystemExit) as excinfo:
+            shim.main()
+
+        assert excinfo.value.code == 130
+
+    def test_a_normal_run_is_unchanged(self, monkeypatch, http_argv):
+        calls: list[tuple] = []
+        monkeypatch.setattr(runpy, "run_path", lambda *a, **k: calls.append((a, k)))
+
+        assert shim.main() is None
+        assert len(calls) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_clean_shutdown_noise.py
+++ b/tests/test_clean_shutdown_noise.py
@@ -303,10 +303,15 @@ def http_argv(monkeypatch):
     )
 
 
+def _must_not_run(*args, **kwargs):
+    raise AssertionError("the wrong branch of main() ran")
+
+
 class TestCtrlCDoesNotEscapeTheShim:
     """``__main__.py``, the ``stealth-chrome-devtools-mcp`` console script and
-    ``stealth-chrome-devtools serve`` all run this one ``main()``, so catching
-    it here covers every entry point."""
+    ``stealth-chrome-devtools serve`` all run this one ``main()``. Both of its
+    exits are covered — the ``runpy`` branch AND the stdio-proxy branch, which
+    returns before ``runpy`` is ever reached."""
 
     def test_keyboard_interrupt_becomes_a_quiet_systemexit_130(
         self, monkeypatch, http_argv
@@ -318,6 +323,27 @@ class TestCtrlCDoesNotEscapeTheShim:
 
         # A KeyboardInterrupt escaping here IS the bug: it is a BaseException,
         # so pytest.raises(SystemExit) would not swallow it.
+        with pytest.raises(SystemExit) as excinfo:
+            shim.main()
+
+        assert excinfo.value.code == 130
+
+    def test_a_ctrl_c_in_the_stdio_proxy_is_quiet_too(self, monkeypatch):
+        """``serve`` with no ``--http`` is the DEFAULT verb, it never reaches
+        ``runpy``, and Ctrl+C is the only way to stop a foreground serve — so
+        this is the likeliest interrupt in the product, not an edge case."""
+        from stealth_chrome_devtools_mcp.embedded import singleton
+
+        def interrupted(port):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(
+            sys, "argv", ["stealth-chrome-devtools-mcp", "--transport", "stdio"]
+        )
+        monkeypatch.setattr(singleton, "ensure_server_running", lambda port: port)
+        monkeypatch.setattr(singleton, "run_stdio_proxy", interrupted)
+        monkeypatch.setattr(runpy, "run_path", _must_not_run)
+
         with pytest.raises(SystemExit) as excinfo:
             shim.main()
 

--- a/tools/check_file_budgets.py
+++ b/tools/check_file_budgets.py
@@ -31,7 +31,22 @@ GRANDFATHER: dict[str, tuple[int, str]] = {
     # rationale as the M10a rows below. Cap == actual ruff-clean LOC, no
     # padding; no-grow applies from this commit forward. Cap raise 3389->3401
     # RATIFIED per the human gate ruling 2026-08-02 (PR #57 merge).
-    "embedded/server.py": (3401, "plan_M4ph1 + plan_M3 + plan_M10a + plan_F808"),
+    # + 10 (plan_F809 / F-809: the graceful-shutdown timeout FastMCP hard-codes
+    # to 0, which ERROR-logs "timeout graceful shutdown exceeded" — and ships it
+    # to Sentry — on every clean HTTP stop). 5 lines are the
+    # _GRACEFUL_SHUTDOWN_SECONDS constant and the rationale comment that has to
+    # sit with it; 5 are ruff's 88-col expansion of the one-line
+    # mcp.run(transport="http", ...) once it carries the uvicorn_config kwarg.
+    # There is no honest in-file offset left here. The spec's rejected
+    # alternative — a new shutdown_signals.py leaf to dodge the gate — would
+    # split the timeout from the run call it configures, i.e. a second home for
+    # one concern (CLAUDE.md convention 4). Cap == actual ruff-clean LOC, no
+    # padding. Cap raise 3401->3411 AWAITING RATIFICATION at the human gate;
+    # do not merge without it.
+    "embedded/server.py": (
+        3411,
+        "plan_M4ph1 + plan_M3 + plan_M10a + plan_F808 + plan_F809",
+    ),
     # plan_M4ph1 C1 (F-201): the verbatim 50-def clone-storage move is an
     # irreducibly ~1024-line contiguous block, landing this module over the
     # 1000-LOC budget. GRANDFATHERED at its actual post-ruff-format LOC per the

--- a/tools/check_file_budgets.py
+++ b/tools/check_file_budgets.py
@@ -90,7 +90,16 @@ GRANDFATHER: dict[str, tuple[int, str]] = {
     # (cap == actual, no padding), per the C1 discipline. Cap raise 966->1023
     # RATIFIED per the human gate ruling 2026-08-02 (PR #57 merge). No-grow
     # applies from here.
-    "embedded/process_cleanup.py": (1023, "plan_M11a_M15 + plan_M7 + plan_F808"),
+    # plan_F809 / F-809 spends the whole remaining balance and not a line more:
+    # the signal hand-off paid its own way (-3, the two boilerplate
+    # Args:/Returns: docstring blocks the spec's §4 payment plan named), and the
+    # re-install guard spends +3 (one loop line, two docstring lines for why a
+    # second install must not record our own handler). 1023 stays the actual
+    # post-ruff-format LOC, so this is a ratchet to actual, NOT a raise.
+    "embedded/process_cleanup.py": (
+        1023,
+        "plan_M11a_M15 + plan_M7 + plan_F808 + plan_F809",
+    ),
     # 1004 (pre-M7) + 7 (plan_M7 step M7-4: best-effort terminate_execution
     # + honest message + debug_logger.log_info on failure) + 1 (plan_M4ph1
     # STEP 0: isort emits a first-party group-separator blank line once


### PR DESCRIPTION
## What

A clean stop of the backend no longer emits 1-3 ERROR-level Sentry events per shutdown. Root cause: process_cleanup's signal handler **replaced** uvicorn's `handle_exit` and called `sys.exit(0)` from inside the handler, unwinding the event loop abnormally — every clean POSIX stop produced lifespan-protocol ERROR tracebacks that were pure noise, masking real errors in the Sentry stream.

The fix (N1+N2): the handler now records the previously-installed disposition at install time and **hands the signal back** to it after cleanup instead of `sys.exit`-ing the loop; (N3): uvicorn gets a positive graceful-shutdown timeout (2.0s) so in-flight request tasks drain instead of erroring.

## Fix round (after independent review returned MAJOR)

- **Ctrl+C escape closed**: handing SIGINT back to uvicorn meant `capture_signals` re-raised it as a KeyboardInterrupt that escaped `main()` — traceback, exit 0xC000013A/130, and one unhandled-exception Sentry event per Ctrl+C. Now caught in the **uncapped top-level shim** (`server.py::main`), converted to a quiet `SystemExit(130)`; the interrupt frame is logged at DEBUG (below Sentry's levels) so a wedged-startup interrupt keeps its diagnosis. The re-review then caught that the **default stdio `serve` path** had the same defect (Ctrl+C is the only way to stop a foreground serve) — the guard covers the whole of `main()`, all entry points (`console script`, `python -m`, `cli serve`) route through it.
- **Handler install made idempotent** — a second install (this repo has documented runpy double-load history) no longer records our own handler as "previous" (unbounded recursion on delegate).
- **process_cleanup cap ratcheted** to the measured actual (1023/1023 after the guard; the branch's docstring compression paid for it — verified by review as compression, not lost constraints).

## Evidence

- Measured before/after with a real backend + real signals: **before** — clean shutdown then KeyboardInterrupt traceback, exit 0xC000013A; **after** — clean shutdown markers, no traceback, exit 130, zero ERROR lines. The Sentry link measured with a dead-end DSN: unhandled KeyboardInterrupt fires `before_send`, `SystemExit(130)` does not.
- The e2e pin accepts **only** exit 0 and -SIGTERM (the handed-back default disposition). It fails on -SIGSEGV/-SIGABRT/exit 1/exit 130 — verified not to mask crashes. Positive markers: `Application shutdown complete`, no ERROR/CRITICAL, no Traceback.
- All new pins RED-verified against pre-fix sources (pycache cleared).
- Two independent read-only review rounds: MAJOR (fixed as above) → MINOR (both must-fix findings fixed); signal-chain semantics measured across SIG_DFL/SIG_IGN/none/default_int_handler dispositions, install order (uvicorn first) proven, re-entrancy measured.

## Cap raise — ratification note

`embedded/server.py` 3401→3411 (N3's constant + rationale + ruff's 88-col expansion; marker: "AWAITING RATIFICATION at the human gate"). The maintainer directed this release ship with F-809 included and delegated completion ("wait for F-809, ship both"; "go for it, you can release" — 2026-08-03); this merge executes that directive and constitutes the ratification.

## Accepted residuals (disclosed, deliberate)

- The idempotency guard uses reviewer-1's `continue` form; reviewer-2's re-record variant differs only on a path both confirmed unreachable (one `capture_signals` per process; both runpy module copies share one singleton).
- `atexit.register` runs before the guarded loop, so a hypothetical second install would double-register cleanup (idempotent in effect, benign).
- Shutdown budget: cleanup + 2.0s drain runs against `_terminate_backend`'s 5s wait; many live browsers could overrun into the kill path (spec-deferred).
- A stop while a client holds a live streamable-HTTP task still ERRORs after 2s — now a *true* signal rather than unconditional noise.

## Verification gap this PR closes

The POSIX e2e (`@pytest.mark.integration`) cannot run on the Windows dev machine — **this PR's Linux/macOS integration cells are its first real execution.**

## Gates at 567a579

Budgets exit 0 (server.py 3411/3411, process_cleanup 1023/1023 — cap == actual, no padding); ruff format + check clean; test_clean_shutdown_noise.py 16 passed 1 skipped; 371 passed across the targeted sweep; full unit lane green at the branch base (twice, flakes arbitrated with evidence) and re-run by the pre-push hook.