### PR TITLE
F-812–F-815: Sentry-driven fixes — CDP Headers crash, expected-error filter, agent-UX forgiveness, strict fake seam

### DIFF
--- a/src/stealth_chrome_devtools_mcp/embedded/browser_manager.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/browser_manager.py
@@ -583,9 +583,8 @@ class BrowserManager:
             )
 
         if options.extra_headers:
-            await tab.send(
-                uc.cdp.network.set_extra_http_headers(headers=options.extra_headers)
-            )
+            headers = uc.cdp.network.Headers(options.extra_headers)
+            await tab.send(uc.cdp.network.set_extra_http_headers(headers=headers))
 
         window_metrics = await window_sizing.apply_and_measure(tab, options)
 
@@ -770,8 +769,10 @@ class BrowserManager:
                 )
             instance.state = BrowserState.ERROR
             hint = spawn_exhaustion.exhaustion_hint(process_cleanup.pid_file) or ""
-            message = f"Failed to spawn browser: {e!s}{hint}"
-            raise Exception(message)  # noqa: B904  plan_M4ph1
+            # No "Failed to spawn browser:" prefix here: the spawn_browser tool in
+            # server.py wraps this exception with exactly one, and carrying a second
+            # copy doubled it in the user-visible ToolError.
+            raise Exception(f"{e!s}{hint}")  # noqa: B904  plan_M4ph1
 
         return instance
 
@@ -1202,7 +1203,7 @@ class BrowserManager:
                 if referrer:
                     await tab.send(
                         uc.cdp.network.set_extra_http_headers(
-                            headers={"Referer": referrer}
+                            headers=uc.cdp.network.Headers({"Referer": referrer})
                         )
                     )
 

--- a/src/stealth_chrome_devtools_mcp/embedded/cdp_function_executor.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/cdp_function_executor.py
@@ -11,8 +11,10 @@ nodriver's CDP access:
 """
 
 import asyncio
+import inspect
 import json
 from collections.abc import Callable
+from types import ModuleType
 from typing import Any
 
 import nodriver as uc
@@ -20,6 +22,65 @@ from nodriver import Tab
 
 from stealth_chrome_devtools_mcp.embedded import python_binding
 from stealth_chrome_devtools_mcp.embedded.debug_logger import debug_logger
+from stealth_chrome_devtools_mcp.embedded.tool_errors import ToolError
+
+
+def _lookup_key(name: str) -> str:
+    """Fold a CDP domain or method name to a case- and separator-free key.
+
+    ``setDeviceMetricsOverride``, ``set_device_metrics_override`` and
+    ``SetDeviceMetricsOverride`` name one command; ``IndexedDB`` and
+    ``indexed_db`` name one domain. Folding is used instead of a camelCase ->
+    snake_case rewrite because nodriver's generated names carry acronyms
+    (``IO`` -> ``io``, ``DOMSnapshot`` -> ``dom_snapshot``) and a reserved word
+    (``Input`` -> ``input_``) that no rewrite rule reproduces.
+    """
+    return name.replace("_", "").lower()
+
+
+def resolve_cdp_command(command: str) -> tuple[Any, str]:
+    """Resolve a caller's CDP command name to nodriver's callable (F-813).
+
+    Accepts the CDP wire spelling (``Emulation.setDeviceMetricsOverride``),
+    nodriver's own spelling (``emulation.set_device_metrics_override``) and the
+    bare Runtime method (``evaluate``) — every AI-facing spelling of the same
+    command. This is ONE lookup, not a second path beside the old one: the exact
+    attribute is tried first, so every name that resolved before resolves to the
+    identical object, and only a miss falls through to the folded key.
+
+    Returns:
+        tuple[Any, str]: the command callable (``None`` if nothing matched) and
+        the ``domain.method`` name that was looked for, so a caller's error can
+        say what was actually attempted.
+    """
+    domain, _, method = command.rpartition(".")
+    module: ModuleType | None = uc.cdp.runtime
+    if domain:
+        wanted = _lookup_key(domain)
+        module = next(
+            (
+                candidate
+                for name, candidate in vars(uc.cdp).items()
+                if isinstance(candidate, ModuleType) and _lookup_key(name) == wanted
+            ),
+            None,
+        )
+        if module is None:
+            return None, f"{wanted}.{method}"
+
+    found = getattr(module, method, None)
+    if found is None:
+        wanted = _lookup_key(method)
+        found = next(
+            (
+                candidate
+                for name, candidate in vars(module).items()
+                if inspect.isfunction(candidate) and _lookup_key(name) == wanted
+            ),
+            None,
+        )
+    domain_name = module.__name__.rpartition(".")[2]
+    return found, f"{domain_name}.{getattr(found, '__name__', method)}"
 
 
 class ExecutionContext:
@@ -168,9 +229,13 @@ class CDPFunctionExecutor:
         """
         try:
             await self.enable_runtime(tab)
-            cdp_method = getattr(uc.cdp.runtime, command, None)
+            cdp_method, tried = resolve_cdp_command(command)
             if not cdp_method:
-                raise ValueError(f"Unknown CDP command: {command}")  # noqa: TRY301  plan_M4ph1
+                # ToolError, not ValueError: a caller naming a command that does
+                # not exist is the error CONVENTION reporting an expected
+                # failure, and observability's before_send drops those by type.
+                # As a ValueError it was an unhandled-crash shape, and shipped.
+                raise ToolError(f"Unknown CDP command: {command} (tried {tried})")  # noqa: TRY301  plan_M4ph1
             result = await tab.send(cdp_method(**params))
             debug_logger.log_info(
                 "cdp_function_executor",

--- a/src/stealth_chrome_devtools_mcp/embedded/dom_handler.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/dom_handler.py
@@ -20,6 +20,11 @@ from stealth_chrome_devtools_mcp.embedded.tool_errors import (
     _require_js_value,
 )
 
+#: Chrome's compile-time complaint when a script carries a top-level ``return``
+#: (lower-cased for matching). ``execute_script`` treats it as "this script is a
+#: function body, not an expression" and retries once — see F-812.
+ILLEGAL_RETURN = "illegal return statement"
+
 
 class DOMHandler:
     """Handles DOM queries and element interactions."""
@@ -680,6 +685,14 @@ class DOMHandler:
         """
         Execute JavaScript in page context.
 
+        A script is evaluated as-is. If — and only if — that fails with Chrome's
+        "Illegal return statement", it is re-evaluated ONCE as a function body so
+        a top-level ``return`` works (F-812: the single most common way an
+        agent-authored script fails). The retry is keyed on that one error rather
+        than wrapping every script, because a wrapper changes what a script
+        MEANS: top-level ``var``/``function`` declarations that a caller expects
+        to persist on the page would become locals of the wrapper instead.
+
         Args:
             tab (Tab): The browser tab object.
             script (str): JavaScript code to execute.
@@ -703,7 +716,37 @@ class DOMHandler:
         # Outside the except on purpose: a script that THREW is a failure of the
         # script, not of the CDP call, so it must not be re-wrapped in the
         # "Failed to execute script" (operational) message. F-795.
-        return _require_js_value(result)
+        try:
+            return _require_js_value(result)
+        except ToolError as exception:
+            if ILLEGAL_RETURN not in str(exception).lower():
+                raise
+
+        return await DOMHandler._evaluate_as_function_body(tab, script)
+
+    @staticmethod
+    async def _evaluate_as_function_body(tab: Tab, script: str) -> Any:
+        """Re-evaluate *script* wrapped in a function so its top-level ``return``
+        is legal (F-812), reporting a failure as the script's own.
+
+        The wrapped attempt's error is the one surfaced: the "Illegal return
+        statement" that sent us here is an artifact of how the FIRST attempt
+        evaluated the script, so re-reporting it would name our strategy instead
+        of the caller's actual defect (a ``ReferenceError`` in the body, say).
+        The wrapper is named in the message because it is visible in the stack.
+        """
+        try:
+            result = await tab.evaluate(f"(() => {{\n{script}\n}})()")
+        except Exception as e:
+            raise Exception(f"Failed to execute script: {e!s}")
+
+        try:
+            return _require_js_value(result)
+        except ToolError as exception:
+            raise ToolError(
+                f"{exception} (the script was re-evaluated inside a wrapper "
+                "function because it has a top-level 'return')"
+            ) from None
 
     @staticmethod
     async def get_page_content(

--- a/src/stealth_chrome_devtools_mcp/embedded/server.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/server.py
@@ -1022,7 +1022,7 @@ async def execute_script(
 
     Args:
         instance_id (str): Browser instance ID.
-        script (str): JavaScript to execute. Must be non-blocking.
+        script (str): JavaScript to execute; non-blocking. Top-level 'return' OK.
         args (Optional[List[Any]]): Arguments passed to the script body.
         timeout_ms (Optional[int]): Max run time in ms (default 10000, max 60000).
             A blocking script is killed at this limit instead of hanging the tab.
@@ -2656,13 +2656,15 @@ async def execute_cdp_command(
     instance_id: str, command: str, params: dict[str, Any] = None
 ) -> dict[str, Any]:
     """
-    Execute a raw CDP Runtime command by name — the low-level escape hatch
-    beneath the exec-family tools. Prefer `execute_script` for ordinary page JS;
-    use this only for a specific CDP method (e.g. 'evaluate', 'callFunctionOn').
+    Execute a raw CDP command by name — the low-level escape hatch beneath the
+    exec-family tools. Prefer `execute_script` for ordinary page JS; use this
+    only for one specific CDP method (e.g. 'evaluate', 'Page.reload').
 
     Args:
         instance_id (str): Browser instance ID.
-        command (str): CDP command name (e.g., 'evaluate', 'callFunctionOn').
+        command (str): CDP command, either domain-qualified ('Page.reload',
+                'Emulation.setDeviceMetricsOverride') or a bare Runtime method
+                ('evaluate'). Wire casing and snake_case both resolve.
         params (Dict[str, Any], optional): Command parameters as a dictionary.
                 IMPORTANT: Use snake_case parameter names (e.g., 'return_by_value')
                 NOT camelCase ('returnByValue'). The nodriver library expects
@@ -2672,10 +2674,8 @@ async def execute_cdp_command(
         Dict[str, Any]: Command execution result.
 
     Example:
-        # Correct - use snake_case
+        # The command NAME is casing-flexible; the PARAMS are not — snake_case.
         params = {"expression": "document.title", "return_by_value": True}
-
-        params = {"expression": "document.title", "returnByValue": True}
     """
     tab = await _require_tab(browser_manager, instance_id)
     return await _with_cdp_timeout(

--- a/src/stealth_chrome_devtools_mcp/observability.py
+++ b/src/stealth_chrome_devtools_mcp/observability.py
@@ -26,11 +26,17 @@ the machine's ``server_name`` is dropped and the home-directory segment of every
 path is replaced with ``~``. Everything a maintainer debugs from — release,
 environment, correlation ids, the exception type and mechanism, the module path
 after the home segment — is deliberately left intact.
+
+The same hook is also the one place that decides an event is not worth sending:
+a failure raised through the project's own error CONVENTION
+(``embedded/tool_errors.py``) is the product working as designed, not a crash.
+See :func:`_is_expected_tool_failure`.
 """
 
 import importlib.metadata
 import logging
 import re
+from functools import cache
 from typing import TYPE_CHECKING, cast
 
 from stealth_chrome_devtools_mcp.settings import get_settings
@@ -148,22 +154,196 @@ def _anonymize(value: object, depth: int = 0) -> object:
     return value
 
 
-def _scrub_event(event: "Event", _hint: "dict[str, object] | None" = None) -> "Event":
-    """Sentry's ``before_send``: strip what identifies the reporter, keep the rest.
+#: The tool-surface classes that mean "expected failure", by NAME. Used only by
+#: the payload fallback below; the live-object path uses ``isinstance`` instead.
+#: Deliberately an explicit allowlist rather than "anything from our package":
+#: this decides what is never seen again, so it names what it drops.
+_EXPECTED_ERROR_NAMES = frozenset({"ToolError", "InstanceNotFoundError"})
+
+#: A name alone is not enough. ``fastmcp.exceptions.ToolError`` is a DIFFERENT
+#: class with the same name, and it is what wraps a genuine crash on its way out
+#: of ``tool_manager`` (``raise ToolError(...) from e``) — matching on the bare
+#: name would drop exactly the real bugs this filter exists to preserve.
+_EXPECTED_ERROR_MODULE_PREFIX = "stealth_chrome_devtools_mcp"
+
+#: ``sys.exc_info()``'s shape — ``(type, value, traceback)``.
+_EXC_INFO_LENGTH = 3
+
+
+@cache
+def _expected_error_base() -> "type[BaseException] | None":
+    """``tool_errors.ToolError``, imported on first use rather than at module import.
+
+    Lazy on purpose. ``cli.py`` imports this module at startup and imports
+    nothing from ``embedded/`` at top level, and importing the ``embedded``
+    package runs its sanctioned ``sys.path`` shim (``embedded/__init__.py``),
+    which puts module names like ``models`` and ``settings`` ahead of everything
+    else on the path. That shim belongs to the backend; nothing is gained by
+    firing it in an ops-CLI process that may never ship an event. By the time a
+    ``ToolError`` exists to classify, the leaf is loaded anyway.
+
+    ``ToolError`` alone is the base: ``InstanceNotFoundError`` and any future
+    subclass are covered by ``isinstance``, which is the point of the convention.
+    Returns ``None`` if the import fails, which degrades to the payload fallback
+    rather than to an exception.
+    """
+    try:
+        from stealth_chrome_devtools_mcp.embedded.tool_errors import ToolError
+    except Exception:  # noqa: BLE001  PERMANENT(never-raises contract, #55)
+        return None
+    return ToolError
+
+
+def _exception_chain(exc: BaseException) -> "list[BaseException]":
+    """``exc`` and everything it was raised from, in the order Sentry reports them.
+
+    Mirrors the SDK's own walk (``__cause__``, else ``__context__`` unless
+    ``raise ... from None`` suppressed it) so the live-object path and the
+    payload path below judge the SAME set of exceptions. Bounded and cycle-safe
+    for the same reason :data:`_MAX_EVENT_DEPTH` exists.
+    """
+    chain: list[BaseException] = []
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and id(current) not in seen:
+        if len(chain) >= _MAX_EVENT_DEPTH:
+            break
+        seen.add(id(current))
+        chain.append(current)
+        following = current.__cause__
+        if following is None and not current.__suppress_context__:
+            following = current.__context__
+        current = following
+    return chain
+
+
+def _hint_exception(hint: "dict[str, object] | None") -> "BaseException | None":
+    """The live exception behind an event, if the SDK handed one over.
+
+    Two shapes, because the logging integration produces both: an exception
+    event carries ``hint["exc_info"]`` (``event_from_exception`` fills it in even
+    when the event came from ``logger.exception``), and the record itself is
+    attached as ``hint["log_record"]``. The record is consulted only as a
+    fallback — a hand-built hint, or an SDK that stops filling ``exc_info`` in.
+    """
+    if not isinstance(hint, dict):
+        return None
+    candidates = (
+        hint.get("exc_info"),
+        getattr(hint.get("log_record"), "exc_info", None),
+    )
+    for candidate in candidates:
+        if isinstance(candidate, BaseException):
+            return candidate
+        if (
+            isinstance(candidate, tuple)
+            and len(candidate) == _EXC_INFO_LENGTH
+            and isinstance(candidate[1], BaseException)
+        ):
+            return candidate[1]
+    return None
+
+
+def _is_expected_tool_failure(
+    event: "Event", hint: "dict[str, object] | None" = None
+) -> bool:
+    """Is this event nothing but the error convention doing its job?
+
+    Tools report an expected failure by RAISING ``tool_errors.ToolError`` (a bad
+    script, a missing instance, an unknown selector) — CLAUDE.md convention 2.
+    FastMCP logs every raising tool through ``logger.exception``, so the logging
+    integration turns each of those into a Sentry ERROR event with
+    ``handled: yes``. The top issues in the project's Sentry were all of them:
+    205 events of an agent passing an illegal script to ``execute_script``. That
+    is the product answering correctly, and it drowns the events that are not.
+
+    Two paths to the same decision, and the SAME rule:
+
+    * ``hint`` carries the live exception → ``isinstance``, which is exact and
+      picks up subclasses raised anywhere;
+    * only the serialized payload is available → the exception ``type`` name must
+      be in :data:`_EXPECTED_ERROR_NAMES` *and* its ``module`` must be ours.
+
+    **Drops only when EVERY exception in the chain is one of ours.** A
+    ``ToolError`` raised while handling an ``AttributeError`` keeps the event:
+    the real bug is in there, and this filter must never be the reason nobody
+    saw it. That is also why a broken logger name is not the test — the
+    ``AttributeError`` in ``navigate`` that this project actually shipped
+    arrived through ``FastMCP.fastmcp.tools.tool_manager``, the very logger the
+    noise arrives on, so ``ignore_logger`` on it would have hidden a real bug.
+
+    Never raises: an event it cannot classify is an event it sends.
+    """
+    try:
+        exception = _hint_exception(hint)
+        if exception is not None:
+            base = _expected_error_base()
+            if base is not None:
+                return all(
+                    isinstance(link, base) for link in _exception_chain(exception)
+                )
+        return _payload_is_expected_tool_failure(event)
+    except Exception:  # noqa: BLE001  PERMANENT(never-raises contract, #55)
+        _log.debug("Sentry expected-failure check failed; shipping", exc_info=True)
+        return False
+
+
+def _payload_is_expected_tool_failure(event: "Event") -> bool:
+    """The name-and-module rule, applied to a serialized event's exception values.
+
+    Every value must match, and an event with no exception values at all does
+    not match: "nothing to classify" is not "expected", or a message-only event
+    would be silently dropped.
+    """
+    if not isinstance(event, dict):
+        return False
+    exception = event.get("exception")
+    values = exception.get("values") if isinstance(exception, dict) else None
+    if not isinstance(values, list) or not values:
+        return False
+    return all(_value_is_expected_tool_failure(value) for value in values)
+
+
+def _value_is_expected_tool_failure(value: object) -> bool:
+    """One serialized exception: ours by name AND by module, or it is not ours."""
+    if not isinstance(value, dict):
+        return False
+    module = value.get("module")
+    return (
+        value.get("type") in _EXPECTED_ERROR_NAMES
+        and isinstance(module, str)
+        and module.startswith(_EXPECTED_ERROR_MODULE_PREFIX)
+    )
+
+
+def _scrub_event(
+    event: "Event", hint: "dict[str, object] | None" = None
+) -> "Event | None":
+    """Sentry's ``before_send``: drop the expected, scrub what is left.
+
+    THE one hook (there is no second ``before_send``; a second way to change an
+    outgoing event is a defect). It does two things in order:
+
+    0. an event that is only the error convention working as designed is dropped
+       — see :func:`_is_expected_tool_failure`;
+    1. everything that survives is scrubbed.
 
     Two removals, both universal — there is no maintainer-only path:
 
     * ``server_name``, which is the machine's own hostname;
     * the home-directory segment of every path, which is the account name.
 
-    Never raises, and never drops the event: an event we could not fully scrub
-    is still worth more than silence, so an internal failure degrades to
+    Never raises. The only event it drops is the one it positively recognised in
+    step 0; an event we could not fully scrub, or could not classify, is still
+    worth more than silence, so an internal failure degrades to
     :func:`_without_server_name` rather than to ``None``. The ``isinstance``
     guards look redundant against the annotation and are not — the annotation
     states what the SDK promises to pass, and this function is the last thing
     that runs before an event leaves the machine, so it defends against being
     handed something else rather than dying at the boundary.
     """
+    if _is_expected_tool_failure(event, hint):
+        return None
     try:
         scrubbed = _anonymize(event)
         if isinstance(scrubbed, dict):

--- a/tests/MANUAL_QA_PROTOCOL.md
+++ b/tests/MANUAL_QA_PROTOCOL.md
@@ -741,19 +741,21 @@ count, not membership of each path created by the test.
 `tests/test_e2e_functions_hooks.py::test_list_cdp_commands_are_domain_method_strings`.
 **Current support (non-acceptance)**: pytest:
 `tests/test_e2e_functions_hooks.py::test_cdp_functions_walk` proves only a
-non-empty list; pytest:
-`tests/test_e2e_functions_hooks.py::test_execute_cdp_command_rejects_domain_qualified_name`
-is an unrouted characterization of the convention mismatch.
+non-empty list; the convention mismatch it used to advertise is closed by F-813
+and pinned hermetically by pytest:
+`tests/test_cdp_command_normalization.py::test_every_command_the_tool_advertises_can_actually_run`
+(every advertised name resolves; the list is still bare Runtime methods, not the
+`domain.method` strings this step asks for).
 
 ### MQ-81: Execute CDP command
 **Manual**: `execute_cdp_command` with `Runtime.evaluate` → returns result.
 **Evidence**: planned — planned-pytest:
 `tests/test_e2e_functions_hooks.py::test_execute_cdp_runtime_evaluate_domain_qualified`.
-**Current support (non-acceptance)**: pytest:
-`tests/test_e2e_functions_hooks.py::test_cdp_functions_walk` succeeds only with
-the bare command `evaluate`; pytest:
-`tests/test_e2e_functions_hooks.py::test_execute_cdp_command_rejects_domain_qualified_name`
-is an unrouted characterization of `Runtime.evaluate` failing.
+**Current support (non-acceptance)**: that node now EXISTS and asserts the fixed
+behaviour (F-813 replaced the characterization that pinned `Runtime.evaluate`
+failing), but it has not been run against real Chrome yet — flip this row to
+acceptance once the integration lane is green. Hermetic half: pytest:
+`tests/test_cdp_command_normalization.py`.
 
 ### MQ-82: Get execution contexts
 **Manual**: `get_execution_contexts` → ≥1 context.

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -30,9 +30,10 @@ from __future__ import annotations
 import inspect
 import json
 from pathlib import Path
-from types import SimpleNamespace
+from types import GeneratorType, SimpleNamespace
 from typing import Any
 
+import nodriver.cdp.dom as cdp_dom
 import nodriver.cdp.target as cdp_target
 
 # ---------------------------------------------------------------------------
@@ -195,6 +196,7 @@ class FakeTab:
         self._select_result = select_result
         self.evaluate_calls: list[str] = []
         self.send_calls: list[str] = []
+        self.get_calls: list[str] = []
         self.select_calls: list[str] = []
         self.cdp_frames: list[dict[str, Any]] = []
         self.handlers: list[tuple[Any, Any]] = []
@@ -215,6 +217,17 @@ class FakeTab:
                 return resp
         return self._evaluate_result
 
+    async def get(self, url: str, *args: Any, **kwargs: Any) -> FakeTab:
+        """nodriver's ``Tab.get`` — the navigation seam.
+
+        Updates ``.url`` the way a real navigation does, so a caller that reads
+        the tab back after navigating sees where it went. Returns ``self``, as
+        ``Tab.get`` returns the tab it navigated.
+        """
+        self.get_calls.append(url)
+        self.url = url
+        return self
+
     async def select(self, selector: str, *args: Any, **kwargs: Any) -> Any:
         """The nodriver element-resolution seam used by the CDP styles path and
         ``clone_element_complete``. Returns the configured ``select_result``
@@ -234,18 +247,26 @@ class FakeTab:
     async def send(self, cdp_obj: Any, *args: Any, **kwargs: Any) -> Any:
         name = cdp_command_name(cdp_obj)
         self.send_calls.append(name)
-        close = getattr(cdp_obj, "close", None)
-        if callable(close):
+        if isinstance(cdp_obj, GeneratorType):
+            # Advancing once yields the request frame ({"method", "params"}), so a
+            # test can assert the *arguments* of a CDP command.
+            #
+            # Nothing here is swallowed, deliberately. A nodriver command builds
+            # its frame WHILE being advanced, so an argument it cannot serialize
+            # (a raw dict where a ``to_json()``-bearing type is required) raises on
+            # exactly this line — and a bare ``except Exception: pass`` around it
+            # is what let Sentry STEALTH-…-1P ship green through 43 tests. Only
+            # StopIteration is tolerated, and only because a command that yields no
+            # frame has nothing to record.
+            #
+            # The ``isinstance`` gate is the whole tolerance: a non-generator
+            # double (a Mock, which answers ``callable(obj.close)`` truthfully)
+            # is skipped outright rather than advanced and forgiven.
             try:
-                # Advancing once yields the request frame ({"method", "params"}),
-                # so a test can assert the *arguments* of a CDP command.
                 self.cdp_frames.append(next(cdp_obj))
-            except Exception:
+            except StopIteration:
                 pass
-            try:
-                close()  # never leave the generator un-iterated
-            except Exception:
-                pass
+            cdp_obj.close()  # never leave the generator un-iterated
         resp = self._cdp_responses.get(name, None)
         return resp(name) if callable(resp) else resp
 
@@ -274,6 +295,21 @@ def fake_target(
     return SimpleNamespace(
         target_id=cdp_target.TargetID(target_id), url=url, title=title, type_=type_
     )
+
+
+def fake_element(node_id: int = 1, **attrs: Any) -> SimpleNamespace:
+    """A nodriver element double carrying a REAL ``cdp.dom.NodeId``.
+
+    The exact twin of :func:`fake_target`'s reasoning, one level down. ``NodeId``
+    is an ``int`` subclass whose only addition is ``to_json()``, and every by-node
+    CDP command serialises with ``node_id.to_json()`` (``cdp/css.py:1814``), so a
+    bare ``int`` here is an element that could not exist: production's
+    ``_resolve_node_id`` returns ``element.node.node_id``, always a real
+    ``NodeId``.
+
+    ``NodeId(n) == n``, so assertions comparing against a plain int still hold.
+    """
+    return SimpleNamespace(node_id=cdp_dom.NodeId(node_id), **attrs)
 
 
 class FakeDiscoveredTarget:

--- a/tests/test_cdp_command_normalization.py
+++ b/tests/test_cdp_command_normalization.py
@@ -1,0 +1,204 @@
+"""Pins for F-813: execute_cdp_command accepts every spelling of a CDP command.
+
+Callers send the name they read in the CDP docs — ``Emulation.setDeviceMetrics
+Override`` — or the one they read in nodriver — ``emulation.set_device_metrics_
+override``. The executor resolved only ``getattr(uc.cdp.runtime, command)``, so
+both raised ``Unknown CDP command`` (Sentry STEALTH-CHROME-DEVTOOLS-MCP-1N, 42
+events). Two separate defects hid in that one lookup:
+
+* it was Runtime-only, so no other domain could ever be reached, and
+* it was casing-exact, so of the 21 camelCase names ``list_cdp_commands``
+  ADVERTISES, only ``evaluate`` (identical in both conventions) could run — the
+  tool's own docstring example, ``callFunctionOn``, could not.
+
+``resolve_cdp_command`` folds case and underscores and resolves through the SAME
+lookup: the exact attribute is tried first, so a name that worked before still
+resolves to the identical object. Hermetic — the resolver is pure, and the
+executor runs against a ``FakeTab``.
+"""
+
+import nodriver as uc
+import pytest
+
+from fakes import FakeBrowserManager, FakeTab, call_tool
+from stealth_chrome_devtools_mcp.embedded import cdp_function_executor, server
+from stealth_chrome_devtools_mcp.embedded.cdp_function_executor import (
+    CDPFunctionExecutor,
+    resolve_cdp_command,
+)
+from stealth_chrome_devtools_mcp.embedded.tool_errors import ToolError
+
+VIEWPORT = {
+    "width": 390,
+    "height": 844,
+    "device_scale_factor": 3.0,
+    "mobile": True,
+}
+
+
+@pytest.mark.parametrize(
+    "spelling",
+    [
+        "evaluate",  # the one spelling that worked before
+        "Runtime.evaluate",  # CDP wire form
+        "runtime.evaluate",  # nodriver module form
+        "Runtime.Evaluate",
+    ],
+)
+def test_every_spelling_of_a_runtime_command_resolves_to_one_object(spelling):
+    found, tried = resolve_cdp_command(spelling)
+
+    assert found is uc.cdp.runtime.evaluate, "must be the same callable, not a copy"
+    assert tried == "runtime.evaluate"
+
+
+@pytest.mark.parametrize(
+    "spelling",
+    [
+        "Emulation.setDeviceMetricsOverride",
+        "emulation.set_device_metrics_override",
+        "emulation.setDeviceMetricsOverride",
+    ],
+)
+def test_a_non_runtime_domain_resolves_from_the_reported_spellings(spelling):
+    """The exact Sentry payload: a domain the old lookup could not reach."""
+    found, tried = resolve_cdp_command(spelling)
+
+    assert found is uc.cdp.emulation.set_device_metrics_override
+    assert tried == "emulation.set_device_metrics_override"
+
+
+@pytest.mark.parametrize(
+    ("spelling", "expected"),
+    [
+        # Folding, not a camelCase->snake_case rewrite: nodriver's generated
+        # names keep acronyms whole and escape one Python keyword, and no
+        # rewrite rule reproduces those.
+        ("DOM.getDocument", uc.cdp.dom.get_document),
+        ("IndexedDB.requestDatabaseNames", uc.cdp.indexed_db.request_database_names),
+        ("Input.dispatchKeyEvent", uc.cdp.input_.dispatch_key_event),
+        ("IO.read", uc.cdp.io.read),
+    ],
+)
+def test_acronym_and_keyword_domains_resolve(spelling, expected):
+    assert resolve_cdp_command(spelling)[0] is expected
+
+
+@pytest.mark.asyncio
+async def test_every_command_the_tool_advertises_can_actually_run():
+    """``list_cdp_commands`` is a promise; this is the pin that it is kept.
+
+    Before F-813 exactly one of these 21 names resolved. A name that cannot be
+    executed has no business being advertised, so the list and the resolver are
+    held together here rather than drifting apart again.
+    """
+    advertised = await CDPFunctionExecutor().list_cdp_commands()
+
+    unresolvable = [name for name in advertised if resolve_cdp_command(name)[0] is None]
+
+    assert not unresolvable, f"advertised but not executable: {unresolvable}"
+
+
+def test_an_unknown_command_stays_unknown():
+    """Folding must not turn a typo into some other command."""
+    assert resolve_cdp_command("Runtime.noSuchThing")[0] is None
+    assert resolve_cdp_command("noSuchThing")[0] is None
+    assert resolve_cdp_command("NoSuchDomain.evaluate")[0] is None
+
+
+@pytest.mark.asyncio
+async def test_the_executor_sends_the_resolved_command():
+    executor = CDPFunctionExecutor()
+    tab = FakeTab(
+        cdp_responses={"enable": None, "set_device_metrics_override": {"ok": True}}
+    )
+
+    result = await executor.execute_cdp_command(
+        tab, "Emulation.setDeviceMetricsOverride", VIEWPORT
+    )
+
+    assert result["success"] is True
+    assert result["result"] == {"ok": True}
+    assert "set_device_metrics_override" in tab.send_calls
+    # The caller's own spelling is echoed back — it is what they asked for.
+    assert result["command"] == "Emulation.setDeviceMetricsOverride"
+
+
+@pytest.mark.asyncio
+async def test_the_executor_still_runs_a_bare_runtime_command_unchanged():
+    executor = CDPFunctionExecutor()
+    tab = FakeTab(cdp_responses={"enable": None, "evaluate": ("remote", None)})
+
+    result = await executor.execute_cdp_command(
+        tab, "evaluate", {"expression": "6 * 7", "return_by_value": True}
+    )
+
+    assert result["success"] is True
+    assert result["result"] == ("remote", None)
+    assert tab.send_calls == ["enable", "evaluate"]
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_command_reports_what_was_looked_for():
+    executor = CDPFunctionExecutor()
+    tab = FakeTab(cdp_responses={"enable": None})
+
+    result = await executor.execute_cdp_command(tab, "Emulation.setNoSuchThing", {})
+
+    assert result["success"] is False
+    assert "Unknown CDP command: Emulation.setNoSuchThing" in result["error"]
+    # Naming the resolved form tells a caller the DOMAIN was found and the
+    # METHOD was not — the difference between a typo and a wrong domain.
+    assert "emulation.setNoSuchThing" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_command_is_reported_as_an_expected_tool_failure(monkeypatch):
+    """The unknown-command failure must be a ToolError, not a ValueError.
+
+    Nothing OUTSIDE this method can see the difference — the executor catches its
+    own raise and returns the ``{"success": False}`` dict either way. The type is
+    observable at exactly one place, the hand-off to ``debug_logger.log_error``,
+    which passes it to the backend logger as ``exc_info``; from there Sentry's
+    ``before_send`` drops it only if it is the project's own error convention.
+    As a ValueError this expected failure shipped as a crash (42 events), so the
+    class is the whole fix and this is where it can be pinned.
+    """
+    reported: list[BaseException] = []
+    monkeypatch.setattr(
+        cdp_function_executor.debug_logger,
+        "log_error",
+        lambda component, method, error, context=None: reported.append(error),
+    )
+
+    result = await CDPFunctionExecutor().execute_cdp_command(
+        FakeTab(cdp_responses={"enable": None}), "Runtime.noSuchThing", {}
+    )
+
+    assert result["success"] is False
+    assert [type(error) for error in reported] == [ToolError]
+    assert not isinstance(reported[0], ValueError)
+
+
+@pytest.mark.asyncio
+async def test_the_tool_surfaces_one_unwrapped_failure(monkeypatch):
+    """What the caller actually receives: ONE message, wrapped exactly zero times.
+
+    The executor catches its own raise, so the ToolError never reaches the tool
+    layer and ``execute_cdp_command`` still answers with the executor's
+    ``{"success": False}`` dict rather than raising. Pinned because the type
+    change above deliberately did NOT change this contract — nothing re-wraps the
+    message into a second error shape on the way out.
+    """
+    tab = FakeTab(cdp_responses={"enable": None})
+    monkeypatch.setattr(server, "browser_manager", FakeBrowserManager(tabs={"i1": tab}))
+
+    result = await call_tool(
+        server, "execute_cdp_command", instance_id="i1", command="Runtime.noSuchThing"
+    )
+
+    assert result["success"] is False
+    assert result["error"] == (
+        "Unknown CDP command: Runtime.noSuchThing (tried runtime.noSuchThing)"
+    )
+    assert result["command"] == "Runtime.noSuchThing"

--- a/tests/test_cdp_element_cloner.py
+++ b/tests/test_cdp_element_cloner.py
@@ -19,7 +19,7 @@ no real Chrome).
 import json
 from types import SimpleNamespace
 
-from fakes import FakeTab
+from fakes import FakeTab, fake_element
 from stealth_chrome_devtools_mcp.embedded.cdp_element_cloner import (
     cdp_element_cloner,
 )
@@ -51,7 +51,7 @@ class TestExtractStylesPseudoWithoutCssRules:
         # The legal combo the defect crashed on: pseudo requested, css_rules not.
         tab = FakeTab(
             cdp_responses=_styles_cdp_responses(),
-            select_result=SimpleNamespace(node_id=2),
+            select_result=fake_element(node_id=2),
         )
         result = await cdp_element_cloner.extract_element_styles(
             tab,

--- a/tests/test_cloner_schemas.py
+++ b/tests/test_cloner_schemas.py
@@ -21,12 +21,14 @@ import inspect
 from pathlib import Path
 from types import SimpleNamespace
 
+import nodriver.cdp.dom as cdp_dom
 import pytest
 
 from fakes import (
     FakeStorage,
     FakeTab,
     as_jsonable,
+    fake_element,
     load_or_capture_golden,
     normalize_golden,
 )
@@ -62,8 +64,10 @@ def _cdp_responses():
     ns = SimpleNamespace
     return {
         "enable": None,
-        "get_document": ns(node_id=1),
-        "query_selector_all": [2],
+        # Real NodeIds, not bare ints: every by-node CDP command serialises with
+        # node_id.to_json(), so a bare int is a response Chrome could not send.
+        "get_document": fake_element(node_id=1),
+        "query_selector_all": [cdp_dom.NodeId(2)],
         "describe_node": ns(
             tag_name="div",
             node_name="DIV",
@@ -266,7 +270,7 @@ class TestCanonicalEngine:
 
     async def test_styles_uses_cdp_direct_schema(self):
         tab = FakeTab(
-            cdp_responses=_cdp_responses(), select_result=SimpleNamespace(node_id=2)
+            cdp_responses=_cdp_responses(), select_result=fake_element(node_id=2)
         )
         result = await _cdc.cdp_element_cloner.extract_element_styles(
             tab, selector="#demo"
@@ -330,7 +334,7 @@ class TestCanonicalEngine:
         """Pins the §2.1 transport decision deterministically (no timing): styles
         takes the CDP (``.send``) path; the JS aspects take ``.evaluate``."""
         styles_tab = FakeTab(
-            cdp_responses=_cdp_responses(), select_result=SimpleNamespace(node_id=2)
+            cdp_responses=_cdp_responses(), select_result=fake_element(node_id=2)
         )
         await _cdc.cdp_element_cloner.extract_element_styles(
             styles_tab, selector="#demo"
@@ -347,7 +351,7 @@ class TestCanonicalEngine:
         tab = FakeTab(cdp_responses=_cdp_responses())
         assert (
             await _cdc.cdp_element_cloner._resolve_node_id(
-                tab, element=SimpleNamespace(node_id=7)
+                tab, element=fake_element(node_id=7)
             )
             == 7
         )
@@ -361,7 +365,7 @@ class TestCanonicalEngine:
         tab = FakeTab(
             evaluate_result=dict(CANNED_JS_ELEMENT),
             cdp_responses=_cdp_responses(),
-            select_result=SimpleNamespace(node_id=2),
+            select_result=fake_element(node_id=2),
         )
         result = await _cdc.cdp_element_cloner.extract_complete_element(
             tab, selector="#demo"

--- a/tests/test_e2e_extra_headers.py
+++ b/tests/test_e2e_extra_headers.py
@@ -1,0 +1,111 @@
+"""Sentry STEALTH-…-1P E2E — the two header call sites against real Chrome.
+
+Both crashed in production with ``AttributeError: 'dict' object has no attribute
+'to_json'``: ``uc.cdp.network.set_extra_http_headers`` builds its command frame by
+calling ``headers.to_json()``, so a raw ``dict`` fails the moment nodriver's
+connection advances the command generator — i.e. inside ``tab.send``, on a real
+browser, and nowhere else. The hermetic tier
+(``tests/test_extra_headers_cdp.py``) pins the serialization; only this file
+proves the command Chrome actually receives is accepted and applied.
+
+Style follows the plan_E2E suite (``e2e_helpers`` mechanism, the session-scoped
+fixture app, bounded polling, every spawn closed in ``finally``). Hermetic: the
+fixture app binds an ephemeral 127.0.0.1 port, so no external network is touched.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from e2e_helpers import (
+    eval_js,
+    get_fn,
+    integration_pytestmark,
+    navigate_and_settle,
+    sandbox_kwargs,
+    warmup_once,
+)
+
+pytestmark = integration_pytestmark()
+
+EXTRA_HEADER_NAME = "X-Stealth-E2E-Extra"
+EXTRA_HEADER_VALUE = "extra-headers-e2e"
+
+
+@pytest.fixture(autouse=True)
+async def _warmup():
+    await warmup_once()
+    yield
+
+
+async def _request_details_for(iid: str, url_substr: str, timeout: float = 10.0):
+    """Bounded-poll the capture for a row whose URL contains ``url_substr`` and
+    return its ``get_request_details`` payload (or ``None`` at the deadline)."""
+    list_requests = get_fn("list_network_requests")
+    details_fn = get_fn("get_request_details")
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        rows = await list_requests(instance_id=iid)
+        if isinstance(rows, list):
+            match = next((r for r in rows if url_substr in (r.get("url") or "")), None)
+            if match:
+                return await details_fn(request_id=match["request_id"])
+        await asyncio.sleep(0.25)
+    return None
+
+
+async def test_spawn_with_extra_headers_launches_and_sends_them(fixture_app_server):
+    """A spawn carrying extra_headers must reach a usable page — and the header
+    must reach the server, not merely fail to crash on the way out."""
+    spawn = get_fn("spawn_browser")
+    close = get_fn("close_instance")
+
+    # Before the fix this raised AttributeError HERE, during spawn: the CDP
+    # command is sent while applying post-launch overrides.
+    result = await spawn(
+        headless=True,
+        extra_headers={EXTRA_HEADER_NAME: EXTRA_HEADER_VALUE},
+        **sandbox_kwargs(),
+    )
+    iid = result["instance_id"]
+    try:
+        await navigate_and_settle(iid, f"{fixture_app_server}/network.html")
+        assert await eval_js(iid, "document.readyState") in ("interactive", "complete")
+
+        details = await _request_details_for(iid, "/network.html")
+        assert details is not None, "the navigation request was never captured"
+        sent = {k.lower(): v for k, v in (details.get("headers") or {}).items()}
+        assert sent.get(EXTRA_HEADER_NAME.lower()) == EXTRA_HEADER_VALUE, (
+            f"extra header absent from the outgoing request: {sorted(sent)}"
+        )
+    finally:
+        await close(instance_id=iid)
+
+
+async def test_navigate_with_a_referrer_applies_it(fixture_app_server):
+    """``navigate(referrer=...)`` sends the same CDP command from a second site.
+
+    ``document.referrer`` is read back from the page because it is Chrome's own
+    view of the header it received — an assertion the tool cannot fake.
+    """
+    spawn = get_fn("spawn_browser")
+    navigate = get_fn("navigate")
+    close = get_fn("close_instance")
+    referrer = f"{fixture_app_server}/referrer-origin.html"
+
+    result = await spawn(headless=True, **sandbox_kwargs())
+    iid = result["instance_id"]
+    try:
+        # Before the fix this raised AttributeError inside navigate's retry loop.
+        nav = await navigate(
+            instance_id=iid,
+            url=f"{fixture_app_server}/network.html",
+            referrer=referrer,
+        )
+        assert nav["success"] is True
+        assert await eval_js(iid, "document.referrer") == referrer
+    finally:
+        await close(instance_id=iid)

--- a/tests/test_e2e_functions_hooks.py
+++ b/tests/test_e2e_functions_hooks.py
@@ -76,10 +76,9 @@ async def test_cdp_functions_walk(fixture_app_server):
 
         assert isinstance(await get_fn("get_execution_contexts")(instance_id=iid), list)
 
-        # execute_cdp_command is Runtime-only: it resolves the command via
-        # getattr(uc.cdp.runtime, command), so the domain-qualified
-        # "Runtime.evaluate" never resolves — use the bare snake_case attr
-        # "evaluate" (advertised-vs-executable mismatch pinned separately below).
+        # The bare Runtime method — the one spelling that resolved before F-813.
+        # Kept as-is so this walk proves it still resolves identically; the
+        # domain-qualified form has its own node below.
         cdp = await get_fn("execute_cdp_command")(
             instance_id=iid,
             command="evaluate",
@@ -200,16 +199,18 @@ async def test_python_binding_is_callable_from_javascript(fixture_app_server):
 
 
 @integration_test
-@pytest.mark.characterization
-async def test_execute_cdp_command_rejects_domain_qualified_name(fixture_app_server):
-    """PINS execute_cdp_command's advertised-vs-executable mismatch.
+async def test_execute_cdp_runtime_evaluate_domain_qualified(fixture_app_server):
+    """MQ-81: a domain-qualified CDP command runs (F-813).
 
-    Finding — execute_cdp_command is Runtime-only and rejects domain-qualified
-    names: it resolves the command via ``getattr(uc.cdp.runtime, command)`` (see
-    cdp_function_executor.py:169-171), so ``list_cdp_commands`` advertises
-    camelCase names like 'evaluate'/'callFunctionOn' but a domain-qualified
-    'Runtime.evaluate' (or any non-Runtime domain) can never resolve. The working
-    path uses ``command="evaluate"`` (test_cdp_functions_walk). Route M4-Ph1/M14.
+    Was ``test_execute_cdp_command_rejects_domain_qualified_name``, a
+    characterization of the advertised-vs-executable mismatch: the command
+    resolved via ``getattr(uc.cdp.runtime, command)``, so ``list_cdp_commands``
+    advertised camelCase names like 'callFunctionOn' while only the bare
+    'evaluate' could run, and 'Runtime.evaluate' — the spelling the CDP docs and
+    every caller use — could not resolve at all. That is now the defect it was
+    routed to fix, so the node asserts the fixed behaviour instead of pinning the
+    bug. Name resolution itself is covered hermetically in
+    tests/test_cdp_command_normalization.py; this is the real-Chrome half.
     """
     await warmup_once()
     base = fixture_app_server
@@ -225,8 +226,14 @@ async def test_execute_cdp_command_rejects_domain_qualified_name(fixture_app_ser
             command="Runtime.evaluate",
             params={"expression": "6 * 7", "return_by_value": True},
         )
-        assert cdp["success"] is False
-        assert "Unknown CDP command" in json.dumps(cdp, default=str)
+        assert cdp["success"] is True, cdp
+        assert "42" in json.dumps(cdp, default=str), cdp
+
+        unknown = await get_fn("execute_cdp_command")(
+            instance_id=iid, command="Runtime.noSuchCommand", params={}
+        )
+        assert unknown["success"] is False
+        assert "Unknown CDP command" in json.dumps(unknown, default=str)
     finally:
         await close(instance_id=iid)
 

--- a/tests/test_execute_script_return_wrap.py
+++ b/tests/test_execute_script_return_wrap.py
@@ -1,0 +1,149 @@
+"""Pins for F-812: a top-level ``return`` in execute_script is not an error.
+
+``return document.title;`` is how an agent writes a script, and it was the #1
+error by volume on the wire (Sentry STEALTH-CHROME-DEVTOOLS-MCP-P, 205 events):
+a bare CDP ``Runtime.evaluate`` is an EXPRESSION evaluator, so Chrome answers
+with ``SyntaxError: Illegal return statement`` and ``tool_errors._require_js_value``
+turns that into a ``ToolError`` (correctly — F-795 — but for a script that has
+nothing wrong with it).
+
+The fix is a retry keyed on that ONE error, at the one eval home
+(``DOMHandler.execute_script``): evaluate as written, and only if Chrome names an
+illegal return, evaluate once more as a function body. What these tests protect
+is the *narrowness* of it — a script that fails for any other reason keeps the
+old error and is never evaluated twice, so nothing that already worked acquires a
+second execution or a changed meaning.
+
+Hermetic: a ``FakeTab`` and real ``nodriver`` CDP records, no browser.
+"""
+
+import pytest
+from nodriver.cdp.runtime import ExceptionDetails, RemoteObject
+
+from fakes import FakeBrowserManager, FakeTab, call_tool
+from stealth_chrome_devtools_mcp.embedded import server
+from stealth_chrome_devtools_mcp.embedded.dom_handler import DOMHandler
+from stealth_chrome_devtools_mcp.embedded.tool_errors import ToolError
+
+# The wrapper the retry evaluates is the only expression containing "=>", which
+# is what lets a FakeTab's evaluate_map answer the two attempts differently.
+WRAPPED = "=>"
+
+
+def _threw(description: str) -> ExceptionDetails:
+    """The record nodriver RETURNS (never raises) when an evaluated script fails.
+
+    Built from nodriver's own constructors rather than a hand-rolled stand-in: a
+    double that invented the field names could keep these tests green over a
+    guard that reads the wrong ones.
+    """
+    return ExceptionDetails(
+        exception_id=1,
+        text="Uncaught",
+        line_number=0,
+        column_number=0,
+        exception=RemoteObject(
+            type_="object",
+            class_name=description.split(":", maxsplit=1)[0],
+            description=description,
+        ),
+    )
+
+
+ILLEGAL_RETURN = _threw("SyntaxError: Illegal return statement")
+
+
+@pytest.mark.asyncio
+async def test_top_level_return_is_retried_as_a_function_body_and_succeeds():
+    # First attempt (bare) is the illegal-return SyntaxError; the retry carries
+    # the wrapper, so the fake answers it with the script's real value.
+    tab = FakeTab(evaluate_result=ILLEGAL_RETURN, evaluate_map={WRAPPED: "Fake Page"})
+
+    result = await DOMHandler.execute_script(tab, "return document.title;")
+
+    assert result == "Fake Page"
+    assert len(tab.evaluate_calls) == 2
+    assert tab.evaluate_calls[0] == "return document.title;", "first try is verbatim"
+    assert "return document.title;" in tab.evaluate_calls[1]
+
+
+@pytest.mark.asyncio
+async def test_a_working_script_is_evaluated_exactly_once():
+    """The retry is dead weight on the happy path — it must never fire there."""
+    tab = FakeTab(evaluate_result=42)
+
+    assert await DOMHandler.execute_script(tab, "6 * 7") == 42
+    assert len(tab.evaluate_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_script_failing_for_another_reason_keeps_its_error_and_one_eval():
+    """No double execution for ordinary failures: a script with a side effect
+    that throws afterwards must not have that side effect applied twice."""
+    tab = FakeTab(evaluate_result=_threw("ReferenceError: nope is not defined"))
+
+    with pytest.raises(ToolError) as raised:
+        await DOMHandler.execute_script(tab, "nope.x = 1; nope.boom()")
+
+    assert str(raised.value) == (
+        "Script raised an exception: ReferenceError: nope is not defined"
+    )
+    assert len(tab.evaluate_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_retry_that_fails_reports_the_scripts_own_error_not_ours():
+    """``return nope.x`` is BOTH an illegal return (attempt 1) and a
+    ReferenceError (attempt 2). The caller must be told about their undefined
+    variable — the illegal-return complaint is an artifact of how we evaluated
+    it, and repeating it would send them fixing the wrong thing."""
+    tab = FakeTab(
+        evaluate_result=ILLEGAL_RETURN,
+        evaluate_map={WRAPPED: _threw("ReferenceError: nope is not defined")},
+    )
+
+    with pytest.raises(ToolError) as raised:
+        await DOMHandler.execute_script(tab, "return nope.x;")
+
+    message = str(raised.value)
+    assert "ReferenceError: nope is not defined" in message
+    assert "Illegal return" not in message
+    # The wrapper is visible in the JS stack, so the message admits to it.
+    assert "wrapper" in message and "top-level 'return'" in message
+
+
+@pytest.mark.asyncio
+async def test_the_args_path_is_untouched():
+    """A script WITH args was already wrapped in a function before this fix, so
+    its top-level return was always legal — it must not gain a second eval."""
+    tab = FakeTab(evaluate_result="ok")
+
+    assert await DOMHandler.execute_script(tab, "return 1;", args=[7]) == "ok"
+    assert len(tab.evaluate_calls) == 1
+    assert tab.evaluate_calls[0] == "(function() { return 1; })(7)"
+
+
+@pytest.mark.asyncio
+async def test_declarations_still_reach_the_page_unwrapped():
+    """The reason for retrying instead of always wrapping: a script that
+    declares a global is evaluated as written, so the declaration lands on the
+    page instead of becoming a local of a wrapper that is thrown away."""
+    tab = FakeTab(evaluate_result=None)
+
+    await DOMHandler.execute_script(tab, "var installed = 1; function f() {}")
+
+    assert tab.evaluate_calls == ["var installed = 1; function f() {}"]
+
+
+@pytest.mark.asyncio
+async def test_the_tool_returns_the_value_of_a_top_level_return(monkeypatch):
+    """End of the path the Sentry issue was reported from: the MCP tool answers
+    with the script's value instead of raising."""
+    tab = FakeTab(evaluate_result=ILLEGAL_RETURN, evaluate_map={WRAPPED: "Fake Page"})
+    monkeypatch.setattr(server, "browser_manager", FakeBrowserManager(tabs={"i1": tab}))
+
+    result = await call_tool(
+        server, "execute_script", instance_id="i1", script="return document.title;"
+    )
+
+    assert result == {"success": True, "result": "Fake Page", "error": None}

--- a/tests/test_extra_headers_cdp.py
+++ b/tests/test_extra_headers_cdp.py
@@ -1,0 +1,258 @@
+"""Sentry STEALTH-…-1P and STEALTH-…-K — the two spawn-path defects.
+
+**1P** — ``uc.cdp.network.set_extra_http_headers`` requires a
+``uc.cdp.network.Headers``: nodriver calls ``headers.to_json()`` while building the
+command frame, so a raw ``dict`` raises ``AttributeError``. Two sites passed raw
+dicts (spawn-time ``extra_headers`` and ``navigate``'s referrer), and both crashed
+in production. ``network_interceptor.modify_headers`` already had the right shape;
+these tests pin all three onto it.
+
+**K** — ``browser_manager.spawn_browser`` prefixed its terminal error with
+"Failed to spawn browser:" and ``server.py``'s tool wrapper added the same prefix
+again, so users saw it twice. The prefix now belongs to the tool wrapper alone.
+
+A CDP command is a *generator*, so ``set_extra_http_headers(headers=<raw dict>)``
+returns fine and only raises when advanced — inside ``tab.send``. ``FakeTab.send``
+used to advance it inside a bare ``except Exception: pass``, which is exactly what
+let this defect ship green; that swallow is now gone, so the harness itself is the
+regression net and these tests need no private tab double.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import nodriver as uc
+import pytest
+
+from fakes import FakeTab
+from stealth_chrome_devtools_mcp.embedded import spawn_exhaustion, window_sizing
+from stealth_chrome_devtools_mcp.embedded.browser_manager import BrowserManager
+from stealth_chrome_devtools_mcp.embedded.models import BrowserOptions
+from stealth_chrome_devtools_mcp.embedded.process_cleanup import process_cleanup
+
+SET_EXTRA = "Network.setExtraHTTPHeaders"
+
+# ``navigate`` reads both back off the tab after a successful get().
+NAV_EVALUATES = {"location.href": "https://fake.test/target", "document.title": "t"}
+
+
+def one_frame(tab: FakeTab, method: str) -> dict[str, Any]:
+    """The one recorded frame for ``method``; fails if it was never sent."""
+    matches = [f for f in tab.cdp_frames if f.get("method") == method]
+    assert len(matches) == 1, f"expected exactly one {method}, got {tab.cdp_frames}"
+    return matches[0]
+
+
+# ---------------------------------------------------------------------------
+# The library contract — measured, not assumed
+# ---------------------------------------------------------------------------
+
+
+def test_headers_object_round_trips_through_the_command():
+    payload = {"X-Stealth-A": "b", "X-Stealth-C": "d"}
+    frame = next(
+        uc.cdp.network.set_extra_http_headers(headers=uc.cdp.network.Headers(payload))
+    )
+    assert frame["method"] == SET_EXTRA
+    assert frame["params"]["headers"] == payload
+
+
+def test_a_raw_dict_is_accepted_at_the_call_and_raises_only_when_advanced():
+    """The deferral is the whole reason this shipped: nothing fails where a
+    reader is looking, so any double that swallows the advance hides the crash."""
+    gen = uc.cdp.network.set_extra_http_headers(headers={"X-Stealth-A": "b"})
+    with pytest.raises(AttributeError, match="to_json"):
+        next(gen)
+
+
+def test_headers_is_a_dict_subclass_so_wrapping_changes_nothing_else():
+    """Wrapping is free at every other call site: it is still a dict."""
+    assert issubclass(uc.cdp.network.Headers, dict)
+    assert uc.cdp.network.Headers({"a": "b"}) == {"a": "b"}
+
+
+# ---------------------------------------------------------------------------
+# Site 1 — spawn-time extra_headers (_apply_post_launch)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def post_launch_manager(monkeypatch):
+    """A ``BrowserManager`` whose ``_apply_post_launch`` neighbours are stubbed,
+    leaving the extra-headers ``tab.send`` as the only live behaviour."""
+    monkeypatch.setattr(process_cleanup, "track_browser_process", lambda *a, **kw: None)
+
+    async def no_measure(tab, options):
+        return window_sizing.WindowSizeMetrics()
+
+    monkeypatch.setattr(window_sizing, "apply_and_measure", no_measure)
+
+    async def no_timezone(self, tab, timezone_id):
+        return None
+
+    monkeypatch.setattr(BrowserManager, "_apply_timezone_override", no_timezone)
+    return BrowserManager()
+
+
+class _StubBrowser:
+    # Truthy so the desktop_launch pid shim (a delegated-launch path) is skipped.
+    _process = object()
+
+
+async def _run_post_launch(manager, tab, options):
+    return await manager._apply_post_launch(
+        browser=_StubBrowser(),
+        tab=tab,
+        options=options,
+        instance_id="iid-1",
+        actual_user_data_dir=None,
+        uses_custom_data_dir=False,
+    )
+
+
+async def test_spawn_extra_headers_serialize_into_the_cdp_frame(post_launch_manager):
+    tab = FakeTab()
+    headers = {"X-Stealth-Extra": "spawn", "Accept-Language": "en-CA"}
+
+    await _run_post_launch(
+        post_launch_manager, tab, BrowserOptions(extra_headers=headers)
+    )
+
+    assert one_frame(tab, SET_EXTRA)["params"]["headers"] == headers
+
+
+async def test_spawn_sends_no_header_command_when_extra_headers_is_empty(
+    post_launch_manager,
+):
+    tab = FakeTab()
+    await _run_post_launch(post_launch_manager, tab, BrowserOptions(extra_headers={}))
+    assert [f["method"] for f in tab.cdp_frames] == []
+
+
+# ---------------------------------------------------------------------------
+# Site 2 — navigate's referrer
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def navigating_manager(monkeypatch):
+    """A ``BrowserManager`` whose instance bookkeeping and post-nav waits are
+    stubbed, leaving the referrer ``tab.send`` as the only live behaviour."""
+
+    async def noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(BrowserManager, "touch_instance", noop)
+    monkeypatch.setattr(BrowserManager, "update_instance_state", noop)
+    monkeypatch.setattr(BrowserManager, "_wait_for_navigation_condition", noop)
+    return BrowserManager()
+
+
+def _with_tab(monkeypatch, manager, tab):
+    async def get_navigation_tab(self, instance_id):
+        return tab
+
+    monkeypatch.setattr(BrowserManager, "get_navigation_tab", get_navigation_tab)
+    return manager
+
+
+async def test_navigate_referrer_serializes_into_the_cdp_frame(
+    monkeypatch, navigating_manager
+):
+    tab = FakeTab(evaluate_map=NAV_EVALUATES)
+    _with_tab(monkeypatch, navigating_manager, tab)
+
+    result = await navigating_manager.navigate(
+        instance_id="iid-1",
+        url="https://fake.test/target",
+        referrer="https://fake.test/origin",
+    )
+
+    assert result["success"] is True
+    assert one_frame(tab, SET_EXTRA)["params"]["headers"] == {
+        "Referer": "https://fake.test/origin"
+    }
+
+
+async def test_navigate_without_a_referrer_sends_no_header_command(
+    monkeypatch, navigating_manager
+):
+    tab = FakeTab(evaluate_map=NAV_EVALUATES)
+    _with_tab(monkeypatch, navigating_manager, tab)
+
+    await navigating_manager.navigate(instance_id="iid-1", url="https://fake.test/t")
+
+    assert [f["method"] for f in tab.cdp_frames] == []
+
+
+# ---------------------------------------------------------------------------
+# Site 3 — the in-repo precedent this converges on
+# ---------------------------------------------------------------------------
+
+
+async def test_modify_headers_already_wrapped_and_still_does():
+    """``network_interceptor.modify_headers`` is where the correct shape lived;
+    pinning it here keeps the three sites converged on one way."""
+    from stealth_chrome_devtools_mcp.embedded.network_interceptor import (
+        NetworkInterceptor,
+    )
+
+    tab = FakeTab()
+    await NetworkInterceptor().modify_headers(tab, {"X-Stealth-Mod": "1"})
+
+    assert one_frame(tab, SET_EXTRA)["params"]["headers"] == {"X-Stealth-Mod": "1"}
+
+
+# ---------------------------------------------------------------------------
+# STEALTH-…-K — exactly one "Failed to spawn browser:" in the user-visible text
+# ---------------------------------------------------------------------------
+
+INNER_FAILURE = "--- Failed to connect to browser ---"
+PREFIX = "Failed to spawn browser:"
+
+
+@pytest.fixture
+def failing_spawn_server(patched_server, monkeypatch):
+    """The real ``spawn_browser`` tool over the REAL ``BrowserManager``, failed at
+    its launch phase.
+
+    Both prefixing layers must be live for this to mean anything: a stub manager
+    that merely raises would bypass the very line that used to add the second
+    prefix, and the test would pass over the open defect.
+    """
+
+    async def failing_launch(self, options, browser_executable, launch_args):
+        raise RuntimeError(INNER_FAILURE)
+
+    monkeypatch.setattr(
+        BrowserManager,
+        "_resolve_launch_args",
+        lambda self, options, proxy, platform_info: ([], "/fake/chrome", []),
+    )
+    monkeypatch.setattr(BrowserManager, "_launch_browser", failing_launch)
+    # Keep the F-811 hint out of the assertion AND off the real process table.
+    monkeypatch.setattr(spawn_exhaustion, "exhaustion_hint", lambda path: None)
+
+    class _CloneStorage:
+        async def resolve_profile_selection(self, user_data_dir):
+            return {"user_data_dir": None, "profile_role": "none"}
+
+        async def _fallback_profile_selection(self, selection, attempt):
+            return None  # no retry: the first failure is the terminal one
+
+    return patched_server(
+        browser_manager=BrowserManager(), clone_storage=_CloneStorage()
+    )
+
+
+async def test_the_user_visible_spawn_failure_carries_exactly_one_prefix(
+    call_tool, failing_spawn_server
+):
+    with pytest.raises(Exception) as err:
+        await call_tool(failing_spawn_server, "spawn_browser", headless=True)
+
+    message = str(err.value)
+    assert message.count(PREFIX) == 1, f"prefix repeated: {message!r}"
+    assert message.startswith(PREFIX)
+    assert INNER_FAILURE in message

--- a/tests/test_observability_toolerror_filter.py
+++ b/tests/test_observability_toolerror_filter.py
@@ -1,0 +1,387 @@
+"""Which failures are worth a Sentry event, and which are the product working.
+
+Live triage of the project's Sentry (2026-08-04) found the top issues were all
+EXPECTED tool failures: `handled: yes`, `mechanism: logging`, arriving through
+`FastMCP.fastmcp.tools.tool_manager` and `stealth.backend`. The largest was 205
+events of "Script raised an exception: ... Illegal return statement" — an agent
+handing `execute_script` a bad script, and `tool_errors._require_js_value`
+correctly refusing it. That is CLAUDE.md convention 2 doing its job, and it was
+drowning the events that are not.
+
+Why the filter is by TYPE and not by logger name
+------------------------------------------------
+The obvious fix — `ignore_logger("FastMCP.fastmcp.tools.tool_manager")` — is the
+wrong one, and this file pins why. `tool_manager` calls `logger.exception` for
+*every* raising tool before re-raising (`tool_manager.py:224`/`:229`), so a real
+production bug (the `AttributeError` in `navigate`) reaches Sentry through the
+exact same logger as the noise. Silencing the logger silences both.
+
+The rule, stated once: **an event is dropped only when every exception in its
+chain is one of ours.** A `ToolError` raised while handling an `AttributeError`
+still ships — the real bug is in there, and this filter must never be the reason
+nobody saw it. Both directions are asserted here, because a filter that only
+proves it drops things is a filter nobody can trust with a crash.
+
+Everything here is a pure `event -> event | None` call. Nothing initializes
+Sentry, opens a socket, or touches `~/.stealth-mcp` (`conftest.py` sets
+`STEALTH_MCP_NO_ERROR_REPORTING=1` for the whole suite besides). Events are
+built with the SDK's **own** `event_from_exception`, never hand-written: a
+hand-shaped double would encode whatever payload shape we assumed, and the
+payload shape IS what the name-matching path depends on.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+import pytest
+
+from stealth_chrome_devtools_mcp import observability
+from stealth_chrome_devtools_mcp.embedded.tool_errors import (
+    InstanceNotFoundError,
+    ToolError,
+)
+
+event_from_exception = pytest.importorskip("sentry_sdk.utils").event_from_exception
+
+#: The message from the largest real issue, kept verbatim so the fixture is the
+#: production event and not a paraphrase of it.
+ILLEGAL_RETURN = "Script raised an exception: SyntaxError: Illegal return statement"
+
+#: The logger the noise AND the real bug both arrive on. Load-bearing: see above.
+TOOL_MANAGER_LOGGER = "FastMCP.fastmcp.tools.tool_manager"
+
+#: A planted home path, so every "this event survived" assertion can also prove
+#: the survivor was still scrubbed. Never a real username.
+USER = "jdoe"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — built by the SDK, the way the logging integration builds them
+# ---------------------------------------------------------------------------
+def _raise(exc: BaseException) -> tuple[type, BaseException, object]:
+    """Raise and catch ``exc`` so it carries a real traceback and chain."""
+    try:
+        raise exc  # noqa: TRY301  PERMANENT(raising HERE is the fixture: an exception built but never raised has no traceback and no chain, which is precisely what the SDK serializes)
+    except BaseException:  # noqa: BLE001  PERMANENT(the fixture must catch whatever it was handed)
+        return sys.exc_info()  # type: ignore[return-value]
+
+
+def _logging_event(exc: BaseException, logger: str = TOOL_MANAGER_LOGGER):
+    """The (event, hint) pair `LoggingIntegration._emit` produces for ``exc``.
+
+    Mirrors `sentry_sdk/integrations/logging.py:275-303` exactly: build from
+    `event_from_exception(record.exc_info, ...)`, then attach the record as
+    ``hint["log_record"]``. That is the shape every issue in this triage had.
+    """
+    exc_info = _raise(exc)
+    event, hint = event_from_exception(
+        exc_info, mechanism={"type": "logging", "handled": True}
+    )
+    record = logging.LogRecord(
+        name=logger,
+        level=logging.ERROR,
+        pathname=f"/home/{USER}/app/tool_manager.py",
+        lineno=224,
+        msg="Error calling tool 'execute_script'",
+        args=(),
+        exc_info=exc_info,
+    )
+    hint["log_record"] = record
+    event["server_name"] = "DESKTOP-ABC123"
+    event["logentry"] = {"message": f"cwd was /home/{USER}"}
+    return event, hint
+
+
+def _payload_only(exc: BaseException, logger: str = TOOL_MANAGER_LOGGER):
+    """The same event with the hint stripped — the name-matching path.
+
+    `hint["exc_info"]` is present in production today. This proves the decision
+    does not DEPEND on it: an SDK that stops filling it in, or a transport that
+    replays a serialized event, must reach the same answer.
+    """
+    event, _ = _logging_event(exc, logger)
+    return event, {}
+
+
+def _tool_error_from_attribute_error() -> tuple[type, BaseException, object]:
+    """exc_info for `raise ToolError(...) from AttributeError(...)`."""
+    try:
+        try:
+            raise AttributeError(  # noqa: TRY301  PERMANENT(the real chain IS the fixture; see _raise)
+                "'NoneType' object has no attribute 'send'"
+            )
+        except AttributeError as cause:
+            raise ToolError(ILLEGAL_RETURN) from cause
+    except ToolError:
+        return sys.exc_info()  # type: ignore[return-value]
+
+
+# ===========================================================================
+# Dropped: the error convention working as designed
+# ===========================================================================
+class TestExpectedFailuresAreDropped:
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            ToolError(ILLEGAL_RETURN),
+            ToolError("Invalid index value: abc. Must be a number."),
+            InstanceNotFoundError("Instance not found: i7"),
+        ],
+        ids=["illegal-return", "validation", "instance-not-found"],
+    )
+    def test_a_raised_tool_error_never_reaches_sentry(self, exc):
+        """The live-object path: `hint["exc_info"]`, matched by isinstance."""
+        event, hint = _logging_event(exc)
+
+        assert observability._scrub_event(event, hint) is None
+
+    @pytest.mark.parametrize(
+        "exc",
+        [ToolError(ILLEGAL_RETURN), InstanceNotFoundError("Instance not found: i7")],
+        ids=["tool-error", "instance-not-found"],
+    )
+    def test_the_serialized_payload_alone_is_enough_to_recognise_it(self, exc):
+        """The name+module path, with no live exception to inspect."""
+        event, hint = _payload_only(exc)
+
+        assert hint == {}
+        assert observability._scrub_event(event, hint) is None
+
+    def test_the_record_is_consulted_when_the_hint_lost_its_exc_info(self):
+        """`hint["log_record"].exc_info` is the documented second shape."""
+        event, hint = _logging_event(ToolError(ILLEGAL_RETURN))
+        del hint["exc_info"]
+
+        assert hint["log_record"].exc_info is not None
+        assert observability._scrub_event(event, hint) is None
+
+    def test_a_subclass_raised_anywhere_is_covered_by_the_convention(self):
+        """isinstance, not an allowlist: a new subclass needs no edit here."""
+
+        class SelectorNotFoundError(ToolError):
+            """A subclass declared outside `tool_errors`, as a future one may be."""
+
+        event, hint = _logging_event(SelectorNotFoundError("no such selector"))
+
+        assert observability._scrub_event(event, hint) is None
+
+    def test_the_logger_it_arrived_on_does_not_change_the_answer(self):
+        """`stealth.backend` and `tool_manager` ship the same noise."""
+        event, hint = _logging_event(ToolError(ILLEGAL_RETURN), "stealth.backend")
+
+        assert observability._scrub_event(event, hint) is None
+
+
+# ===========================================================================
+# Kept: everything that might be a real bug
+# ===========================================================================
+class TestRealCrashesStillShip:
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            AttributeError("'NoneType' object has no attribute 'send'"),
+            ValueError("Unknown CDP command: Page.nope"),
+            TypeError("expected str, got int"),
+            ConnectionError("connection reset by peer"),
+            KeyError("instance_id"),
+        ],
+    )
+    def test_an_unexpected_exception_survives_the_same_logging_path(self, exc):
+        """THE regression this filter must never cause.
+
+        The `AttributeError` in `navigate` — a real production bug — arrived
+        through `FastMCP.fastmcp.tools.tool_manager`, the very logger the noise
+        arrives on. Anything that decided by logger name would have lost it.
+        """
+        event, hint = _logging_event(exc)
+
+        assert observability._scrub_event(event, hint) is not None
+
+    @pytest.mark.parametrize(
+        "exc",
+        [AttributeError("'NoneType' object has no attribute 'send'"), ValueError("x")],
+    )
+    def test_it_survives_the_payload_only_path_too(self, exc):
+        event, hint = _payload_only(exc)
+
+        assert observability._scrub_event(event, hint) is not None
+
+    def test_a_tool_error_wrapping_a_real_bug_still_ships(self):
+        """A chain is dropped only if EVERY link is ours; here one is not.
+
+        This is the failure mode that would be invisible: the product converts
+        an internal `AttributeError` into a `ToolError` on the way out, and a
+        filter that judged only the outermost type would bury the crash under
+        the convention.
+        """
+        exc_info = _tool_error_from_attribute_error()
+        event, hint = event_from_exception(
+            exc_info, mechanism={"type": "logging", "handled": True}
+        )
+
+        # Both links really are in the payload — otherwise this passes vacuously.
+        assert [v["type"] for v in event["exception"]["values"]] == [
+            "AttributeError",
+            "ToolError",
+        ]
+        assert observability._scrub_event(event, hint) is not None
+
+    def test_the_same_chain_survives_the_payload_only_path(self):
+        exc_info = _tool_error_from_attribute_error()
+        event, _ = event_from_exception(exc_info)
+
+        assert observability._scrub_event(event, {}) is not None
+
+    def test_fastmcps_own_tool_error_is_a_different_class_and_still_ships(self):
+        """A name collision that matters: `fastmcp.exceptions.ToolError`.
+
+        `tool_manager` wraps every non-fastmcp failure as
+        `raise ToolError(f"Error calling tool {key!r}") from e` — so a class
+        named exactly `ToolError` is what a genuine crash looks like on its way
+        out. Matching the bare name would drop precisely the wrong events; the
+        module is checked for this reason.
+        """
+        fastmcp_error = pytest.importorskip("fastmcp.exceptions").ToolError
+        assert fastmcp_error is not ToolError
+
+        event, hint = _logging_event(fastmcp_error("Error calling tool 'navigate'"))
+        assert event["exception"]["values"][-1]["type"] == "ToolError"
+
+        assert observability._scrub_event(event, hint) is not None
+        assert (
+            observability._scrub_event(*_payload_only(fastmcp_error("x"))) is not None
+        )
+
+    def test_an_event_with_no_exception_at_all_is_not_an_expected_failure(self):
+        """A bare `logger.error(...)` has no exception values; it is not noise
+        we recognised, so it ships. "Nothing to classify" is never "expected"."""
+        out = observability._scrub_event({"logentry": {"message": "backend wedged"}})
+
+        assert out is not None
+
+
+# ===========================================================================
+# The survivors are still scrubbed — the filter runs BEFORE the scrubber and
+# must not have replaced it
+# ===========================================================================
+class TestSurvivingEventsAreStillScrubbed:
+    def test_a_real_crash_keeps_its_diagnostics_and_loses_its_pii(self):
+        event, hint = _logging_event(AttributeError("boom"))
+
+        out = observability._scrub_event(event, hint)
+
+        assert out is not None
+        assert "server_name" not in out
+        assert USER not in str(out)
+        assert out["logentry"]["message"] == "cwd was /home/~"
+        assert out["exception"]["values"][-1]["type"] == "AttributeError"
+        assert out["exception"]["values"][-1]["mechanism"]["handled"] is True
+
+    def test_the_frame_paths_of_a_survivor_are_anonymized(self):
+        event, hint = _logging_event(ValueError("boom"))
+        frames = event["exception"]["values"][-1]["stacktrace"]["frames"]
+        frames[0]["abs_path"] = rf"C:\Users\{USER}\src\server.py"
+
+        out = observability._scrub_event(event, hint)
+
+        assert out is not None
+        survivor = out["exception"]["values"][-1]["stacktrace"]["frames"][0]
+        assert survivor["abs_path"] == r"C:\Users\~\src\server.py"
+
+
+# ===========================================================================
+# The never-raises contract (#55) — now guarding a DROP decision
+# ===========================================================================
+class TestNeverRaises:
+    @pytest.mark.parametrize(
+        "malformed",
+        [
+            {},
+            None,
+            "not an event at all",
+            ["a", "list"],
+            42,
+            {"exception": None},
+            {"exception": {}},
+            {"exception": {"values": None}},
+            {"exception": {"values": []}},
+            {"exception": {"values": "not a list"}},
+            {"exception": {"values": [None]}},
+            {"exception": {"values": [{"type": "ToolError"}]}},
+            {"exception": {"values": [{"type": None, "module": None}]}},
+        ],
+    )
+    @pytest.mark.parametrize(
+        "hint",
+        [
+            None,
+            {},
+            {"exc_info": None},
+            {"exc_info": (None, None, None)},
+            {"exc_info": "not a tuple"},
+            {"exc_info": ()},
+            {"log_record": None},
+            {"log_record": object()},
+            "not a dict",
+        ],
+    )
+    def test_a_malformed_event_or_hint_is_never_a_reason_to_raise(
+        self, malformed, hint
+    ):
+        observability._scrub_event(malformed, hint)
+
+    def test_an_unclassifiable_event_is_shipped_not_dropped(self):
+        """On doubt, send. A classifier crash must not become a silent drop."""
+
+        class _Hostile(dict):
+            def get(self, *args, **kwargs):
+                raise RuntimeError("classification exploded")
+
+        out = observability._scrub_event(_Hostile(release="2.0.7"), {})
+
+        assert out is not None
+
+    def test_a_self_referential_exception_chain_terminates(self):
+        """A cycle in `__context__` must not spin inside `before_send`."""
+        first = ToolError("a")
+        second = ToolError("b")
+        first.__context__ = second
+        second.__context__ = first
+
+        assert observability._is_expected_tool_failure({}, {"exc_info": first}) is True
+
+    def test_a_missing_tool_errors_module_degrades_to_name_matching(self, monkeypatch):
+        """If the leaf could not be imported, the payload rule still decides."""
+        monkeypatch.setattr(observability, "_expected_error_base", lambda: None)
+
+        event, hint = _logging_event(ToolError(ILLEGAL_RETURN))
+        assert observability._scrub_event(event, hint) is None
+
+        event, hint = _logging_event(AttributeError("boom"))
+        assert observability._scrub_event(event, hint) is not None
+
+
+# ===========================================================================
+# One home — the drop lives in the one registered hook, not beside it
+# ===========================================================================
+def test_the_filter_is_reached_through_the_one_registered_before_send(monkeypatch):
+    """A second hook would be a second way to change an outgoing event.
+
+    `test_observability.py` pins that `before_send is _scrub_event`; this pins
+    the other half — that the drop decision is INSIDE that hook, so there is no
+    second event-mutating callback to register, and no ordering between them.
+    """
+    pytest.importorskip("sentry_sdk")
+    monkeypatch.delenv("STEALTH_MCP_NO_ERROR_REPORTING", raising=False)
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr("sentry_sdk.init", lambda **kwargs: captured.update(kwargs))
+    assert observability.sentry_init() is True
+
+    hook = captured["before_send"]
+    assert hook is observability._scrub_event
+    assert "before_send_transaction" not in captured
+    assert hook(*_logging_event(ToolError(ILLEGAL_RETURN))) is None
+    assert hook(*_logging_event(AttributeError("boom"))) is not None

--- a/tests/test_spawn_exhaustion_hint.py
+++ b/tests/test_spawn_exhaustion_hint.py
@@ -266,7 +266,9 @@ async def test_the_hint_lands_in_the_raised_error_when_the_seam_reads_high(
         await doomed_manager.spawn_browser(BrowserOptions())
 
     message = str(err.value)
-    assert message.startswith("Failed to spawn browser:")
+    # The "Failed to spawn browser:" prefix belongs to server.py's tool wrapper
+    # alone; carrying a second copy here doubled it in the user-visible ToolError.
+    assert not message.startswith("Failed to spawn browser")
     assert INNER_FAILURE in message
     assert message.endswith(sentinel)
     # Read off the live singleton at call time — that binding is what the
@@ -280,8 +282,9 @@ async def test_no_hint_when_the_seam_returns_none(monkeypatch, doomed_manager):
     with pytest.raises(Exception) as err:
         await doomed_manager.spawn_browser(BrowserOptions())
 
-    # EXACTLY today's text: pins the `or ""` and leaves no trailing artifact.
-    assert str(err.value) == f"Failed to spawn browser: {INNER_FAILURE}"
+    # EXACTLY the inner failure: pins the `or ""` and leaves no trailing artifact,
+    # and pins that the prefix is server.py's to add, never this layer's.
+    assert str(err.value) == INNER_FAILURE
 
 
 def test_no_public_function_defaults_its_path_parameter():

--- a/tests/test_truthful_success_flags.py
+++ b/tests/test_truthful_success_flags.py
@@ -180,20 +180,24 @@ async def test_execute_script_raises_when_the_script_throws(
     """F-795: a script that raises is a failure, whatever raised it.
 
     Both classes are driven: a SyntaxError the evaluator raises before the
-    script runs (a top-level ``return``, which is what found the defect) and a
-    runtime ``throw`` from inside a script that parsed fine. Both used to come
-    back as ``success: true`` with the exception record standing in for the
-    value.
+    script runs and a runtime ``throw`` from inside a script that parsed fine.
+    Both used to come back as ``success: true`` with the exception record
+    standing in for the value.
+
+    The SyntaxError specimen is genuinely malformed JS rather than the original
+    top-level ``return`` (which is what found the defect) because that one is no
+    longer a failure at all: F-812 retries it as a function body, asserted at
+    the end of this node. F-795's invariant is untouched — only the example.
     """
     execute = get_fn("execute_script")
     await navigate_and_settle(instance, f"{fixture_app_server}/index.html")
 
     with pytest.raises(ToolError) as syntax_error:
         await _bounded(
-            execute(instance_id=instance, script="return 'illegal-here';"),
-            "execute_script with an illegal top-level return",
+            execute(instance_id=instance, script="] f795-not-js ["),
+            "execute_script with malformed JS",
         )
-    assert "SyntaxError: Illegal return statement" in str(syntax_error.value)
+    assert "SyntaxError" in str(syntax_error.value)
 
     with pytest.raises(ToolError) as runtime_error:
         await _bounded(
@@ -212,6 +216,18 @@ async def test_execute_script_raises_when_the_script_throws(
         "execute_script after a thrown script",
     )
     assert ok == {"success": True, "result": 2, "error": None}, ok
+
+    # F-812: the script an agent actually writes — a top-level ``return`` — is
+    # a VALUE now, not the SyntaxError this node used to demonstrate F-795 with.
+    returned = await _bounded(
+        execute(instance_id=instance, script="return 'top-level-return';"),
+        "execute_script with a top-level return",
+    )
+    assert returned == {
+        "success": True,
+        "result": "top-level-return",
+        "error": None,
+    }, returned
     assert (
         await eval_js(instance, "document.getElementById('sentinel').textContent")
         == "fixture-index-page"

--- a/tests/test_wire_semantics.py
+++ b/tests/test_wire_semantics.py
@@ -570,11 +570,10 @@ async def test_execute_script_reports_failure_for_a_script_that_threw(
 ):
     """F-795 (FIXED): a script that raises is an ERROR on the wire.
 
-    Found incidentally: the first draft of MQ-139 above used ``return 'x';``,
-    which is a ``SyntaxError: Illegal return statement`` for an expression
-    evaluator — and the tool used to report it as a success whose ``result``
-    happened to be an exception record, with ``success: true``, ``error: null``
-    and ``isError`` false.
+    Found incidentally: the first draft of MQ-139 above used ``return 'x';`` and
+    the tool reported the failure as a success whose ``result`` happened to be an
+    exception record, with ``success: true``, ``error: null`` and ``isError``
+    false.
 
     ``nodriver``'s ``Tab.evaluate`` RETURNS the CDP ``ExceptionDetails`` in the
     value's place instead of raising, so the fix is one guard
@@ -582,12 +581,21 @@ async def test_execute_script_reports_failure_for_a_script_that_threw(
     half of that fix: what a caller sees is ``isError: true`` carrying the
     exception text — and the SAME tab still runs a valid script afterwards, so
     the failure is reported without wedging anything.
+
+    The specimen is a script that THROWS rather than the original ``return 'x';``
+    because that one is no longer a failure at all: a top-level ``return`` is
+    retried as a function body (F-812), pinned hermetically in
+    tests/test_execute_script_return_wrap.py and on the wire at the end of this
+    node. F-795's invariant is untouched — only the example that demonstrates it.
     """
     await _navigate(wire, named_instance, f"{fixture_app_server}/index.html")
 
     request_id = await wire.call_tool(
         "execute_script",
-        {"instance_id": named_instance, "script": "return 'illegal-here';"},
+        {
+            "instance_id": named_instance,
+            "script": "throw new Error('thrown-on-purpose');",
+        },
     )
     frame = await wire.response(request_id, OUTER_BOUND)
     result = _tool_result(frame)
@@ -598,7 +606,16 @@ async def test_execute_script_reports_failure_for_a_script_that_threw(
     assert text.startswith(
         "Error calling tool 'execute_script': Script raised an exception: "
     ), text
-    assert "SyntaxError: Illegal return statement" in text, text
+    assert "thrown-on-purpose" in text, text
+
+    # F-812, the other half: the script an agent actually writes is a VALUE on
+    # the wire, not the SyntaxError this node used to demonstrate F-795 with.
+    returned = await _call(
+        wire,
+        "execute_script",
+        {"instance_id": named_instance, "script": "return 'top-level-return';"},
+    )
+    assert _tool_payload(returned)["result"] == "top-level-return"
 
     # The tab is not wedged by its own script's exception.
     ok = await _call(


### PR DESCRIPTION
Four fixes driven by live triage of the project's Sentry (org `devino`), one commit each. Implemented by three parallel Opus subagents on disjoint file sets; every behavioural fix is RED-verified against the unfixed code.

## F-814 — `extra_headers` / `referrer` crashed every call that used them (`…-1P`, `…-K`)
nodriver's `set_extra_http_headers` requires a `Headers` object (`.to_json()` is called on it); `browser_manager.py` passed raw dicts at two sites (spawn `extra_headers`, navigate `referrer`). Both now wrap in `uc.cdp.network.Headers`, converging on `network_interceptor`'s existing pattern. Also drops the doubled `Failed to spawn browser:` prefix — `server.py`'s wrap is now the sole owner.

## F-814 (harness) — the strict fake that would have caught it
`FakeTab.send` advanced CDP generators inside a bare `except Exception: pass`, which is exactly why the raw-dict crash stayed green for months. The fake now tolerates only `StopIteration`; argument/serialization errors escape into the test. Narrowing exposed the same bug-class twice more **in the doubles themselves** (bare ints where nodriver requires `cdp.dom.NodeId`) — verified test-double defects, not prod; fixed via a new `fake_element()` twin of the existing `fake_target()` precedent. Three sites in this repo passed bare values where nodriver requires typed wrappers; the harness now catches the whole class.

## F-815 — expected `ToolError`s no longer ship to Sentry
The top Sentry issues were all `handled: yes` events: tools raising `ToolError` per convention 2, logged by FastMCP's `logger.exception`, shipped by the logging integration. `_scrub_event` (still the one `before_send` hook) now drops an event only when **every** exception in its chain is our `ToolError` family — `isinstance` on the live `hint` exc_info, name+module-prefix allowlist as payload fallback. Load-bearing subtlety: `fastmcp.exceptions.ToolError` shares the name and wraps *genuine* crashes, so bare-name matching would drop exactly the real bugs. A `ToolError` raised from an `AttributeError` still ships. Verified over a live `sentry_sdk.Client` + `LoggingIntegration`, not just the seam.

## F-812 — `execute_script` accepts top-level `return` (`…-P`, 205 events)
Evaluate as-is; only on Chrome's "Illegal return statement" retry once as `(() => { … })()`. Always-wrapping would change script semantics (top-level `var`/`function` persistence), so the retry is keyed on that one error. A failed retry surfaces the body's own error, not the illegal-return artifact.

## F-813 — `execute_cdp_command` resolves domain-qualified + snake_case names (`…-1N`, 42 events)
One lookup: exact `getattr` first, case/underscore-folded key on a miss (folding, not a rewrite rule — nodriver's `io`, `dom_snapshot`, `input_` defeat any camel→snake rewrite). The old line was Runtime-only **and** casing-exact: of the 21 camelCase names `list_cdp_commands` advertises, only `evaluate` could actually run. Unknown-command raise is now `ToolError` so F-815 recognises it as expected.

## Validation
- Full hermetic lane: **1594 passed, 1 skipped, 142 deselected** (run twice — once directly, once by the pre-push hook).
- LOC budgets: `browser_manager.py` 1532/1532 net-zero, `server.py` 3411/3411 (docstring-only, +8/−8), `cdp_function_executor.py` 1004/1012. No cap raised.
- Goldens: one characterization test retired *because its pinned defect is fixed* (it was MQ-81's planned evidence node); `test_wire_semantics`' throwing specimen re-pointed (it used the exact pattern F-812 makes work; the F-795 invariant untouched).

## Known gap
`tests/test_e2e_extra_headers.py` (real-Chrome E2E for both fixed options) is written and collects, but has **not run locally** — the dev machine is process-exhausted (~2,400 processes; Chrome itself refuses: "run out of resources"; reproduced with plain nodriver as control). Needs the CI integration lane or a healthier machine before merge. One consolation: the failed local spawn surfaced with a *single* prefix — F-814's dedup confirmed against real Chrome.

The `Fixes STEALTH-CHROME-DEVTOOLS-MCP-{1P,K,P,1N}` lines in the commit bodies auto-resolve the Sentry issues on merge.