### PR TITLE
chore: npm trusted-publishing placeholder for @stealthly/mcp

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,30 @@
+name: Publish npm placeholder
+
+# Manual only, by design. This repo's own release flow publishes to PyPI, so
+# this workflow deliberately does NOT trigger on `release` — it must never
+# fire as a side effect of that flow.
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: npm
+    permissions:
+      contents: read
+      # Required for npm trusted publishing (OIDC). No NPM_TOKEN secret is used.
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      # Trusted publishing requires npm >= 11.5.1; setup-node ships an older npm.
+      - run: npm install -g npm@latest
+
+      - run: npm publish --access public

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,3 @@
+# @stealthly/mcp
+
+Reserved for the official Stealthly MCP server — coming soon. See https://stealthly.io.

--- a/npm/index.js
+++ b/npm/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@stealthly/mcp",
+  "version": "0.0.1",
+  "description": "Placeholder — the official Stealthly MCP server. Coming soon.",
+  "license": "MIT",
+  "homepage": "https://stealthly.io",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DevinoSolutions/stealth-chrome-devtools-mcp.git"
+  }
+}


### PR DESCRIPTION
Parks the published @stealthly/mcp 0.0.1 placeholder in `npm/` and adds a manual-trigger npm trusted-publishing workflow (OIDC, no NPM_TOKEN).

The workflow is `workflow_dispatch` only on purpose: this repo's release flow publishes to PyPI, and an npm publish must never fire as a side effect of it.

The npm trusted publisher for @stealthly/mcp is already bound to `npm-publish.yml` in this repo, so merging this makes the binding live.