### PR TITLE
2.0.8 batch: five Sentry-evidenced fixes (F-509, F-783, F-816, F-817, F-818)

### DIFF
--- a/audit/stage2/finding_F783_timeout_and_cancellation_escape_the_error_convention.md
+++ b/audit/stage2/finding_F783_timeout_and_cancellation_escape_the_error_convention.md
@@ -1,6 +1,11 @@
 # F-783 — the timeout and cancellation paths escape the one-error convention
 
-**Status:** OPEN — characterized by plan_RELEASE W15, not fixed (W15 is zero-`src/`).
+**Status:** FIXED (2026-08-07, fix/sentry-2.0.8-batch) — `_with_cdp_timeout`'s
+timeout raise is now `ToolError`; the cancellation path still propagates
+`CancelledError` untouched (pinned by
+`tests/test_error_typing.py::test_cdp_timeout_does_not_convert_cancellation`).
+The W15 characterization pin in `tests/test_observability.py` was inverted into
+a regression guard (`test_the_timeout_path_now_joins_the_one_error_convention`).
 **Severity:** MEDIUM. A client cannot distinguish the commonest runtime failure
 from an interpreter bug by type.
 **Surface:** `src/stealth_chrome_devtools_mcp/embedded/server.py`

--- a/src/stealth_chrome_devtools_mcp/embedded/browser_manager.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/browser_manager.py
@@ -16,6 +16,7 @@ from nodriver import Browser, Tab
 from stealth_chrome_devtools_mcp.embedded import (
     desktop_launch,
     spawn_exhaustion,
+    tool_errors,
     window_sizing,
 )
 from stealth_chrome_devtools_mcp.embedded.debug_logger import debug_logger
@@ -482,15 +483,13 @@ class BrowserManager:
             )
 
         # Identify browser type for logging
+        executable_lower = browser_executable.lower()
         browser_type = "Unknown"
-        if (
-            "edge" in browser_executable.lower()
-            or "msedge" in browser_executable.lower()
-        ):
+        if "edge" in executable_lower or "msedge" in executable_lower:
             browser_type = "Microsoft Edge"
-        elif "chromium" in browser_executable.lower():
+        elif "chromium" in executable_lower:
             browser_type = "Chromium"
-        elif "chrome" in browser_executable.lower():
+        elif "chrome" in executable_lower:
             browser_type = "Google Chrome"
 
         debug_logger.log_info(
@@ -1040,7 +1039,17 @@ class BrowserManager:
 
         browser = data["browser"]
         previous_tab = data.get("tab")
-        new_tab = await browser.get("about:blank", new_tab=True)
+        try:
+            new_tab = await browser.get("about:blank", new_tab=True)
+        except RuntimeError as e:
+            # nodriver picks the new target with a bare next(filter(...)) over
+            # browser.targets; PEP 479 turns that StopIteration into this.
+            if not isinstance(e.__cause__, StopIteration):
+                raise
+            raise tool_errors.ToolError(
+                "Browser has no usable page target (it may be shutting down or "
+                "its last tab was closed); spawn a new instance or retry."
+            ) from e
         await new_tab
 
         if close_existing and previous_tab:
@@ -1088,16 +1097,11 @@ class BrowserManager:
         tracked_tab = data.get("tab")
         navigation_count = data.get("navigation_count", 0)
 
-        if (
-            self.NAVIGATION_RECYCLE_THRESHOLD > 0
-            and navigation_count >= self.NAVIGATION_RECYCLE_THRESHOLD
-        ):
+        threshold = self.NAVIGATION_RECYCLE_THRESHOLD
+        if threshold > 0 and navigation_count >= threshold:
             return await self._replace_main_tab(
                 instance_id,
-                reason=(
-                    f"navigation recycle threshold "
-                    f"{self.NAVIGATION_RECYCLE_THRESHOLD} reached"
-                ),
+                reason=f"navigation recycle threshold {threshold} reached",
             )
 
         # F-775a: never await a browser.tabs entry, nor hand one to a caller that
@@ -1186,16 +1190,16 @@ class BrowserManager:
             if attempt == 0:
                 tab = await self.get_navigation_tab(instance_id)
             else:
+                cause = type(last_error).__name__ if last_error else "unknown"
                 tab = await self._replace_main_tab(
                     instance_id,
-                    reason=(
-                        f"recovering after navigation failure: "
-                        f"{type(last_error).__name__ if last_error else 'unknown'}"
-                    ),
+                    reason=f"recovering after navigation failure: {cause}",
                 )
 
             if not tab:
-                raise Exception(f"Instance not found: {instance_id}")
+                raise tool_errors.InstanceNotFoundError(
+                    f"Instance not found: {instance_id}"
+                )
 
             start_time = time.monotonic()
 
@@ -1239,11 +1243,7 @@ class BrowserManager:
                             self._instances[instance_id].get("navigation_count", 0) + 1
                         )
 
-                return {
-                    "url": final_url,
-                    "title": title,
-                    "success": True,
-                }
+                return {"url": final_url, "title": title, "success": True}
             except Exception as error:
                 last_error = error
                 debug_logger.log_warning(
@@ -1255,7 +1255,7 @@ class BrowserManager:
                 )
                 if attempt == 1 or not self._is_recoverable_navigation_error(error):
                     if isinstance(error, asyncio.TimeoutError):
-                        raise Exception(
+                        raise tool_errors.ToolError(
                             f"Navigation to {url} timed out after {timeout}ms"
                         ) from error
                     raise

--- a/src/stealth_chrome_devtools_mcp/embedded/cdp_function_executor.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/cdp_function_executor.py
@@ -13,7 +13,7 @@ nodriver's CDP access:
 import asyncio
 import inspect
 import json
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from types import ModuleType
 from typing import Any
 
@@ -81,6 +81,15 @@ def resolve_cdp_command(command: str) -> tuple[Any, str]:
         )
     domain_name = module.__name__.rpartition(".")[2]
     return found, f"{domain_name}.{getattr(found, '__name__', method)}"
+
+
+def build_cdp_call(method: Callable, params: dict[str, Any]) -> Generator:
+    """Build ``method``'s call, folding the wire's param names onto its own (F-816)."""
+    real = {_lookup_key(name): name for name in inspect.signature(method).parameters}
+    try:
+        return method(**{real.get(_lookup_key(k), k): v for k, v in params.items()})
+    except TypeError as exc:
+        raise ToolError(f"{exc}; valid params: {', '.join(real.values())}") from exc
 
 
 class ExecutionContext:
@@ -216,13 +225,10 @@ class CDPFunctionExecutor:
     async def execute_cdp_command(
         self, tab: Tab, command: str, params: dict[str, Any]
     ) -> dict[str, Any]:
-        """
-        Executes any CDP Runtime command with given parameters.
+        """Executes any CDP command (any domain, since F-813) with given params.
 
-        Args:
-            tab (Tab): The browser tab.
-            command (str): CDP command name.
-            params (Dict[str, Any]): Parameters for the command.
+        The command name and its param names are each forgiven their spelling —
+        see ``resolve_cdp_command`` (F-813) and ``build_cdp_call`` (F-816).
 
         Returns:
             Dict[str, Any]: Result of the command execution.
@@ -236,7 +242,7 @@ class CDPFunctionExecutor:
                 # failure, and observability's before_send drops those by type.
                 # As a ValueError it was an unhandled-crash shape, and shipped.
                 raise ToolError(f"Unknown CDP command: {command} (tried {tried})")  # noqa: TRY301  plan_M4ph1
-            result = await tab.send(cdp_method(**params))
+            result = await tab.send(build_cdp_call(cdp_method, params))
             debug_logger.log_info(
                 "cdp_function_executor",
                 "execute_cdp_command",

--- a/src/stealth_chrome_devtools_mcp/embedded/dom_handler.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/dom_handler.py
@@ -208,6 +208,12 @@ class DOMHandler:
             )
             return results
 
+        except ToolError:
+            # The resolution layer already raised THE canonical error for this
+            # selector, names the selector itself, and logged its own diagnosis.
+            # Re-wrapping would spell the selector twice in one message and bury
+            # that diagnosis under a generic prefix.
+            raise
         except Exception as e:
             debug_logger.log_error(
                 "DOMHandler",
@@ -247,7 +253,7 @@ class DOMHandler:
                 element = await resolve_element(tab, selector, timeout=timeout / 1000)
 
             if not element:
-                raise Exception(f"Element not found: {selector}")
+                raise ToolError(f"Element not found: {selector}")
 
             await element.scroll_into_view()
             await asyncio.sleep(0.5)
@@ -261,7 +267,7 @@ class DOMHandler:
             return True
 
         except Exception as e:
-            raise Exception(f"Failed to click element: {e!s}")
+            raise ToolError(f"Failed to click element: {e!s}")
 
     @staticmethod
     async def upload_file(
@@ -289,31 +295,31 @@ class DOMHandler:
         """
         try:
             if not file_paths:
-                raise Exception("No file paths provided")
+                raise ToolError("No file paths provided")
 
             resolved: list[str] = []
             for raw_path in file_paths:
                 path = Path(str(raw_path)).expanduser()  # noqa: ASYNC240  plan_M7
                 if not path.is_file():
-                    raise Exception(f"File not found: {path}")
+                    raise ToolError(f"File not found: {path}")
                 resolved.append(str(path.resolve()))
 
             element = await resolve_element(tab, selector, timeout=timeout / 1000)
             if not element:
-                raise Exception(f"File input not found: {selector}")
+                raise ToolError(f"File input not found: {selector}")
 
             tag_name = (getattr(element, "tag_name", "") or "").lower()
             input_type = ""
             if hasattr(element, "attrs") and element.attrs:
                 input_type = (element.attrs.get("type") or "").lower()
             if tag_name and tag_name != "input":
-                raise Exception(
+                raise ToolError(
                     f"Selector '{selector}' resolved to <{tag_name}>, "
                     "not a file input. "
                     'Point the selector at an <input type="file"> element.'
                 )
             if input_type and input_type != "file":
-                raise Exception(
+                raise ToolError(
                     f"Selector '{selector}' is an <input type=\"{input_type}\">, "
                     'not type="file".'
                 )
@@ -323,7 +329,7 @@ class DOMHandler:
             return {"uploaded": resolved, "count": len(resolved)}
 
         except Exception as e:
-            raise Exception(f"Failed to upload file: {e!s}")
+            raise ToolError(f"Failed to upload file: {e!s}")
 
     @staticmethod
     async def type_text(  # noqa: PLR0913  PERMANENT(function interface)
@@ -354,7 +360,7 @@ class DOMHandler:
         try:
             element = await resolve_element(tab, selector)
             if not element:
-                raise Exception(f"Element not found: {selector}")
+                raise ToolError(f"Element not found: {selector}")
 
             await element.focus()
             await asyncio.sleep(0.1)
@@ -420,7 +426,7 @@ class DOMHandler:
             return True
 
         except Exception as e:
-            raise Exception(f"Failed to type text: {e!s}")
+            raise ToolError(f"Failed to type text: {e!s}")
 
     @staticmethod
     async def paste_text(
@@ -444,7 +450,7 @@ class DOMHandler:
         try:
             element = await resolve_element(tab, selector)
             if not element:
-                raise Exception(f"Element not found: {selector}")
+                raise ToolError(f"Element not found: {selector}")
 
             await element.focus()
             await asyncio.sleep(0.1)
@@ -495,7 +501,7 @@ class DOMHandler:
             return True
 
         except Exception as e:
-            raise Exception(f"Failed to paste text: {e!s}")
+            raise ToolError(f"Failed to paste text: {e!s}")
 
     @staticmethod
     async def select_option(
@@ -521,7 +527,7 @@ class DOMHandler:
         try:
             select_element = await resolve_element(tab, selector)
             if not select_element:
-                raise Exception(f"Select element not found: {selector}")
+                raise ToolError(f"Select element not found: {selector}")
 
             if text is not None:
                 await select_element.send_keys(text)
@@ -552,10 +558,10 @@ class DOMHandler:
                 """)
                 return True
 
-            raise Exception("No selection criteria provided (value, text, or index)")
+            raise ToolError("No selection criteria provided (value, text, or index)")
 
         except Exception as e:
-            raise Exception(f"Failed to select option: {e!s}")
+            raise ToolError(f"Failed to select option: {e!s}")
 
     @staticmethod
     async def get_element_state(tab: Tab, selector: str) -> dict[str, Any]:
@@ -572,7 +578,7 @@ class DOMHandler:
         try:
             element = await resolve_element(tab, selector)
             if not element:
-                raise Exception(f"Element not found: {selector}")
+                raise ToolError(f"Element not found: {selector}")
 
             if hasattr(element, "update"):
                 await element.update()
@@ -609,7 +615,7 @@ class DOMHandler:
             }
 
         except Exception as e:
-            raise Exception(f"Failed to get element state: {e!s}")
+            raise ToolError(f"Failed to get element state: {e!s}")
 
     @staticmethod
     async def wait_for_element(
@@ -711,7 +717,7 @@ class DOMHandler:
                 result = await tab.evaluate(script)
 
         except Exception as e:
-            raise Exception(f"Failed to execute script: {e!s}")
+            raise ToolError(f"Failed to execute script: {e!s}")
 
         # Outside the except on purpose: a script that THREW is a failure of the
         # script, not of the CDP call, so it must not be re-wrapped in the
@@ -738,7 +744,7 @@ class DOMHandler:
         try:
             result = await tab.evaluate(f"(() => {{\n{script}\n}})()")
         except Exception as e:
-            raise Exception(f"Failed to execute script: {e!s}")
+            raise ToolError(f"Failed to execute script: {e!s}")
 
         try:
             return _require_js_value(result)
@@ -808,7 +814,7 @@ class DOMHandler:
             return content
 
         except Exception as e:
-            raise Exception(f"Failed to get page content: {e!s}")
+            raise ToolError(f"Failed to get page content: {e!s}")
 
     @staticmethod
     async def scroll_page(
@@ -864,4 +870,4 @@ class DOMHandler:
             return True
 
         except Exception as e:
-            raise Exception(f"Failed to scroll page: {e!s}")
+            raise ToolError(f"Failed to scroll page: {e!s}")

--- a/src/stealth_chrome_devtools_mcp/embedded/element_resolution.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/element_resolution.py
@@ -16,9 +16,18 @@ place selectors resolve through, so every selector-driven tool inherits the
 recovery instead of surfacing an intermittent -32000 to callers -- and to real
 users -- under DOM churn.
 
-The recovery is keyed to the exact -32000 signal and bounded: a genuinely
+nodriver has a second, unrelated race with the same "retry clears it" shape, so
+it recovers here too. ``Tab.select_all`` awaits the tab, and ``Tab.wait``
+registers page-event handlers (``FrameStoppedLoading`` and friends) then drops
+them in a ``finally`` via ``Connection.remove_handler``, whose cleanup is a bare
+``del self.handlers[evt_dom]``. That delete removes the whole key rather than
+just this handler, so when two ``wait``s overlap on one tab the second one's
+cleanup finds the key gone and raises ``KeyError(<cdp event class>)``.
+
+The recovery is keyed to those two exact signals and bounded: a genuinely
 absent selector still surfaces as the normal not-found/timeout after the final
-attempt, and any other ``ProtocolException`` propagates unchanged.
+attempt, and any other ``ProtocolException`` -- or any ``KeyError`` not naming a
+``nodriver.cdp`` event class -- propagates unchanged.
 """
 
 from __future__ import annotations
@@ -30,6 +39,7 @@ from nodriver import cdp
 from nodriver.core.connection import ProtocolException
 
 from stealth_chrome_devtools_mcp.embedded.debug_logger import debug_logger
+from stealth_chrome_devtools_mcp.embedded.tool_errors import ToolError
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -44,6 +54,11 @@ _T = TypeVar("_T")
 # code only inside the stringified exception.
 _STALE_NODE_MARKER = "Could not find node with given id"
 
+# Package of the CDP event classes nodriver keys its handler table by. A KeyError
+# carrying one of these classes is nodriver's own bookkeeping race, never a
+# lookup miss in our code or a caller's.
+_CDP_EVENT_PACKAGE = "nodriver.cdp"
+
 # A DOM.documentUpdated burst settles within a few frames, so a small bounded
 # number of re-resolves clears the race; past that the selector is treated as
 # genuinely unresolvable and the stale-node error is surfaced to the caller.
@@ -55,8 +70,37 @@ def _is_stale_node_error(exc: ProtocolException) -> bool:
     return _STALE_NODE_MARKER in str(exc)
 
 
+def _raced_cdp_event(exc: KeyError) -> str | None:
+    """Name of the CDP event class in a nodriver handler-cleanup ``KeyError``.
+
+    ``None`` for every other ``KeyError`` — a missing dict key raised anywhere
+    else is a real defect and must not be retried or reworded.
+    """
+    if not exc.args:
+        return None
+    key = exc.args[0]
+    if not isinstance(key, type):
+        return None
+    module = getattr(key, "__module__", "") or ""
+    if module != _CDP_EVENT_PACKAGE and not module.startswith(f"{_CDP_EVENT_PACKAGE}."):
+        return None
+    return key.__name__
+
+
+def _recoverable_race(exc: ProtocolException | KeyError) -> str | None:
+    """Describe ``exc`` if it is one of the two known nodriver resolve races."""
+    if isinstance(exc, ProtocolException):
+        if _is_stale_node_error(exc):
+            return "document node invalidated mid-resolve"
+        return None
+    event = _raced_cdp_event(exc)
+    if event is None:
+        return None
+    return f"transient nodriver event-handler race ({event})"
+
+
 async def _resolve_with_recovery(what: str, resolve: Callable[[], Awaitable[_T]]) -> _T:
-    """Run ``resolve``, re-running it on the -32000 stale-document race.
+    """Run ``resolve``, re-running it on either known nodriver resolve race.
 
     ``resolve`` must build a *fresh* awaitable on each call so the retry lands on
     a freshly fetched document nodeId.
@@ -65,20 +109,29 @@ async def _resolve_with_recovery(what: str, resolve: Callable[[], Awaitable[_T]]
     while True:
         try:
             return await resolve()
-        except ProtocolException as exc:
-            if not _is_stale_node_error(exc):
+        except (ProtocolException, KeyError) as exc:
+            race = _recoverable_race(exc)
+            if race is None:
                 raise
             attempt += 1
             if attempt >= _MAX_RESOLVES:
+                if isinstance(exc, KeyError):
+                    # str(KeyError(cls)) is just the class repr, which tells a
+                    # caller nothing — name the condition instead.
+                    raise ToolError(
+                        f"{race} while resolving {what}; re-resolved {attempt} "
+                        f"times without clearing it"
+                    ) from exc
                 raise
             debug_logger.log_warning(
                 "element_resolution",
                 "_resolve_with_recovery",
-                f"document node invalidated mid-resolve ({what}); re-resolving on "
-                f"a fresh document (attempt {attempt}/{_MAX_RESOLVES})",
+                f"{race} ({what}); re-resolving on a fresh document "
+                f"(attempt {attempt}/{_MAX_RESOLVES})",
                 context={"what": what, "attempt": attempt},
             )
-            # Let the documentUpdated burst settle before re-resolving.
+            # Let the documentUpdated burst (or the handler-table churn) settle
+            # before re-resolving.
             await asyncio.sleep(_SETTLE_SECONDS * attempt)
 
 
@@ -124,7 +177,9 @@ async def resolve_elements(tab: Tab, selector: str) -> list[Element]:
     full match list of live ``Element`` objects (with ``.attrs``/``.text_all``/
     ``.get_position()``), or an empty list on a genuine zero-match. A -32000
     stale-node race re-resolves against a fresh document; a persistent one
-    surfaces after ``_MAX_RESOLVES`` exactly like the single-element path.
+    surfaces after ``_MAX_RESOLVES`` exactly like the single-element path. This
+    is also the path that hits nodriver's handler-cleanup ``KeyError``, since
+    ``select_all`` awaits the tab between attempts.
     """
 
     async def _do() -> list[Element]:

--- a/src/stealth_chrome_devtools_mcp/embedded/proxy_forwarder.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/proxy_forwarder.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import contextlib
+import logging
 import socket
 import ssl
 from ssl import SSLContext
@@ -27,6 +28,74 @@ def _free_port() -> int:
     port = free_socket.getsockname()[1]
     free_socket.close()
     return port
+
+
+def _port_is_forbidden(port: int) -> bool:
+    """True iff the OS refuses us ``port`` OUTRIGHT — a permission verdict,
+    never a "someone is using it right now" one.
+
+    The question a CONNECT probe cannot ask (``singleton._port_is_foreign_held``
+    is one): it only ever sees ports someone LISTENS on. A port inside a
+    Windows excluded/reserved range (Hyper-V/WinNAT reserve them — ``netsh
+    interface ipv4 show excludedportrange protocol=tcp``) has no listener at
+    all, reads "free" to every such probe, and still fails bind with
+    ``[Errno 13] ... [winerror 10013] ... forbidden by its access
+    permissions``. uvicorn then dies INSIDE the spawned backend, where the
+    parent sees only a backend that never comes up — Sentry
+    STEALTH-CHROME-DEVTOOLS-MCP-2J, an external user's box on 2.0.6 whose MCP
+    server never started because ``singleton.DEFAULT_PORT`` was reserved.
+
+    ONLY ``PermissionError`` counts — errno 13, exactly what that report
+    shows. Every other bind failure (EADDRINUSE above all) answers False,
+    deliberately:
+
+      * it is a TRANSIENT, contended fact, and every proxy in a startup herd
+        asks this at once. A probe that treated "in use" as disqualifying
+        would collide with the OTHER proxies' momentary probe sockets and
+        scatter the herd across private ports nothing will ever bind —
+        measured, not theorised (tests/test_startup_herd.py went from 23s
+        green to a 240s hard timeout on exactly that mistake);
+      * "occupied" already belongs to ``singleton._port_is_foreign_held``,
+        and OUR OWN backend legitimately occupies its own port — diverting a
+        healthy restart off it would undo plan_M8 SSA1.5.
+
+    A permission verdict has neither problem: it is structural to the machine,
+    identical for every process, and stable across a herd.
+    """
+    probe = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        probe.bind(("127.0.0.1", port))
+    except PermissionError:
+        return True
+    except OSError:
+        # In use, or any other transient refusal - not this question. See above.
+        return False
+    finally:
+        probe.close()
+    return False
+
+
+def bindable_port(preferred: int, *, force_new: bool = False) -> int:
+    """A loopback port we can actually bind: ``preferred`` when the OS permits
+    it, else a fresh OS-assigned one from `_free_port`.
+
+    The port-ACQUISITION half of the F-509 fallback, kept beside the picker it
+    delegates to. The port-SELECTION policy — which port to prefer, and when a
+    conflict or a foreign occupant forces a move — stays whole in
+    ``singleton._select_backend_port``, which passes its verdict as
+    ``force_new`` rather than re-deriving anything here.
+    """
+    if force_new:
+        return _free_port()
+    if not _port_is_forbidden(preferred):
+        return preferred
+    replacement = _free_port()
+    logging.getLogger("stealth.proxy").warning(
+        "port %s is reserved on this machine (bind forbidden); using %s instead",
+        preferred,
+        replacement,
+    )
+    return replacement
 
 
 class AuthenticatedProxyForwarder:

--- a/src/stealth_chrome_devtools_mcp/embedded/server.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/server.py
@@ -144,7 +144,7 @@ async def _with_cdp_timeout(coro, timeout: float = 0, instance_id: str = ""):
         return await asyncio.wait_for(coro, timeout=t)
     except TimeoutError:
         tag = f" (instance {instance_id})" if instance_id else ""
-        raise Exception(
+        raise ToolError(
             f"CDP operation timed out after {t:.0f}s{tag}. "
             "The browser may have crashed or the connection dropped. "
             "Try closing the instance with close_instance and spawning a new one."
@@ -2665,16 +2665,16 @@ async def execute_cdp_command(
         command (str): CDP command, either domain-qualified ('Page.reload',
                 'Emulation.setDeviceMetricsOverride') or a bare Runtime method
                 ('evaluate'). Wire casing and snake_case both resolve.
-        params (Dict[str, Any], optional): Command parameters as a dictionary.
-                IMPORTANT: Use snake_case parameter names (e.g., 'return_by_value')
-                NOT camelCase ('returnByValue'). The nodriver library expects
-                Python-style parameter names.
+        params (Dict[str, Any], optional): Command parameters. Wire casing and
+                snake_case both resolve, per parameter ('returnByValue' and
+                'return_by_value' are the same argument), so the CDP docs' own
+                spelling works.
 
     Returns:
         Dict[str, Any]: Command execution result.
 
     Example:
-        # The command NAME is casing-flexible; the PARAMS are not — snake_case.
+        # Both the command NAME and its PARAM names are casing-flexible.
         params = {"expression": "document.title", "return_by_value": True}
     """
     tab = await _require_tab(browser_manager, instance_id)

--- a/src/stealth_chrome_devtools_mcp/embedded/singleton.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/singleton.py
@@ -664,18 +664,18 @@ def _select_backend_port(preferred: int = DEFAULT_PORT) -> int:
     eviction/restart land where a prior backend ran), else ``preferred``. Keeps
     that target when free or held by OUR OWN backend; a FOREIGN occupant — or
     one another display context recorded, whose entry our spawn's own record
-    would supersede-evict (F-808) — forces an OS-assigned fallback via
-    ``proxy_forwarder._free_port()`` (the one existing port-picker — no new
-    convention), so a collision is recoverable, not a silent 120s outage.
+    would supersede-evict (F-808), or a target the OS FORBIDS us outright
+    (F-509's field residual) — each forces an OS-assigned fallback via the one
+    picker, ``proxy_forwarder.bindable_port``: recoverable, not a 120s outage.
     """
     # lazy; no module-top cycle
-    from stealth_chrome_devtools_mcp.embedded.proxy_forwarder import _free_port
+    from stealth_chrome_devtools_mcp.embedded.proxy_forwarder import bindable_port
 
     own = display_context.display_context()
     recorded = backend_registry.port_for_context(SERVER_STATE_FILE, own)
     target = preferred if recorded is None else recorded
     taken = backend_registry.port_conflict(SERVER_STATE_FILE, target, own)
-    return _free_port() if taken or _port_is_foreign_held(target) else target
+    return bindable_port(target, force_new=taken or _port_is_foreign_held(target))
 
 
 def ensure_server_running(port: int = DEFAULT_PORT) -> int | None:

--- a/tests/test_browser_manager_tab_rediscovery.py
+++ b/tests/test_browser_manager_tab_rediscovery.py
@@ -39,6 +39,10 @@ from fakes import (
     fake_target,
 )
 from stealth_chrome_devtools_mcp.embedded.browser_manager import BrowserManager
+from stealth_chrome_devtools_mcp.embedded.tool_errors import (
+    InstanceNotFoundError,
+    ToolError,
+)
 
 INSTANCE_ID = "i1"
 
@@ -223,3 +227,93 @@ async def test_switch_to_tab_reports_an_unknown_tab_id_unchanged(manager_and_bro
 
     assert await manager.switch_to_tab(INSTANCE_ID, "T-nope") is False
     assert browser.connection.send_calls == []
+
+
+# ---------------------------------------------------------------------------
+# F-816 — _replace_main_tab: nodriver's bare StopIteration escapes as RuntimeError
+# ---------------------------------------------------------------------------
+
+
+async def _get_with_no_page_target(*_args, **_kwargs):
+    """``nodriver.Browser.get``'s failure mode, reproduced line-for-line.
+
+    ``get(new_tab=True)`` locates the freshly created target with
+    ``next(filter(lambda item: item.type_ == "page", self.targets))``
+    (``core/browser.py:256-261``). When nothing in ``targets`` is a page — the
+    browser is tearing down, the last tab was closed, or the entries degraded to
+    raw ``Connection`` objects after a rediscovery — that bare ``next`` raises
+    ``StopIteration`` *inside a coroutine*, which PEP 479 converts to
+    ``RuntimeError("coroutine raised StopIteration")`` with the ``StopIteration``
+    as its ``__cause__``.
+
+    Built from the real construct rather than a hand-written
+    ``RuntimeError(...)`` so the double cannot encode a ``__cause__``/message
+    shape the interpreter would never produce.
+    """
+    return next(filter(lambda item: item.type_ == "page", []))
+
+
+async def test_replace_main_tab_reports_a_browser_with_no_page_target(
+    manager_and_browser,
+):
+    """THE pin: the RuntimeError becomes an actionable ``ToolError``.
+
+    Sentry STEALTH-CHROME-DEVTOOLS-MCP-2K: ``navigate`` retries through
+    ``_replace_main_tab``, whose ``browser.get`` blew up with the bare
+    ``RuntimeError: coroutine raised StopIteration`` — a message that names
+    neither the browser nor anything the operator can act on.
+    """
+    manager, browser, _tracked = manager_and_browser
+    browser.get = _get_with_no_page_target
+
+    with pytest.raises(ToolError) as excinfo:
+        await manager._replace_main_tab(INSTANCE_ID, reason="test")
+
+    message = str(excinfo.value)
+    assert "page target" in message
+    assert "StopIteration" not in message
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+
+
+async def test_replace_main_tab_lets_an_unrelated_runtime_error_through(
+    manager_and_browser,
+):
+    """The guard is scoped to the StopIteration cause, not to ``RuntimeError``.
+
+    A transport-level ``RuntimeError`` (a closed event loop, a dead websocket)
+    is NOT "no usable page target" and must keep its own type and message so it
+    still reaches Sentry as the unexpected failure it is.
+    """
+    manager, browser, _tracked = manager_and_browser
+
+    async def _boom(*_args, **_kwargs):
+        raise RuntimeError("Event loop is closed")
+
+    browser.get = _boom
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await manager._replace_main_tab(INSTANCE_ID, reason="test")
+
+    assert not isinstance(excinfo.value, ToolError)
+    assert str(excinfo.value) == "Event loop is closed"
+
+
+# ---------------------------------------------------------------------------
+# F-816 — navigate: the instance-not-found shape is typed, not a bare Exception
+# ---------------------------------------------------------------------------
+
+
+async def test_navigate_on_an_unknown_instance_raises_instance_not_found():
+    """Sentry STEALTH-CHROME-DEVTOOLS-MCP-12 (7 events).
+
+    ``navigate`` raised a bare ``Exception``, which breaks CLAUDE.md convention 2
+    and — because it is not a ``ToolError`` — defeats the F-815 before-send
+    filter, shipping an ordinary "you named an instance that does not exist"
+    caller mistake to Sentry as if it were a crash.
+    """
+    manager = BrowserManager()
+
+    with pytest.raises(InstanceNotFoundError) as excinfo:
+        await manager.navigate("no-such-instance", "https://fake.test/page")
+
+    assert str(excinfo.value) == "Instance not found: no-such-instance"

--- a/tests/test_cdp_command_normalization.py
+++ b/tests/test_cdp_command_normalization.py
@@ -24,6 +24,7 @@ from fakes import FakeBrowserManager, FakeTab, call_tool
 from stealth_chrome_devtools_mcp.embedded import cdp_function_executor, server
 from stealth_chrome_devtools_mcp.embedded.cdp_function_executor import (
     CDPFunctionExecutor,
+    build_cdp_call,
     resolve_cdp_command,
 )
 from stealth_chrome_devtools_mcp.embedded.tool_errors import ToolError
@@ -202,3 +203,88 @@ async def test_the_tool_surfaces_one_unwrapped_failure(monkeypatch):
         "Unknown CDP command: Runtime.noSuchThing (tried runtime.noSuchThing)"
     )
     assert result["command"] == "Runtime.noSuchThing"
+
+
+# ---------------------------------------------------------------------------
+# F-816: the same forgiveness, one level down — the command's PARAMETERS
+#
+# Resolving the command name only moved the identical mistake one line along:
+# the caller who reads ``Runtime.evaluate`` in the CDP docs reads its parameters
+# there too, and sends ``awaitPromise`` to a generated function that declares
+# ``await_promise`` (Sentry STEALTH-CHROME-DEVTOOLS-MCP-22, 3 events, 2.0.6).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        {"expression": "6 * 7", "awaitPromise": True, "returnByValue": True},
+        {"expression": "6 * 7", "await_promise": True, "return_by_value": True},
+        {"expression": "6 * 7", "awaitPromise": True, "return_by_value": True},
+    ],
+    ids=["wire", "nodriver", "mixed"],
+)
+@pytest.mark.asyncio
+async def test_every_spelling_of_a_param_reaches_the_wire(params):
+    """All three spellings must build the ONE frame the protocol defines.
+
+    The frame is the assertion rather than the kwargs: it is what Chrome
+    receives, so it proves the value arrived under the right name instead of
+    being silently dropped.
+    """
+    tab = FakeTab(cdp_responses={"enable": None, "evaluate": ("remote", None)})
+
+    result = await CDPFunctionExecutor().execute_cdp_command(tab, "evaluate", params)
+
+    assert result["success"] is True
+    assert tab.cdp_frames[-1] == {
+        "method": "Runtime.evaluate",
+        "params": {"expression": "6 * 7", "returnByValue": True, "awaitPromise": True},
+    }
+    # The caller's own spelling is echoed back, exactly as the command name is.
+    assert result["params"] == params
+
+
+def test_the_param_folding_is_not_runtime_only():
+    """Folding is a property of the resolved callable, not of one domain."""
+    call = build_cdp_call(
+        uc.cdp.emulation.set_device_metrics_override,
+        {"width": 390, "height": 844, "deviceScaleFactor": 3.0, "mobile": True},
+    )
+
+    assert next(call)["params"]["deviceScaleFactor"] == 3.0
+
+
+def test_an_exact_param_name_is_never_folded_onto_another():
+    """The exact name wins, so a name that worked before is passed untouched."""
+    call = build_cdp_call(uc.cdp.runtime.evaluate, {"expression": "1", "silent": True})
+
+    assert next(call)["params"] == {"expression": "1", "silent": True}
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_param_names_the_ones_the_command_takes(monkeypatch):
+    """A param no folding can match is a caller mistake: an EXPECTED failure.
+
+    Same shape as the unknown-command path above — a ToolError the executor
+    catches itself, so Sentry's ``before_send`` drops it by type and the caller
+    still receives the method's ``{"success": False}`` KEEP contract. The valid
+    names go in the message because that is the one thing the caller needs.
+    """
+    reported: list[BaseException] = []
+    monkeypatch.setattr(
+        cdp_function_executor.debug_logger,
+        "log_error",
+        lambda component, method, error, context=None: reported.append(error),
+    )
+    tab = FakeTab(cdp_responses={"enable": None, "evaluate": ("remote", None)})
+
+    result = await CDPFunctionExecutor().execute_cdp_command(
+        tab, "Runtime.evaluate", {"expression": "1", "awaitPromis": True}
+    )
+
+    assert result["success"] is False
+    assert "awaitPromis" in result["error"]
+    assert "await_promise" in result["error"], "must list what the command takes"
+    assert [type(error) for error in reported] == [ToolError]
+    assert "evaluate" not in tab.send_calls, "a bad call must not reach the browser"

--- a/tests/test_cdp_timeout.py
+++ b/tests/test_cdp_timeout.py
@@ -23,6 +23,7 @@ from stealth_chrome_devtools_mcp.embedded.server import (
     _clamp_timeout,
     _with_cdp_timeout,
 )
+from stealth_chrome_devtools_mcp.embedded.tool_errors import ToolError
 
 # ---------------------------------------------------------------------------
 # Unit tests: _with_cdp_timeout mechanism
@@ -332,14 +333,18 @@ class TestFastTimeoutFailure:
 
     @pytest.mark.asyncio
     async def test_1s_timeout_returns_correct_error_type(self):
-        """Timeout should raise a plain Exception (not asyncio.TimeoutError)."""
+        """Timeout raises ``ToolError`` (not ``asyncio.TimeoutError``, and no
+        longer a bare ``Exception`` — F-783 closed in 2.0.8: the timeout path
+        joins convention 2 so a client can tell it from an interpreter bug by
+        type, and Sentry can drop the whole family instead of splitting it into
+        one issue per instance UUID)."""
 
         async def hang():
             await asyncio.sleep(9999)
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(ToolError) as exc_info:
             await _with_cdp_timeout(hang(), timeout=1)
-        assert type(exc_info.value) is Exception
+        assert type(exc_info.value) is ToolError
         assert "CDP operation timed out" in str(exc_info.value)
 
     @pytest.mark.asyncio

--- a/tests/test_element_resolution.py
+++ b/tests/test_element_resolution.py
@@ -9,6 +9,7 @@ hermetic (a fake Tab) so they run in the fast unit lane, not the browser lane.
 """
 
 import pytest
+from nodriver import cdp
 from nodriver.core.connection import ProtocolException
 
 from stealth_chrome_devtools_mcp.embedded import element_resolution
@@ -17,7 +18,9 @@ from stealth_chrome_devtools_mcp.embedded.element_resolution import (
     query_selector_all,
     resolve_by_text,
     resolve_element,
+    resolve_elements,
 )
+from stealth_chrome_devtools_mcp.embedded.tool_errors import ToolError
 
 
 @pytest.fixture(autouse=True)
@@ -38,6 +41,14 @@ def _other():
     return ProtocolException({"message": "Some unrelated CDP failure", "code": -32601})
 
 
+def _handler_race():
+    # Mirrors nodriver's own bookkeeping race: Tab.wait() registers the
+    # page-event handlers and its finally-block does a bare
+    # ``del self.handlers[evt_dom]``; a concurrent wait() on the same tab has
+    # already dropped the key, so the KeyError's arg is the CDP event CLASS.
+    return KeyError(cdp.page.FrameStoppedLoading)
+
+
 def _pop(effects):
     effect = effects.pop(0)
     if isinstance(effect, Exception):
@@ -46,17 +57,23 @@ def _pop(effects):
 
 
 class _FakeTab:
-    def __init__(self, *, select=None, find=None, send=None):
+    def __init__(self, *, select=None, select_all=None, find=None, send=None):
         self._select = list(select or [])
+        self._select_all = list(select_all or [])
         self._find = list(find or [])
         self._send = list(send or [])
         self.select_calls = 0
+        self.select_all_calls = 0
         self.find_calls = 0
         self.send_calls = 0
 
     async def select(self, selector, timeout=None):
         self.select_calls += 1
         return _pop(self._select)
+
+    async def select_all(self, selector):
+        self.select_all_calls += 1
+        return _pop(self._select_all)
 
     async def find(self, text, best_match=True, timeout=None):
         self.find_calls += 1
@@ -124,6 +141,61 @@ async def test_resolve_by_text_recovers_from_stale_node():
     tab = _FakeTab(find=[_stale(), sentinel])
     assert await resolve_by_text(tab, "Submit") is sentinel
     assert tab.find_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_resolve_elements_recovers_from_nodriver_handler_race():
+    # STEALTH-CHROME-DEVTOOLS-MCP-2R: select_all -> `await self` -> Tab.wait(),
+    # whose handler cleanup raises KeyError(<cdp event class>) under concurrency.
+    # Transient by construction: the same call succeeds on the retry.
+    nodes = [object()]
+    tab = _FakeTab(select_all=[_handler_race(), nodes])
+    assert await resolve_elements(tab, ".row") == nodes
+    assert tab.select_all_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_resolve_elements_raises_readable_tool_error_when_race_persists():
+    # STEALTH-CHROME-DEVTOOLS-MCP-2S: the bare KeyError used to escape as
+    # "<class 'nodriver.cdp.page.FrameStoppedLoading'>" — useless to a caller.
+    tab = _FakeTab(select_all=[_handler_race() for _ in range(_MAX_RESOLVES)])
+    with pytest.raises(ToolError) as excinfo:
+        await resolve_elements(tab, ".row")
+    message = str(excinfo.value)
+    assert "FrameStoppedLoading" in message
+    assert "nodriver" in message
+    assert ".row" in message
+    assert "<class " not in message  # never the raw class repr
+    assert tab.select_all_calls == _MAX_RESOLVES  # bounded, same as the -32000 path
+
+
+@pytest.mark.asyncio
+async def test_resolve_element_recovers_from_nodriver_handler_race():
+    # The single-element path inherits the same recovery (one shared structure).
+    sentinel = object()
+    tab = _FakeTab(select=[_handler_race(), sentinel])
+    assert await resolve_element(tab, "#btn") is sentinel
+    assert tab.select_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_unrelated_key_error_is_neither_retried_nor_converted():
+    # A KeyError from anywhere else is a real defect: it must not be silently
+    # retried, nor dressed up as a nodriver race.
+    tab = _FakeTab(select_all=[KeyError("foo")])
+    with pytest.raises(KeyError, match="foo"):
+        await resolve_elements(tab, ".row")
+    assert tab.select_all_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_key_error_naming_a_non_nodriver_class_is_not_retried():
+    # Scoped to nodriver.cdp classes: a KeyError whose arg happens to be some
+    # other class is still a genuine failure.
+    tab = _FakeTab(select_all=[KeyError(dict)])
+    with pytest.raises(KeyError):
+        await resolve_elements(tab, ".row")
+    assert tab.select_all_calls == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_error_typing.py
+++ b/tests/test_error_typing.py
@@ -1,0 +1,351 @@
+"""RED-first pins for F-783 / the dom_handler raise-typing sweep (2.0.8).
+
+Convention 2 says a tool reports an expected failure by RAISING
+``tool_errors.ToolError``. Two families escaped it and shipped to Sentry as if
+they were crashes, because ``observability._is_expected_tool_failure`` drops an
+event only when EVERY exception in the chain is one of ours:
+
+* ``dom_handler``'s interaction surface raised bare ``Exception`` — the live
+  evidence was ``Element not found: {selector}`` re-wrapped as ``Failed to type
+  text: ...`` (issue STEALTH-CHROME-DEVTOOLS-MCP-2H);
+* ``server._with_cdp_timeout`` raised bare ``Exception``, and because the
+  instance UUID is inside the message, Sentry split one failure mode into seven
+  issues (the F-783 residual the audit deferred as C5).
+
+These pin the TYPE, not just the message: ``pytest.raises(Exception)`` passes
+for a ``ToolError`` too, so every assertion here is on the exact class.
+"""
+
+import asyncio
+from typing import ClassVar
+
+import pytest
+
+from stealth_chrome_devtools_mcp import observability
+from stealth_chrome_devtools_mcp.embedded import dom_handler as dom_handler_mod
+from stealth_chrome_devtools_mcp.embedded.dom_handler import DOMHandler
+from stealth_chrome_devtools_mcp.embedded.server import _with_cdp_timeout
+from stealth_chrome_devtools_mcp.embedded.tool_errors import ToolError
+
+SELECTOR = "#no-such-element"
+
+
+@pytest.fixture()
+def no_element(monkeypatch):
+    """``resolve_element`` finds nothing — the one seam every interaction uses.
+
+    Patched on ``dom_handler``'s own namespace because that is where the name is
+    bound (the absolute-import convention means the module holds its own
+    reference, so patching ``element_resolution`` would not be seen here).
+    """
+
+    async def _none(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(dom_handler_mod, "resolve_element", _none)
+
+
+@pytest.fixture()
+def any_element(monkeypatch):
+    """``resolve_element`` succeeds, so a test can reach an argument guard."""
+
+    class _Element:
+        tag_name = "select"
+        attrs: ClassVar[dict[str, str]] = {}
+
+        async def send_keys(self, _text):
+            return None
+
+    async def _found(*args, **kwargs):
+        return _Element()
+
+    monkeypatch.setattr(dom_handler_mod, "resolve_element", _found)
+
+
+class _RaisingTab:
+    """A tab whose every CDP call fails with a plain transport-shaped error."""
+
+    def __init__(self, error=None):
+        self._error = error or RuntimeError("connection lost")
+
+    async def evaluate(self, *args, **kwargs):
+        raise self._error
+
+    async def get_content(self, *args, **kwargs):
+        raise self._error
+
+    async def send(self, *args, **kwargs):
+        raise self._error
+
+
+# ---------------------------------------------------------------------------
+# The two families named in the Sentry evidence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_type_text_missing_element_raises_tool_error(no_element):
+    """The exact shipped issue: type_text on a selector that resolves to nothing.
+
+    The message chain is preserved — the outer re-wrap still names the operation
+    and the inner failure still names the selector, so a caller can still act.
+    """
+    with pytest.raises(ToolError) as caught:
+        await DOMHandler.type_text(_RaisingTab(), SELECTOR, "hello")
+
+    assert type(caught.value) is ToolError
+    assert str(caught.value).startswith("Failed to type text: ")
+    assert f"Element not found: {SELECTOR}" in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_cdp_timeout_raises_tool_error():
+    """F-783/C5: the timeout path joins the one error convention.
+
+    Typing it drops the whole family from Sentry, which also dissolves the
+    per-UUID issue split (the instance id is inside the message).
+    """
+
+    async def never():
+        await asyncio.sleep(30)
+
+    with pytest.raises(ToolError) as caught:
+        await _with_cdp_timeout(never(), timeout=0.01, instance_id="dead-1")
+
+    assert type(caught.value) is ToolError
+    assert str(caught.value).startswith("CDP operation timed out after 0s")
+    assert "(instance dead-1)" in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_cdp_timeout_does_not_convert_cancellation():
+    """Cancellation is NOT a tool failure — it must still propagate unconverted.
+
+    ``CancelledError`` is a ``BaseException``; turning it into a ``ToolError``
+    would let a cancelled call be reported as a product answer.
+    """
+
+    async def cancelled():
+        raise asyncio.CancelledError
+
+    with pytest.raises(asyncio.CancelledError) as caught:
+        await _with_cdp_timeout(cancelled(), timeout=5)
+
+    assert not isinstance(caught.value, ToolError)
+
+
+# ---------------------------------------------------------------------------
+# The rest of the dom_handler interaction surface — same defect, same fix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method", "args", "prefix"),
+    [
+        ("click_element", (SELECTOR,), "Failed to click element: "),
+        ("paste_text", (SELECTOR, "hello"), "Failed to paste text: "),
+        ("get_element_state", (SELECTOR,), "Failed to get element state: "),
+    ],
+)
+async def test_missing_element_raises_tool_error(no_element, method, args, prefix):
+    with pytest.raises(ToolError) as caught:
+        await getattr(DOMHandler, method)(_RaisingTab(), *args)
+
+    assert type(caught.value) is ToolError
+    assert str(caught.value).startswith(prefix)
+    assert SELECTOR in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_select_option_missing_element_raises_tool_error(no_element):
+    with pytest.raises(ToolError) as caught:
+        await DOMHandler.select_option(_RaisingTab(), SELECTOR, value="a")
+
+    assert type(caught.value) is ToolError
+    assert f"Select element not found: {SELECTOR}" in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_select_option_without_criteria_raises_tool_error(any_element):
+    """An argument guard, not a lookup failure — equally caller-actionable."""
+    with pytest.raises(ToolError) as caught:
+        await DOMHandler.select_option(_RaisingTab(), SELECTOR)
+
+    assert type(caught.value) is ToolError
+    assert "No selection criteria provided" in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_upload_file_without_paths_raises_tool_error():
+    with pytest.raises(ToolError) as caught:
+        await DOMHandler.upload_file(_RaisingTab(), SELECTOR, [])
+
+    assert type(caught.value) is ToolError
+    assert "No file paths provided" in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_upload_file_missing_path_raises_tool_error(tmp_path):
+    absent = tmp_path / "not-here.txt"
+    with pytest.raises(ToolError) as caught:
+        await DOMHandler.upload_file(_RaisingTab(), SELECTOR, [str(absent)])
+
+    assert type(caught.value) is ToolError
+    assert "File not found: " in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_upload_file_wrong_element_raises_tool_error(monkeypatch, tmp_path):
+    """Pointing the selector at a non-input is the caller's mistake, not a crash."""
+    present = tmp_path / "payload.txt"
+    present.write_text("x", encoding="utf-8")
+
+    class _Div:
+        tag_name = "div"
+        attrs: ClassVar[dict[str, str]] = {}
+
+    async def _found(*args, **kwargs):
+        return _Div()
+
+    monkeypatch.setattr(dom_handler_mod, "resolve_element", _found)
+
+    with pytest.raises(ToolError) as caught:
+        await DOMHandler.upload_file(_RaisingTab(), SELECTOR, [str(present)])
+
+    assert type(caught.value) is ToolError
+    assert "not a file input" in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_execute_script_transport_failure_raises_tool_error():
+    """The CDP call itself failing — distinct from a script that THREW (F-795)."""
+    with pytest.raises(ToolError) as caught:
+        await DOMHandler.execute_script(_RaisingTab(), "1 + 1")
+
+    assert type(caught.value) is ToolError
+    assert str(caught.value).startswith("Failed to execute script: ")
+
+
+@pytest.mark.asyncio
+async def test_function_body_retry_transport_failure_raises_tool_error():
+    """The F-812 wrapped retry reports its failure with the same type."""
+    with pytest.raises(ToolError) as caught:
+        await DOMHandler._evaluate_as_function_body(_RaisingTab(), "return 1")
+
+    assert type(caught.value) is ToolError
+    assert str(caught.value).startswith("Failed to execute script: ")
+
+
+@pytest.mark.asyncio
+async def test_get_page_content_failure_raises_tool_error():
+    with pytest.raises(ToolError) as caught:
+        await DOMHandler.get_page_content(_RaisingTab())
+
+    assert type(caught.value) is ToolError
+    assert str(caught.value).startswith("Failed to get page content: ")
+
+
+@pytest.mark.asyncio
+async def test_scroll_page_invalid_direction_raises_tool_error():
+    with pytest.raises(ToolError) as caught:
+        await DOMHandler.scroll_page(_RaisingTab(), direction="sideways")
+
+    assert type(caught.value) is ToolError
+    assert "Invalid scroll direction: sideways" in str(caught.value)
+
+
+# ---------------------------------------------------------------------------
+# query_elements: one canonical error, not two nested ones
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_elements_passes_a_resolution_tool_error_through(monkeypatch):
+    """A ``ToolError`` from the resolution seam surfaces unwrapped.
+
+    ``element_resolution`` raises its own ``ToolError`` for a recovered-but-
+    persistent nodriver handler race, and that error already names the selector.
+    The generic wrap would spell the selector a second time and bury the
+    resolution layer's diagnosis, so it must pass through identically — asserted
+    on object identity, which no re-wrap can fake. The error is injected here
+    rather than provoked, so this pins dom_handler's contract without coupling to
+    element_resolution's wording.
+    """
+    canonical = ToolError(f"selector {SELECTOR!r} never resolved: stale node")
+
+    async def _raise(*args, **kwargs):
+        raise canonical
+
+    monkeypatch.setattr(dom_handler_mod, "resolve_elements", _raise)
+
+    with pytest.raises(ToolError) as caught:
+        await DOMHandler.query_elements(_RaisingTab(), SELECTOR)
+
+    assert caught.value is canonical
+    assert str(caught.value).count(SELECTOR) == 1
+    assert "Failed to query elements" not in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_query_elements_still_wraps_a_foreign_failure(monkeypatch):
+    """The guard against over-correcting: a non-ToolError is still wrapped.
+
+    Only errors already in the convention pass through; anything else still gets
+    the operation name and the selector it failed on.
+    """
+
+    async def _raise(*args, **kwargs):
+        raise RuntimeError("connection lost")
+
+    monkeypatch.setattr(dom_handler_mod, "resolve_elements", _raise)
+
+    with pytest.raises(ToolError) as caught:
+        await DOMHandler.query_elements(_RaisingTab(), SELECTOR)
+
+    assert type(caught.value) is ToolError
+    assert str(caught.value).startswith("Failed to query elements for selector ")
+    assert "connection lost" in str(caught.value)
+
+
+# ---------------------------------------------------------------------------
+# Why the type matters: what Sentry does with the result
+# ---------------------------------------------------------------------------
+
+
+def _hint_for(exception):
+    return {"exc_info": (type(exception), exception, exception.__traceback__)}
+
+
+@pytest.mark.asyncio
+async def test_the_typed_failure_is_dropped_before_sentry(no_element):
+    """The whole point: an expected failure now classifies as expected.
+
+    The chain is ``ToolError("Failed to type text: ...")`` raised while handling
+    ``ToolError("Element not found: ...")`` — every link ours, so the filter
+    drops it instead of paging a maintainer with the product working correctly.
+    """
+    with pytest.raises(ToolError) as caught:
+        await DOMHandler.type_text(_RaisingTab(), SELECTOR, "hello")
+
+    assert observability._is_expected_tool_failure({}, _hint_for(caught.value))
+
+
+@pytest.mark.asyncio
+async def test_a_real_bug_under_the_wrap_still_ships(monkeypatch):
+    """The guard on over-dropping: a genuine bug inside the chain still ships.
+
+    ``resolve_element`` raising ``AttributeError`` is an interpreter-level defect,
+    and the re-wrap being a ``ToolError`` must not hide it — the filter keeps any
+    chain with a link that is not ours.
+    """
+
+    async def _boom(*args, **kwargs):
+        raise AttributeError("'NoneType' object has no attribute 'send_keys'")
+
+    monkeypatch.setattr(dom_handler_mod, "resolve_element", _boom)
+
+    with pytest.raises(ToolError) as caught:
+        await DOMHandler.type_text(_RaisingTab(), SELECTOR, "hello")
+
+    assert not observability._is_expected_tool_failure({}, _hint_for(caught.value))

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -319,10 +319,12 @@ class TestDiagnosticOracle:
     async def test_timeout_failure_pins_its_exact_bytes(self, w15_server):
         import asyncio
 
+        from stealth_chrome_devtools_mcp.embedded.tool_errors import ToolError
+
         async def never() -> None:
             await asyncio.sleep(30)
 
-        with pytest.raises(Exception) as caught:  # noqa: B017  PERMANENT(F-783: the timeout path raises bare Exception; narrowing here would hide that)
+        with pytest.raises(ToolError) as caught:
             await w15_server._with_cdp_timeout(
                 never(), timeout=0.01, instance_id="w15-dead"
             )
@@ -334,10 +336,12 @@ class TestDiagnosticOracle:
     async def test_the_timeout_tag_is_omitted_without_an_instance(self, w15_server):
         import asyncio
 
+        from stealth_chrome_devtools_mcp.embedded.tool_errors import ToolError
+
         async def never() -> None:
             await asyncio.sleep(30)
 
-        with pytest.raises(Exception) as caught:  # noqa: B017  PERMANENT(F-783, as above)
+        with pytest.raises(ToolError) as caught:
             await w15_server._with_cdp_timeout(never(), timeout=0.01)
         assert str(caught.value) == MSG_CDP_TIMEOUT.format(t=0.01, tag="")
 
@@ -456,14 +460,18 @@ class TestErrorConventionGaps:
         assert ToolError.__mro__[1] is Exception
         assert InstanceNotFoundError.__mro__[1] is ToolError
 
-    @pytest.mark.characterization
     @pytest.mark.asyncio
-    async def test_the_timeout_path_escapes_the_one_error_convention(self, w15_server):
-        """route:F-783 — ``_with_cdp_timeout`` raises a bare ``Exception``.
+    async def test_the_timeout_path_now_joins_the_one_error_convention(
+        self, w15_server
+    ):
+        """route:F-783 — CLOSED in 2.0.8: ``_with_cdp_timeout`` raises ``ToolError``.
 
-        CLAUDE.md convention 2 says tools raise ``ToolError``. The CDP timeout
-        path — the single most likely runtime failure — raises the base class,
-        so a client cannot tell a timeout from an interpreter bug by type.
+        This class characterizes gaps; this one is no longer a gap, so the pin is
+        inverted rather than deleted — it is now the regression guard. The timeout
+        path is the single most likely runtime failure, and while it raised the
+        base class a client could not tell a timeout from an interpreter bug by
+        type, and ``_is_expected_tool_failure`` could not drop it (Sentry carried
+        it as seven issues, one per instance UUID in the message).
         """
         import asyncio
 
@@ -472,10 +480,9 @@ class TestErrorConventionGaps:
         async def never() -> None:
             await asyncio.sleep(30)
 
-        with pytest.raises(Exception) as caught:  # noqa: B017  PERMANENT(that the type is exactly Exception IS the finding)
+        with pytest.raises(ToolError) as caught:
             await w15_server._with_cdp_timeout(never(), timeout=0.01)
-        assert type(caught.value) is Exception
-        assert not isinstance(caught.value, ToolError)
+        assert type(caught.value) is ToolError
 
     @pytest.mark.characterization
     @pytest.mark.asyncio

--- a/tests/test_singleton_display_routing.py
+++ b/tests/test_singleton_display_routing.py
@@ -276,6 +276,11 @@ class TestPortSelectionKeepsContextsApart:
         )
         client_context(DESKTOP)
         monkeypatch.setattr(singleton, "_port_is_foreign_held", lambda port: False)
+        # ...and not diverted by the reserved-port probe either: that probe
+        # really binds, so leaving it live would aim a real bind at the real
+        # 19222 on whatever machine runs this. The claim under test is the
+        # v1-record routing, not the OS's opinion of the port.
+        monkeypatch.setattr(proxy_forwarder, "_port_is_forbidden", lambda port: False)
         monkeypatch.setattr(proxy_forwarder, "_free_port", lambda: 54321)
 
         selected = singleton._select_backend_port(singleton.DEFAULT_PORT)
@@ -292,5 +297,8 @@ class TestPortSelectionKeepsContextsApart:
         _record(state_file, 4444, DESKTOP)
         client_context(DESKTOP)
         monkeypatch.setattr(singleton, "_port_is_foreign_held", lambda port: False)
+        # Same reason as the test above: keep the real bind probe off the
+        # literal 4444, which this machine may well have something on.
+        monkeypatch.setattr(proxy_forwarder, "_port_is_forbidden", lambda port: False)
 
         assert singleton._select_backend_port(singleton.DEFAULT_PORT) == 4444

--- a/tests/test_singleton_port_fallback.py
+++ b/tests/test_singleton_port_fallback.py
@@ -4,10 +4,17 @@
 once, synchronously, at the ``ensure_server_running`` boundary (plan_M8
 SSA1.3): prefer the port recorded in ``server.json`` (so eviction/restart
 land where a prior backend ran), else ``preferred``; keep that target when it
-is free or held by OUR OWN backend (eviction rebinds it there); only a
-FOREIGN occupant (the ``_port_is_foreign_held`` predicate) forces an
-OS-assigned fallback via the one existing port-picker,
-``proxy_forwarder._free_port()`` - no new picker, no port-range scan.
+is free or held by OUR OWN backend (eviction rebinds it there); a FOREIGN
+occupant (the ``_port_is_foreign_held`` predicate) - or a target the OS
+FORBIDS us outright (``proxy_forwarder._port_is_forbidden``, the field
+residual pinned by this file's second half) - forces an OS-assigned fallback.
+
+Both routes leave through ``proxy_forwarder.bindable_port``, which owns the
+port-ACQUISITION half (and the existing ``_free_port`` picker it delegates
+to); selection POLICY stays whole in ``_select_backend_port``, which passes
+its verdict down as ``force_new``. The split also keeps singleton.py at its
+1000-LOC budget (tools/check_file_budgets.py), which it already sat exactly
+on: this fix cost that file a net zero lines.
 
 HERMETICITY: this is a real developer machine, not a clean CI runner - a
 live ``stealth-chrome-devtools-mcp`` backend may genuinely be running (e.g.
@@ -21,13 +28,18 @@ redirects ``STATE_DIR``/``SERVER_STATE_FILE``/``PORT_FILE`` into ``tmp_path``
 so no test reads or writes the real state file either.
 """
 
+import logging
 import socket
 import threading
 from unittest.mock import MagicMock
 
 import pytest
 
-from stealth_chrome_devtools_mcp.embedded import backend_registry, singleton
+from stealth_chrome_devtools_mcp.embedded import (
+    backend_registry,
+    proxy_forwarder,
+    singleton,
+)
 
 
 @pytest.fixture()
@@ -64,6 +76,45 @@ def _bind_and_listen() -> socket.socket:
     sock.bind(("127.0.0.1", 0))
     sock.listen(1)
     return sock
+
+
+def _bind_without_listen() -> socket.socket:
+    """A port that is OCCUPIED while looking perfectly free: bound, never
+    listened on, so nothing accepts a connection (every probe in singleton.py
+    reads "free, nothing there") yet a second bind fails with EADDRINUSE.
+    Caller closes it."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    return sock
+
+
+def _forbid_binds_on(monkeypatch, forbidden_port: int) -> None:
+    """Make ``forbidden_port`` behave like a Windows RESERVED port, and only
+    that port.
+
+    Injection is the only way to express this case: a reserved range cannot
+    be created without admin on Windows and does not exist at all on
+    Linux/macOS, so no real socket can produce the verdict. The raised
+    exception is the field one - ``PermissionError``/errno 13 is exactly what
+    the Sentry event shows Python surfacing for WinError 10013.
+
+    Scoped to one port BY DESIGN: `socket.socket` is what the fallback picker
+    (`proxy_forwarder._free_port`) uses to obtain the replacement port, so a
+    blanket stub would forbid the cure along with the disease.
+    """
+    real_socket = socket.socket
+
+    class _ReservedPortSocket(real_socket):
+        def bind(self, address):
+            if address[1] == forbidden_port:
+                raise PermissionError(
+                    13,
+                    "an attempt was made to access a socket in a way "
+                    "forbidden by its access permissions",
+                )
+            return super().bind(address)
+
+    monkeypatch.setattr(socket, "socket", _ReservedPortSocket)
 
 
 class TestSelectBackendPort:
@@ -104,10 +155,16 @@ class TestSelectBackendPort:
     ):
         """Plan_M8 SSA1.6's explicit regression guard ("still 19222"), pinned
         WITHOUT touching the real port 19222 or a real backend that may be
-        running on this machine: stub the two probes _select_backend_port
-        delegates to, rather than binding the literal port."""
+        running on this machine: stub the probes _select_backend_port
+        delegates to, rather than binding the literal port.
+
+        THREE probes now, not two: `_port_is_forbidden` is the one that
+        really binds, so leaving it live would aim a real bind at the real
+        19222 on whatever machine runs this - the exact cross-talk the
+        module docstring's hermeticity rule exists to prevent."""
         monkeypatch.setattr(singleton, "_server_is_healthy", lambda port: False)
         monkeypatch.setattr(singleton, "_backend_pid_on_port", lambda port: None)
+        monkeypatch.setattr(proxy_forwarder, "_port_is_forbidden", lambda port: False)
 
         assert singleton._select_backend_port() == singleton.DEFAULT_PORT
 
@@ -188,3 +245,163 @@ class TestStartServerProcessRecordsSelectedPort:
             assert recorded["port"] == fallback
         finally:
             squatter.close()
+
+
+class TestForbiddenTargetFallsBack:
+    """F-509's residual, from the field: Sentry
+    STEALTH-CHROME-DEVTOOLS-MCP-2J, 2 events on an EXTERNAL user's Windows
+    box, release 2.0.6 -
+
+        [Errno 13] error while attempting to bind on address
+        ('127.0.0.1', 19222): [winerror 10013] an attempt was made to
+        access a socket in a way forbidden by its access permissions
+
+    19222 fell inside a Windows EXCLUDED port range (Hyper-V/WinNAT reserve
+    ranges; `netsh interface ipv4 show excludedportrange protocol=tcp`).
+    Nothing was listening there, so `_port_is_foreign_held` - a CONNECT
+    probe - correctly read "free", selection kept 19222, and uvicorn then
+    died on bind() inside the child, every single start.
+
+    The trigger is a PERMISSION verdict only, never "in use": see
+    TestOccupiedIsNotForbidden below for why that distinction is
+    load-bearing rather than pedantic.
+    """
+
+    def test_a_forbidden_target_is_not_selected(self, isolated_state, monkeypatch):
+        target = _free_closed_port()
+        _forbid_binds_on(monkeypatch, target)
+
+        assert singleton._select_backend_port(target) != target
+
+    def test_the_fallback_is_logged_with_both_ports(
+        self, isolated_state, monkeypatch, caplog
+    ):
+        target = _free_closed_port()
+        _forbid_binds_on(monkeypatch, target)
+
+        with caplog.at_level(logging.WARNING, logger="stealth.proxy"):
+            selected = singleton._select_backend_port(target)
+
+        logged = "\n".join(
+            r.getMessage() for r in caplog.records if r.name == "stealth.proxy"
+        )
+        assert str(target) in logged
+        assert str(selected) in logged
+
+    def test_a_permitted_target_is_kept(self, isolated_state, monkeypatch):
+        """The common case, unchanged: nothing foreign there, the OS permits
+        the port -> that port, no fallback, no warning."""
+        preferred = _free_closed_port()
+        monkeypatch.setattr(singleton, "_server_is_healthy", lambda port: False)
+
+        assert singleton._select_backend_port(preferred) == preferred
+
+    def test_the_predicate_answers_true_only_for_a_forbidden_port(self, monkeypatch):
+        free_port = _free_closed_port()
+        assert not proxy_forwarder._port_is_forbidden(free_port)
+
+        _forbid_binds_on(monkeypatch, free_port)
+        assert proxy_forwarder._port_is_forbidden(free_port)
+
+
+class TestOccupiedIsNotForbidden:
+    """THE regression guard for how this fix was first written wrong.
+
+    A first cut asked "can I bind this?" and treated ANY bind failure as
+    disqualifying. That reads as strictly safer and is not: every proxy in a
+    startup herd runs this selection at once, so the probes collide with EACH
+    OTHER's momentary probe sockets, and eleven of twelve sessions "fall
+    back" to private ports that nothing will ever bind - then poll them for
+    the full 120s BACKEND_READY_TIMEOUT. Measured, not theorised:
+    tests/test_startup_herd.py went from 23s green to a 240s hard timeout,
+    and back to green once the predicate was narrowed to PermissionError.
+
+    The same conflation would divert a healthy restart off our OWN backend's
+    port, which is legitimately in use by us (SSA1.5).
+    """
+
+    def test_a_port_bound_without_a_listener_is_not_forbidden(self):
+        holder = _bind_without_listen()
+        try:
+            occupied = holder.getsockname()[1]
+            assert not singleton._server_is_healthy(occupied), (
+                "precondition: an unlistened port looks FREE to the connect probe"
+            )
+
+            assert not proxy_forwarder._port_is_forbidden(occupied)
+        finally:
+            holder.close()
+
+    def test_a_port_with_a_live_listener_is_not_forbidden(self):
+        listener = _bind_and_listen()
+        try:
+            assert not proxy_forwarder._port_is_forbidden(listener.getsockname()[1])
+        finally:
+            listener.close()
+
+    def test_our_own_backend_keeps_its_port_although_it_holds_it(
+        self, isolated_state, monkeypatch
+    ):
+        """End-to-end through the selector, on a REALLY bound port: ours, so
+        not foreign, and occupied-not-forbidden, so kept."""
+        listener = _bind_and_listen()
+        try:
+            ours = listener.getsockname()[1]
+            monkeypatch.setattr(singleton, "_backend_pid_on_port", lambda port: 4242)
+
+            assert singleton._select_backend_port(ours) == ours
+        finally:
+            listener.close()
+
+
+class TestForbiddenFallbackReachesTheSpawn:
+    """The chosen port must flow everywhere the default would have. Same
+    claim as TestStartServerProcessRecordsSelectedPort above, for the
+    forbidden-target cause rather than the foreign-squatter one."""
+
+    def test_child_argv_and_server_json_both_get_the_fallback(
+        self, isolated_state, monkeypatch
+    ):
+        forbidden = _free_closed_port()
+        with monkeypatch.context() as reserved:
+            _forbid_binds_on(reserved, forbidden)
+            fallback = singleton._select_backend_port(forbidden)
+        assert fallback != forbidden
+
+        monkeypatch.setattr(singleton, "_server_version", lambda: "1.2.1")
+        fake_proc = MagicMock()
+        fake_proc.pid = 4242
+        captured_popen = MagicMock(return_value=fake_proc)
+        monkeypatch.setattr(singleton.subprocess, "Popen", captured_popen)
+
+        singleton._start_server_process(fallback)
+
+        cmd_args = captured_popen.call_args.args[0]
+        assert cmd_args[cmd_args.index("--port") + 1] == str(fallback)
+        recorded = backend_registry.first_backend(singleton._read_server_state())
+        assert recorded["port"] == fallback
+
+    def test_cold_start_thread_and_return_value_agree_on_the_fallback(
+        self, isolated_state, monkeypatch
+    ):
+        """ensure_server_running's return value is the proxy's connect
+        target; the thread's arg is the spawn port. A forbidden default must
+        move BOTH, in lock-step, or the proxy dials a port nothing will ever
+        bind for the full 120s BACKEND_READY_TIMEOUT."""
+        forbidden = _free_closed_port()
+        _forbid_binds_on(monkeypatch, forbidden)
+        captured = {}
+        got_arg = threading.Event()
+
+        def _fake_cold_start(port):
+            captured["port"] = port
+            got_arg.set()
+
+        monkeypatch.setattr(singleton, "_find_running_server", lambda: None)
+        monkeypatch.setattr(singleton, "_start_backend_holding_lock", _fake_cold_start)
+
+        returned = singleton.ensure_server_running(port=forbidden)
+
+        assert got_arg.wait(timeout=5), "cold-start thread never ran"
+        assert captured["port"] == returned
+        assert returned != forbidden


### PR DESCRIPTION
Stacked on #63 (it builds on the F-815 Sentry filter there). Retarget to `main` after #63 merges.

Five fixes, each driven by a live Sentry stacktrace, each TDD'd RED-first against the exact production error shape. Full hermetic lane: **1636 passed** (+42 new tests), budget gate green, all LOC caps exact.

## The fixes

**F-817 — nodriver handler-table race** (`element_resolution.py`) — Fixes STEALTH-CHROME-DEVTOOLS-MCP-2R, -2S
nodriver 0.47's `remove_handler` ends in a bare `del self.handlers[evt_dom]` that deletes the whole key; two overlapping `Tab.wait()`s race and the loser crashes with `KeyError: <class 'nodriver.cdp.page.FrameStoppedLoading'>`. The existing recovery wrapper now retries it like the -32000 stale-node case (one classifier, no parallel path); if it persists, a readable ToolError replaces the class-repr leak. Unrelated KeyErrors propagate untouched (two negative-control pins).

**F-816 — CDP param-name folding** (`cdp_function_executor.py`, 1010/1012) — Fixes -22
F-813 forgave command-name spelling; params still crashed on the CDP docs' own casing (`awaitPromise`). `build_cdp_call` folds incoming keys onto the resolved method's real signature; unknown params raise ToolError listing the valid names, through the method's KEEP contract.

**F-818 — target-less browser + typed instance-not-found** (`browser_manager.py`, exactly 1532/1532, line-neutral) — Fixes -2K, -12
`Browser.get()`'s bare `next(filter(...))` turns into `RuntimeError: coroutine raised StopIteration` when no page target remains; the one exposed call site converts exactly that shape into an actionable ToolError. `navigate`'s unknown-instance raise becomes `InstanceNotFoundError`, its timeout ToolError. Census of all 7 bare raises included in the commit; 4 left deliberately (F-811 operator-hint contract, internal invariants).

**F-783 closed — error-convention sweep** (`dom_handler.py`, `server.py` exactly 3411/3411) — Fixes -2H, -Y, -2F, -2P, -2V, -2Q, -2M, -2N
All 21 bare `raise Exception` sites in dom_handler + `_with_cdp_timeout`'s timeout raise become ToolError (messages byte-identical). The F-815 filter now drops the family — which also dissolves the per-instance-UUID splitting of CDP-timeout issues. Deliberately kept shipping: cancellation (still `CancelledError`) and spawn failures (`server.py:454` stays bare so the F-811 exhaustion class remains visible in Sentry). Audit finding doc annotated closed.

**F-509 — reserved-port fallback** (`singleton.py` exactly 1000/1000, `proxy_forwarder.py`) — Fixes -2J
Windows excluded-port ranges forbid binding 19222 (WinError 10013) but have **no listener**, so the connect-based foreign-held probe read the port as free and uvicorn died in the child on every start — seen on an external user's machine. New bind-and-close probe disqualifies a port **only on PermissionError**: treating any bind failure as disqualifying scattered the cold-start herd onto private ports (herd test 240s timeout vs 3.9s — the A/B that found it is pinned in `TestOccupiedIsNotForbidden`). Selection policy, `restart_backend`'s contract, and identity/adoption gates unchanged.

## Known residuals (flagged, not fixed here)
- F-509 A2 (DESIGN.md): a fleet cold-starting against a genuinely reserved port still scatters; needs port choice serialized under the cold-start lock.
- nodriver upstream: `remove_handler`'s unguarded `del`s remain — we work around, not vendor-patch.
- `dom_handler.py:859` `ValueError` for invalid scroll direction still ships to Sentry (chain contains a non-ToolError).
- DESIGN.md/RUNBOOK.md port-selection prose doesn't yet mention the permission dimension (no doc pin falsified).

Integration lane runs on this PR's CI (E2E across 3 OSes), same as #63.