### PR TITLE
F-819: freeze the image's Chrome before reading its identity

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -91,8 +91,10 @@ jobs:
       - name: Record the Chrome Stable this future run happened to get
         # Informational identity capture only. It does not qualify the release
         # SHA and does not extend support to this Chrome version.
+        # F-819: --freeze-updater pins that Stable for the rest of the run, so
+        # the recorded identity describes the browser this run actually used.
         shell: bash
-        run: uv run python tools/resolve_chrome.py --out chrome-identity.json
+        run: uv run python tools/resolve_chrome.py --freeze-updater --out chrome-identity.json
       - name: Start Xvfb
         run: |
           sudo apt-get update -qq
@@ -142,6 +144,9 @@ jobs:
           echo "AUTHORITY OF EACH HALF:"
           echo "  deterministic     : local fixture, RED MEANS RED (calls the one reusable gate)"
           echo "  live-observation  : INFORMATIONAL ONLY, cannot gate or license a claim"
-          echo "  chrome identity   : whichever Stable the runner image supplied AT RUN TIME;"
-          echo "                      it does not qualify the release SHA, and says nothing"
-          echo "                      about historical, future, or non-stable channels."
+          echo "  chrome identity   : whichever Stable the runner image supplied, FROZEN AT RUN"
+          echo "                      START (F-819: the image's background updater is neutralised"
+          echo "                      before the version is read, so the recorded identity is the"
+          echo "                      one this run used end to end). It does not qualify the"
+          echo "                      release SHA, and says nothing about historical, future, or"
+          echo "                      non-stable channels."

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -286,8 +286,13 @@ jobs:
           --expect-arch "${{ matrix.runner_arch }}" --python "3.12"
           --out "runner-identity.json"
       - name: Resolve image Chrome Stable identity
+        # F-819: --freeze-updater neutralises the image's background Chrome
+        # updater BEFORE the version is read, so the identity recorded here is
+        # the identity the browser this job launches will still report. Without
+        # it, macOS Keystone can swap Chrome Stable mid-run and the CDP
+        # comparison in TestChromeIdentity fails on two different binaries.
         shell: bash
-        run: uv run python tools/resolve_chrome.py --out chrome-identity.json
+        run: uv run python tools/resolve_chrome.py --freeze-updater --out chrome-identity.json
       - name: Start Xvfb (Linux headed cases only)
         if: runner.os == 'Linux'
         run: |
@@ -470,8 +475,13 @@ jobs:
           --expect-arch "${{ matrix.runner_arch }}" --python "3.12"
           --out "runner-identity.json"
       - name: Resolve image Chrome Stable identity
+        # F-819: --freeze-updater neutralises the image's background Chrome
+        # updater BEFORE the version is read, so the identity recorded here is
+        # the identity the browser this job launches will still report. Without
+        # it, macOS Keystone can swap Chrome Stable mid-run and the CDP
+        # comparison in TestChromeIdentity fails on two different binaries.
         shell: bash
-        run: uv run python tools/resolve_chrome.py --out chrome-identity.json
+        run: uv run python tools/resolve_chrome.py --freeze-updater --out chrome-identity.json
       - name: Start Xvfb (Linux headed cases only)
         if: runner.os == 'Linux'
         run: |
@@ -645,8 +655,13 @@ jobs:
           --expect-arch "${{ matrix.runner_arch }}" --python "3.12"
           --out "runner-identity.json"
       - name: Resolve image Chrome Stable identity
+        # F-819: --freeze-updater neutralises the image's background Chrome
+        # updater BEFORE the version is read, so the identity recorded here is
+        # the identity the browser this job launches will still report. Without
+        # it, macOS Keystone can swap Chrome Stable mid-run and the CDP
+        # comparison in TestChromeIdentity fails on two different binaries.
         shell: bash
-        run: uv run python tools/resolve_chrome.py --out chrome-identity.json
+        run: uv run python tools/resolve_chrome.py --freeze-updater --out chrome-identity.json
       - name: Start Xvfb (Linux only)
         if: runner.os == 'Linux'
         run: |
@@ -935,8 +950,13 @@ jobs:
           --expect-arch "${{ matrix.cell.runner_arch }}" --python "3.12"
           --out "runner-identity.json"
       - name: Resolve image Chrome Stable identity
+        # F-819: --freeze-updater neutralises the image's background Chrome
+        # updater BEFORE the version is read, so the identity recorded here is
+        # the identity the browser this job launches will still report. Without
+        # it, macOS Keystone can swap Chrome Stable mid-run and the CDP
+        # comparison in TestChromeIdentity fails on two different binaries.
         shell: bash
-        run: uv run python tools/resolve_chrome.py --out chrome-identity.json
+        run: uv run python tools/resolve_chrome.py --freeze-updater --out chrome-identity.json
       - name: Start Xvfb (Linux headed cases only)
         if: runner.os == 'Linux'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## Unreleased
+
+### Fixed — CI: the image's Chrome is frozen at run start, so a red macOS cell means red (F-819)
+
+No product change. `tools/resolve_chrome.py` — the one home of the expected Chrome
+identity — gains `--freeze-updater`, and every CI invocation now passes it.
+
+GitHub's macOS runners let Google's Keystone updater upgrade Chrome Stable in place
+*while a job is running*. The gate resolves the image's Chrome identity at the top of
+each browser job and then trusts it minutes later, when the browser actually launches,
+so an upgrade in between makes the two readings describe two different binaries. PR
+#64 showed it twice on byte-identical trees: CDP `Browser.getVersion` reported
+`Chrome/151.0.7922.76` against a resolved identity of `150.0.7871.187`, and on the
+re-run the same swap surfaced through the UA-coherence gates instead. No product fix
+can close that — F-806 already narrowed the product-side window as far as measurement
+allows; a program cannot make a binary hold still between two measurements.
+
+So the run environment is frozen instead. Before the version is read, the flag
+neutralises the OS's updater: on macOS it unloads and deletes Keystone's launchd jobs
+and both `GoogleSoftwareUpdate` trees, then leaves each path as a root-owned
+unwritable stub inside a root-owned parent — Chrome re-registers Keystone every time
+it launches, and this run launches Chrome, so removal alone would not survive the very
+act it has to survive. On Windows it stops and disables the two Google Update
+services, disables the machine update tasks, and sets the enterprise policy that
+forbids updates. On Linux it does nothing and says so — the images ship no background
+updater.
+
+Every sub-step is best-effort: exit codes are recorded, never checked, and an absent
+service, task, plist or directory is the normal case on at least one OS. The freeze
+narrates to stderr; stdout stays the identity JSON alone. Without the flag, behaviour
+is byte-identical to before, and `resolve_chrome()` itself remains side-effect-free,
+so importing the module can never touch a developer's machine.
+
 ## 2.0.6
 
 ### Fixed — a failed spawn tells you the machine is out of process capacity (F-811)

--- a/audit/stage2/finding_F806_masked_ua_advertises_a_version_the_browser_no_longer_has.md
+++ b/audit/stage2/finding_F806_masked_ua_advertises_a_version_the_browser_no_longer_has.md
@@ -283,3 +283,8 @@ narrowed.
 F-774 (Chrome blanks the *high-entropy* UA client hints whenever a
 `--user-agent` override is active) is unchanged by this work and remains an
 open, strictly-xfailed gap.
+
+The CI-environment half of that remaining window — a runner whose Chrome the
+image's own updater replaces *between* two of the gate's measurements, which no
+product change can close — is
+[F-819](./finding_F819_ci_image_chrome_updates_mid_run.md).

--- a/audit/stage2/finding_F819_ci_image_chrome_updates_mid_run.md
+++ b/audit/stage2/finding_F819_ci_image_chrome_updates_mid_run.md
@@ -1,0 +1,188 @@
+# F-819 — the runner image's Chrome updates mid-run, so the resolved identity and the launched browser are two different binaries
+
+**Status: FIXED (environment-side) — `tools/resolve_chrome.py --freeze-updater`,
+wired into every CI invocation.**
+**Severity: MEDIUM (CI integrity)** — no product defect and no user impact. What
+it costs is the thing a gate exists to provide: a red that means red. The macOS
+cell fails on byte-identical trees, so a reviewer cannot tell a regression from
+a runner that upgraded Chrome while the job was running, and the honest response
+to a red macOS cell becomes "re-run it", which is how a gate stops gating.
+
+---
+
+## The behaviour
+
+Every Chrome-launching job in `release-gate.yml` starts by resolving the image's
+Chrome Stable identity:
+
+```yaml
+- name: Resolve image Chrome Stable identity
+  run: uv run python tools/resolve_chrome.py --out chrome-identity.json
+```
+
+That reading is then trusted for the **rest of the job** — minutes later, by the
+uploaded artifact and by `tests/test_browser_integration.py`'s
+`TestChromeIdentity`, which asserts that production's auto-discovery and the
+launched browser's CDP `Browser.getVersion` agree with it.
+
+The trust is only earned if the binary behind the path cannot change in between.
+On GitHub's macOS runners it can. Google's Keystone updater is live on the image
+and upgrades Chrome Stable in place — the path does not move, only the bytes
+behind it — so a job can resolve `150.x`, launch minutes later, and be answered
+by `151.x`. The gate then reports a mismatch that is entirely real and entirely
+about the runner.
+
+## Evidence
+
+**PR #64, two runs on byte-identical trees, both red on macOS.** The tree was
+re-pushed unchanged precisely to separate a defect from a flake; both runs went
+red on macOS through the same mechanism, in different nodes.
+
+*Run 1* — the identity comparison itself, from the JUnit report:
+
+```
+tests/test_browser_integration.py::test_autodiscovery_and_cdp_match_image_chrome
+AssertionError comparing ('Chrome/151.0.7922.76', '150.0.7871.187')
+```
+
+CDP `Browser.getVersion` reported **151.0.7922.76** while the identity resolved
+at the top of the same job said **150.0.7871.187**. Nothing in the repo produced
+that gap: the resolver and the browser were reading two different binaries,
+because the updater swapped one between the two measurements.
+
+*Run 2* — the same mechanism surfacing one layer down: the two
+`tests/test_stealth.py` UA-coherence gates went red, which is the F-806 shape
+(the masked UA's major disagreeing with the browser's own `sec-ch-ua`) arriving
+by way of a mid-run binary swap rather than a stale memo.
+
+**Prior history.** This is the same runner behaviour that opened F-806. CI run
+**30607810053**, macOS, on 2.0.1: the stealth coherence predicate failed on
+product code byte-identical to the run before it, which had passed — the
+runner's Chrome had moved from 150 to 151 and nothing in the repo had moved at
+all (see
+[`finding_F806_masked_ua_advertises_a_version_the_browser_no_longer_has.md`](./finding_F806_masked_ua_advertises_a_version_the_browser_no_longer_has.md)).
+
+## Why the fix is environment-side, not product-side
+
+F-806's product fix is merged (`ca63b77`, shipped 2.0.4) and is not in question
+here. It closed the parts a program can close: the probe now reads the binary
+itself rather than its neighbouring staged directories, the memo is re-keyed on
+the executable's on-disk identity so an in-place upgrade expires it, and a
+post-launch reconciliation corrects the memo from the browser that actually
+launched.
+
+None of that can close this one, and the reason is structural: **the product
+takes two measurements at two moments, and the defect is that the subject
+changes in between.** A program cannot make a binary hold still. It can only
+narrow the window — F-806 narrowed it from days to the probe-to-launch interval
+of one spawn — and a narrower window is still a window a scheduled updater can
+land in. The gate needs the window closed, not narrowed, and the only place it
+can be closed is the run environment.
+
+So the fix stops the updater rather than out-measuring it.
+
+## The fix
+
+`tools/resolve_chrome.py` — already the ONE home of the expected Chrome identity
+— gains `--freeze-updater`. When passed, it neutralises the OS's background
+Chrome updater **before** `_read_version` runs, so the identity it reports is by
+construction the frozen one. Without the flag, behaviour is byte-identical to
+before, and `resolve_chrome()` itself stays side-effect-free: importers
+(`TestChromeIdentity`) get the reading and nothing else. The flag is opt-in
+because it changes machine state, and only CI should ask for that.
+
+**macOS — remove Keystone, then keep it removed.** Its launchd jobs are unloaded
+and deleted (user agents in the calling user's domain, system daemons under
+`sudo`), both `GoogleSoftwareUpdate` trees are deleted, and each path is
+recreated as a **root-owned mode-000 stub** inside a root-owned parent.
+
+The documented soft knob — `defaults write com.google.Keystone.Agent
+checkInterval 0` — was considered and rejected. Chrome re-registers Keystone
+through `KeystoneRegistration.framework` every time it launches, and launching
+Chrome is exactly what this job does next; an advisory setting can therefore be
+undone by the very act it has to survive. Deleting the trees alone has the same
+weakness in a different form, because a reinstall would simply recreate them.
+The stub is the part that makes the removal durable: there is nowhere for a
+reinstall to land. The parent directory is locked too, because a root-owned stub
+inside a user-owned parent is still removable by that user — unlinking is
+governed by the parent's write bit, not the stub's.
+
+**Windows — stop, disable, and forbid.** The `gupdate` and `gupdatem` services
+are stopped and then disabled (disabling a running service leaves it running for
+the current boot, so the order matters), the `GoogleUpdateTaskMachineCore` /
+`GoogleUpdateTaskMachineUA` scheduled tasks are disabled, and the enterprise
+policy under `HKLM\SOFTWARE\Policies\Google\Update` sets both `UpdateDefault=0`
+and `AutoUpdateCheckPeriodMinutes=0`. Runners are administrators.
+
+**Linux — an explicit no-op.** The images carry no background Chrome updater;
+the package moves only when a job runs `apt`, and none does. The freeze says so
+in the log rather than staying silent, because a silent no-op reads as a bug.
+
+**Nothing here may turn a green run red.** Every sub-step is best-effort by
+construction: exit codes are recorded and never checked, an unrunnable tool is
+swallowed, and a missing service, task, plist or directory is the *normal* case
+on at least one OS. The freeze narrates every step to stderr so the run log
+shows what it actually did on this image; stdout stays the identity JSON alone,
+unchanged, so any consumer parsing it is unaffected.
+
+## What the gate now claims
+
+Before: *"the browser we launched matches whichever Chrome Stable the image
+supplied"* — a claim the runner could invalidate mid-job.
+
+After: **"the Chrome Stable identity is frozen at run start, and the browser we
+launched matches it."** A macOS identity mismatch is now a product signal, and a
+re-run is no longer a legitimate response to one.
+
+## Tests
+
+`tests/test_resolve_chrome_freeze.py` — 25 nodes, fully hermetic. The freeze
+cannot be exercised for real anywhere (running it on a developer workstation
+would disable that human's Chrome updates), so the pins are command-level: they
+fake `subprocess.run` with a recorder that answers with a real
+`subprocess.CompletedProcess` built by the stdlib's own constructor, and assert
+the exact argv per OS. That is the only assertable surface, and without it a
+silent change to the commands would reach CI unreviewed.
+
+Pinned: the per-OS command tables (Keystone plists, both `GoogleSoftwareUpdate`
+roots, the stubs and the parent lock; the Windows services, tasks and policy
+values); that user agents are *not* unloaded under `sudo` (that would target
+root's domain and unload nothing); that Linux issues no command at all but still
+reports; that a non-zero exit, a missing tool and a timeout each leave the
+freeze — and the CLI's exit code — successful; that without the flag no freeze
+runs and stdout is byte-identical; and that the version is read **after** the
+freeze ran.
+
+`tests/test_release_workflows.py::test_every_chrome_identity_resolution_freezes_the_updater_first`
+— the structural half, in the existing home for workflow-YAML pins: every
+`resolve_chrome.py` invocation across `release-gate.yml` and `canary.yml` must
+carry the flag. A job added later that resolves an identity without freezing is
+resolving something it cannot rely on, and this is what says so.
+
+## Residual
+
+**The one-instance probe-to-launch window from F-806 remains accepted, and is
+unchanged by this work.** On a developer workstation, where nothing freezes the
+updater, an upgrade that completes between a spawn's version probe and that
+spawn's launch still costs exactly that one instance a skewed UA; every later
+spawn is corrected by the post-launch reconciliation. Widening the product fix
+to cover that instance was judged the wrong trade in F-806 and this finding does
+not revisit it.
+
+**A runner image whose Chrome is old stays old for the whole run — that is the
+point, not a side effect.** The freeze buys determinism within a run, not
+currency across runs. If an image ships a Chrome the product genuinely does not
+support, this finding will not surface it; that is the canary's job, and the
+canary's identity capture remains informational and still gates nothing.
+
+**The freeze is unverifiable from here.** No test in this repo executes it, and
+none can: the only machines where the real commands may run are the CI runners,
+and this workstation is explicitly not one of them. The pins assert what is
+issued, not what it accomplishes. The first real evidence that Keystone stayed
+down will be a macOS gate cell that stops disagreeing with itself on
+byte-identical trees.
+
+**Nothing restores the runner.** The freeze is one-way within a job, which is
+correct for an ephemeral VM that is destroyed afterwards, and would be wrong
+anywhere else. The flag's help text says so, and it is off by default for
+exactly that reason.

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -475,6 +475,29 @@ def test_the_deterministic_half_is_not_marked_non_gating(canary_jobs):
             )
 
 
+# ---------------------------------------------------------------------------
+# F-819: every resolved identity is a frozen identity.
+# ---------------------------------------------------------------------------
+def test_every_chrome_identity_resolution_freezes_the_updater_first():
+    """An unfrozen `resolve_chrome.py` reads an identity the runner may replace.
+
+    GitHub's macOS images let Keystone upgrade Chrome Stable mid-run, so a job
+    that resolves the identity and later launches the browser can compare two
+    different binaries (PR #64: CDP said 151.x, the artifact said 150.x). The
+    flag is what makes the reading durable for the rest of the job, so a job
+    that resolves without it is resolving something it cannot rely on.
+    """
+    for path in (RELEASE_GATE, CANARY):
+        for name, job in _jobs(path).items():
+            for run in _all_run_steps(job):
+                if "resolve_chrome.py" not in run:
+                    continue
+                assert "--freeze-updater" in run, (
+                    f"{path.name} job {name!r} resolves the Chrome identity "
+                    f"without freezing the updater first: {run.strip()!r}"
+                )
+
+
 def test_the_canary_is_not_wired_into_the_gate(gate_jobs):
     """Nothing in the required check may depend on an observation lane."""
     for name, job in gate_jobs.items():

--- a/tests/test_resolve_chrome_freeze.py
+++ b/tests/test_resolve_chrome_freeze.py
@@ -1,0 +1,322 @@
+"""F-819: `resolve_chrome.py --freeze-updater` stops the image's Chrome moving.
+
+`tools/resolve_chrome.py` is the ONE home of the *expected* Chrome identity. It
+is read once per CI job and then trusted for the rest of the run — by the JSON
+artifact and by `tests/test_browser_integration.py`'s CDP comparison. That trust
+is only earned if the binary cannot change underneath the reading, and on
+GitHub's macOS runners it can: Keystone upgrades Chrome Stable mid-run, so the
+resolved identity and the launched browser disagree (PR #64, both red macOS runs
+on byte-identical trees).
+
+These pins characterise the freeze the flag performs. They are deliberately
+command-level: the freeze cannot be exercised for real anywhere — running it on
+a developer workstation would disable that human's Chrome updates — so the exact
+argv per OS is the only thing there is to assert, and a silent change to it
+would otherwise reach CI unreviewed.
+
+Every seam is faked. Nothing here starts a process or touches a real path.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+TOOLS = Path(__file__).resolve().parent.parent / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import resolve_chrome  # (imported after the sys.path line above; tests/** allows E402)
+
+
+class RecordingRun:
+    """A stand-in for `subprocess.run` that records argv and answers as told.
+
+    The reply is a real `subprocess.CompletedProcess`, built by the stdlib's own
+    constructor, so a pin can never pass against a shape the real call would not
+    produce.
+    """
+
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = ""):
+        self.calls: list[list[str]] = []
+        self._returncode = returncode
+        self._stdout = stdout
+        self._stderr = stderr
+
+    def __call__(self, command, **kwargs):
+        self.calls.append(list(command))
+        return subprocess.CompletedProcess(
+            args=list(command),
+            returncode=self._returncode,
+            stdout=self._stdout,
+            stderr=self._stderr,
+        )
+
+
+@pytest.fixture
+def run_recorder(monkeypatch) -> RecordingRun:
+    recorder = RecordingRun()
+    monkeypatch.setattr(resolve_chrome.subprocess, "run", recorder)
+    return recorder
+
+
+def _as_lines(calls: list[list[str]]) -> list[str]:
+    return [" ".join(call) for call in calls]
+
+
+def _home(*parts: str) -> str:
+    """A home-relative path rendered in the HOST's flavour.
+
+    The freeze only ever executes on macOS, but this pin runs on all three
+    runners, and `Path.home() / "Library"` renders with a backslash on Windows.
+    Building the expectation through the same join keeps the pin about the path
+    the code chose rather than about the separator the host prefers.
+    """
+    return str(Path.home().joinpath(*parts))
+
+
+# ---------------------------------------------------------------------------
+# What the freeze issues, per OS.
+# ---------------------------------------------------------------------------
+class TestMacOSFreezesKeystone:
+    """macOS is the OS the defect was observed on; Keystone is the updater."""
+
+    @pytest.fixture
+    def lines(self, monkeypatch, run_recorder) -> list[str]:
+        monkeypatch.setattr(resolve_chrome.platform, "system", lambda: "Darwin")
+        resolve_chrome.freeze_updater()
+        return _as_lines(run_recorder.calls)
+
+    def test_the_user_launch_agents_are_unloaded_and_removed(self, lines):
+        for label in ("agent", "xpcservice"):
+            plist = _home(
+                "Library", "LaunchAgents", f"com.google.keystone.{label}.plist"
+            )
+            assert f"launchctl unload -w {plist}" in lines
+            assert f"rm -f {plist}" in lines
+
+    def test_the_user_agents_are_not_unloaded_as_root(self, lines):
+        """`sudo launchctl` targets root's domain and would unload nothing."""
+        plist = _home("Library", "LaunchAgents", "com.google.keystone.agent.plist")
+        assert f"sudo launchctl unload -w {plist}" not in lines
+
+    def test_the_system_launch_daemons_are_unloaded_as_root(self, lines):
+        for plist in (
+            "/Library/LaunchAgents/com.google.keystone.agent.plist",
+            "/Library/LaunchDaemons/com.google.keystone.daemon.plist",
+            "/Library/LaunchDaemons/com.google.keystone.system.agent.plist",
+        ):
+            assert f"sudo launchctl unload -w {plist}" in lines
+            assert f"sudo rm -f {plist}" in lines
+
+    def test_both_googlesoftwareupdate_roots_are_removed(self, lines):
+        for root in (
+            _home("Library", "Google", "GoogleSoftwareUpdate"),
+            "/Library/Google/GoogleSoftwareUpdate",
+        ):
+            assert f"sudo rm -rf {root}" in lines
+
+    def test_each_root_is_left_as_a_root_owned_unwritable_stub(self, lines):
+        """Removal alone is not a freeze: Chrome re-registers Keystone when it
+        launches, and this run launches Chrome. The stub is what makes the
+        removal survive the very act the identity is being resolved for."""
+        for root in (
+            _home("Library", "Google", "GoogleSoftwareUpdate"),
+            "/Library/Google/GoogleSoftwareUpdate",
+        ):
+            assert f"sudo mkdir -p {root}" in lines
+            assert f"sudo chown root:wheel {root}" in lines
+            assert f"sudo chmod 000 {root}" in lines
+
+    def test_the_home_parent_directory_is_locked_too(self, lines):
+        """A root-owned stub inside a user-owned parent can still be unlinked by
+        that user — the parent's write bit, not the stub's, governs removal."""
+        parent = _home("Library", "Google")
+        assert f"sudo chown root:wheel {parent}" in lines
+        assert f"sudo chmod 555 {parent}" in lines
+
+    def test_the_stub_is_created_before_its_parent_is_locked(self, lines):
+        root = _home("Library", "Google", "GoogleSoftwareUpdate")
+        assert lines.index(f"sudo mkdir -p {root}") < lines.index(
+            f"sudo chmod 555 {_home('Library', 'Google')}"
+        )
+
+
+class TestWindowsFreezesGoogleUpdate:
+    @pytest.fixture
+    def lines(self, monkeypatch, run_recorder) -> list[str]:
+        monkeypatch.setattr(resolve_chrome.platform, "system", lambda: "Windows")
+        resolve_chrome.freeze_updater()
+        return _as_lines(run_recorder.calls)
+
+    def test_both_update_services_are_stopped_then_disabled(self, lines):
+        for service in ("gupdate", "gupdatem"):
+            assert f"sc.exe stop {service}" in lines
+            assert f"sc.exe config {service} start= disabled" in lines
+            assert lines.index(f"sc.exe stop {service}") < lines.index(
+                f"sc.exe config {service} start= disabled"
+            )
+
+    def test_the_machine_update_tasks_are_disabled(self, lines):
+        for task in ("GoogleUpdateTaskMachineCore", "GoogleUpdateTaskMachineUA"):
+            assert f"schtasks.exe /Change /TN {task} /DISABLE" in lines
+
+    def test_the_enterprise_policy_turns_updates_off(self, lines):
+        key = r"HKLM\SOFTWARE\Policies\Google\Update"
+        assert f"reg.exe add {key} /v UpdateDefault /t REG_DWORD /d 0 /f" in lines
+        assert (
+            f"reg.exe add {key} /v AutoUpdateCheckPeriodMinutes /t REG_DWORD /d 0 /f"
+            in lines
+        )
+
+    def test_every_step_is_argv_not_a_shell_string(self, lines, run_recorder):
+        assert run_recorder.calls, "the Windows freeze issued nothing at all"
+        for call in run_recorder.calls:
+            assert all(isinstance(arg, str) for arg in call), (
+                "argv form only — a shell string would need quoting nobody checks"
+            )
+
+
+class TestLinuxIsAnExplicitNoOp:
+    def test_no_command_runs_at_all(self, monkeypatch, run_recorder):
+        monkeypatch.setattr(resolve_chrome.platform, "system", lambda: "Linux")
+        notes = resolve_chrome.freeze_updater()
+        assert run_recorder.calls == [], (
+            "the Linux runner images ship no background Chrome updater; issuing "
+            "commands there would be a second mechanism with nothing to freeze"
+        )
+        assert notes, "a no-op must still say so in the log — silence reads as a bug"
+        assert any("no background" in note.lower() for note in notes)
+
+
+# ---------------------------------------------------------------------------
+# The freeze may never turn a green run red.
+# ---------------------------------------------------------------------------
+class TestAbsenceIsNotFailure:
+    @pytest.mark.parametrize("system", ["Darwin", "Windows"])
+    def test_a_missing_service_dir_or_task_still_succeeds(self, monkeypatch, system):
+        """Every sub-step is best-effort: an absent target exits non-zero."""
+        monkeypatch.setattr(resolve_chrome.platform, "system", lambda: system)
+        monkeypatch.setattr(
+            resolve_chrome.subprocess,
+            "run",
+            RecordingRun(returncode=1, stderr="The specified service does not exist"),
+        )
+        notes = resolve_chrome.freeze_updater()
+        assert notes, "a freeze that did nothing must still report what it tried"
+
+    @pytest.mark.parametrize("system", ["Darwin", "Windows"])
+    @pytest.mark.parametrize(
+        "boom",
+        [FileNotFoundError("no such tool"), subprocess.TimeoutExpired("sc.exe", 60)],
+    )
+    def test_an_unrunnable_tool_is_swallowed(self, monkeypatch, system, boom):
+        monkeypatch.setattr(resolve_chrome.platform, "system", lambda: system)
+
+        def explode(command, **kwargs):
+            raise boom
+
+        monkeypatch.setattr(resolve_chrome.subprocess, "run", explode)
+        notes = resolve_chrome.freeze_updater()
+        assert notes, "the freeze must report the failure, not propagate it"
+
+    def test_the_cli_still_exits_zero_when_every_step_fails(self, monkeypatch, capsys):
+        monkeypatch.setattr(resolve_chrome.platform, "system", lambda: "Darwin")
+
+        def explode(command, **kwargs):
+            raise OSError("permission denied")
+
+        monkeypatch.setattr(resolve_chrome.subprocess, "run", explode)
+        monkeypatch.setattr(resolve_chrome, "_resolve_path", lambda: Path("/chrome"))
+        monkeypatch.setattr(resolve_chrome, "_read_version", lambda path: "151.0.1.2")
+        assert resolve_chrome.main(["--freeze-updater"]) == 0
+        assert json.loads(capsys.readouterr().out)["version"] == "151.0.1.2"
+
+
+# ---------------------------------------------------------------------------
+# The flag, and only the flag, changes behaviour.
+# ---------------------------------------------------------------------------
+class TestTheFlagGatesTheFreeze:
+    @pytest.fixture
+    def identity_stub(self, monkeypatch) -> None:
+        monkeypatch.setattr(resolve_chrome, "_resolve_path", lambda: Path("/chrome"))
+        monkeypatch.setattr(resolve_chrome, "_read_version", lambda path: "150.0.0.1")
+
+    def test_without_the_flag_nothing_is_frozen(
+        self, monkeypatch, capsys, identity_stub
+    ):
+        froze: list[bool] = []
+        monkeypatch.setattr(
+            resolve_chrome, "freeze_updater", lambda: froze.append(True) or []
+        )
+        assert resolve_chrome.main([]) == 0
+        assert froze == [], "the default invocation must not touch the machine"
+
+    def test_without_the_flag_stdout_is_byte_identical_to_the_identity_json(
+        self, monkeypatch, capsys, identity_stub
+    ):
+        monkeypatch.setattr(resolve_chrome.platform, "system", lambda: "Darwin")
+        assert resolve_chrome.main([]) == 0
+        printed = capsys.readouterr().out
+        assert (
+            printed
+            == json.dumps(resolve_chrome.resolve_chrome(), indent=2, sort_keys=True)
+            + "\n"
+        )
+
+    def test_with_the_flag_the_freeze_runs(self, monkeypatch, capsys, identity_stub):
+        froze: list[bool] = []
+        monkeypatch.setattr(
+            resolve_chrome, "freeze_updater", lambda: froze.append(True) or []
+        )
+        assert resolve_chrome.main(["--freeze-updater"]) == 0
+        assert froze == [True]
+
+    def test_the_identity_json_on_stdout_is_unchanged_by_the_flag(
+        self, monkeypatch, capsys, identity_stub
+    ):
+        """The freeze narrates to stderr; a consumer parsing stdout sees the same
+        document either way."""
+        monkeypatch.setattr(
+            resolve_chrome, "freeze_updater", lambda: ["froze: something"]
+        )
+        assert resolve_chrome.main(["--freeze-updater"]) == 0
+        captured = capsys.readouterr()
+        assert json.loads(captured.out)["version"] == "150.0.0.1"
+        assert "froze: something" in captured.err
+
+
+class TestTheFreezePrecedesTheReading:
+    def test_the_version_is_read_after_the_freeze_ran(self, monkeypatch, capsys):
+        """The whole point: a version read before the freeze is a version the
+        updater may still move."""
+        order: list[str] = []
+        monkeypatch.setattr(
+            resolve_chrome, "freeze_updater", lambda: order.append("freeze") or []
+        )
+        monkeypatch.setattr(resolve_chrome, "_resolve_path", lambda: Path("/chrome"))
+
+        def read_version(path):
+            order.append("read")
+            return "151.0.0.0"
+
+        monkeypatch.setattr(resolve_chrome, "_read_version", read_version)
+        assert resolve_chrome.main(["--freeze-updater"]) == 0
+        assert order == ["freeze", "read"]
+
+    def test_resolving_the_identity_never_freezes_on_its_own(
+        self, monkeypatch, run_recorder
+    ):
+        """`tests/test_browser_integration.py` imports this module and calls
+        `resolve_chrome()` directly. That call must stay side-effect-free: the
+        freeze belongs to the CLI, so importing the module cannot disable a
+        developer's Chrome updates."""
+        monkeypatch.setattr(resolve_chrome.platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(resolve_chrome, "_resolve_path", lambda: Path("/chrome"))
+        monkeypatch.setattr(resolve_chrome, "_read_version", lambda path: "151.0.0.0")
+        resolve_chrome.resolve_chrome()
+        assert run_recorder.calls == []

--- a/tools/resolve_chrome.py
+++ b/tools/resolve_chrome.py
@@ -18,6 +18,12 @@ ways with no second implementation:
 Candidate lists are deliberately Chrome-Stable-only per OS: a match on Chromium
 or Edge is a *different* identity and must surface as a mismatch, not a pass.
 Stdlib only — no runtime dependency, no browser launch here.
+
+``--freeze-updater`` (F-819) neutralises the OS's background Chrome updater
+*before* the identity is read, so the answer stays true for the rest of the job.
+It is opt-in for a reason: it changes machine state, so only CI asks for it.
+:func:`resolve_chrome` itself stays side-effect-free — importers get the reading
+and nothing else.
 """
 
 from __future__ import annotations
@@ -139,6 +145,154 @@ def resolve_chrome() -> dict[str, str]:
     }
 
 
+# ---------------------------------------------------------------------------
+# F-819 — freeze the updater before reading the identity.
+#
+# A CI job resolves this identity once and then trusts it for the whole run: the
+# JSON artifact records it, and TestChromeIdentity compares it against CDP
+# ``Browser.getVersion`` from a browser launched minutes later. On GitHub's macOS
+# runners Keystone can swap Chrome Stable in between, and the comparison then
+# reports a product mismatch that no product change can prevent — the two
+# readings were of two different binaries.
+#
+# The mechanism per OS is deliberately the *destructive* one, not the polite one:
+#
+# * **macOS** — unload and delete Keystone's launchd jobs, delete both
+#   ``GoogleSoftwareUpdate`` trees, and leave each path as a root-owned mode-000
+#   stub inside a root-owned parent. The documented soft knob
+#   (``defaults write com.google.Keystone.Agent checkInterval 0``) was rejected:
+#   Chrome re-registers Keystone through KeystoneRegistration.framework every
+#   time it launches, and launching Chrome is precisely what this run does next,
+#   so an advisory setting can be undone by the very act it must survive. The
+#   stub is what makes the removal durable — a reinstall has nowhere to land.
+# * **Windows** — stop and disable the two Google Update services, disable the
+#   machine update tasks, and set the enterprise policy that turns update checks
+#   off. Runners are administrators.
+# * **Linux** — nothing. The images carry no background updater; the package is
+#   only upgraded when a job runs apt, and no job here does.
+#
+# Every sub-step is best-effort by construction: exit codes are recorded, never
+# checked, and an unrunnable tool is swallowed. A missing service, task, plist or
+# directory is the normal case on at least one OS, and this must never be the
+# thing that turns a green run red.
+# ---------------------------------------------------------------------------
+_KEYSTONE_USER_PLISTS = (
+    ("Library", "LaunchAgents", "com.google.keystone.agent.plist"),
+    ("Library", "LaunchAgents", "com.google.keystone.xpcservice.plist"),
+)
+_KEYSTONE_SYSTEM_PLISTS = (
+    "/Library/LaunchAgents/com.google.keystone.agent.plist",
+    "/Library/LaunchDaemons/com.google.keystone.daemon.plist",
+    "/Library/LaunchDaemons/com.google.keystone.system.agent.plist",
+)
+_GOOGLE_UPDATE_SERVICES = ("gupdate", "gupdatem")
+_GOOGLE_UPDATE_TASKS = ("GoogleUpdateTaskMachineCore", "GoogleUpdateTaskMachineUA")
+_GOOGLE_UPDATE_POLICY_KEY = r"HKLM\SOFTWARE\Policies\Google\Update"
+
+
+def _macos_freeze_steps() -> list[list[str]]:
+    """Keystone's launchd jobs, its trees, and the stubs that keep them gone."""
+    home = Path.home()
+    steps: list[list[str]] = []
+
+    for relative in _KEYSTONE_USER_PLISTS:
+        plist = str(home.joinpath(*relative))
+        # The user agents live in the calling user's launchd domain: `sudo` here
+        # would target root's domain and unload nothing.
+        steps.append(["launchctl", "unload", "-w", plist])
+        steps.append(["rm", "-f", plist])
+
+    for plist in _KEYSTONE_SYSTEM_PLISTS:
+        steps.append(["sudo", "launchctl", "unload", "-w", plist])
+        steps.append(["sudo", "rm", "-f", plist])
+
+    for root in (
+        str(home / "Library" / "Google" / "GoogleSoftwareUpdate"),
+        "/Library/Google/GoogleSoftwareUpdate",
+    ):
+        steps.append(["sudo", "rm", "-rf", root])
+        steps.append(["sudo", "mkdir", "-p", root])
+        steps.append(["sudo", "chown", "root:wheel", root])
+        steps.append(["sudo", "chmod", "000", root])
+
+    # A root-owned stub inside a user-owned parent is still removable by that
+    # user — unlinking is governed by the parent's write bit. `/Library/Google`
+    # is already root-owned; the one in the home directory is not.
+    home_parent = str(home / "Library" / "Google")
+    steps.append(["sudo", "chown", "root:wheel", home_parent])
+    steps.append(["sudo", "chmod", "555", home_parent])
+    return steps
+
+
+def _windows_freeze_steps() -> list[list[str]]:
+    """Google Update's services, its scheduled tasks, and the policy."""
+    steps: list[list[str]] = []
+    for service in _GOOGLE_UPDATE_SERVICES:
+        # Stop first: disabling a running service leaves it running for this boot.
+        steps.append(["sc.exe", "stop", service])
+        steps.append(["sc.exe", "config", service, "start=", "disabled"])
+    steps.extend(
+        ["schtasks.exe", "/Change", "/TN", task, "/DISABLE"]
+        for task in _GOOGLE_UPDATE_TASKS
+    )
+    # UpdateDefault=0 forbids updates; AutoUpdateCheckPeriodMinutes=0 stops the
+    # checks that would otherwise still run. Google documents both as the policy
+    # pair — neither alone is the off switch.
+    steps.extend(
+        [
+            "reg.exe",
+            "add",
+            _GOOGLE_UPDATE_POLICY_KEY,
+            "/v",
+            value,
+            "/t",
+            "REG_DWORD",
+            "/d",
+            "0",
+            "/f",
+        ]
+        for value in ("UpdateDefault", "AutoUpdateCheckPeriodMinutes")
+    )
+    return steps
+
+
+def _run_freeze_step(command: list[str]) -> str:
+    """Run one freeze step and narrate it. Never raises, never checks the code."""
+    rendered = " ".join(command)
+    try:
+        completed = subprocess.run(  # noqa: S603  PERMANENT(F-819: the argv comes from the fixed per-OS tables above — no shell, no caller input; the OS tools are named rather than absolute because their absence is a legitimate outcome this step tolerates)
+            command,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return f"skipped  {rendered}  :: {type(exc).__name__}: {exc}"
+    detail = (completed.stderr or completed.stdout or "").strip().splitlines()
+    tail = f"  :: {detail[-1].strip()}" if detail else ""
+    return f"rc={completed.returncode}  {rendered}{tail}"
+
+
+def freeze_updater() -> list[str]:
+    """Neutralise this OS's background Chrome updater. Best-effort, idempotent.
+
+    Returns one narration line per step attempted, so the CI log shows what the
+    freeze actually did on this image rather than what it hoped to do.
+    """
+    system = platform.system().lower()
+    if system == "darwin":
+        steps = _macos_freeze_steps()
+    elif system == "windows":
+        steps = _windows_freeze_steps()
+    else:
+        return [
+            f"freeze_updater: {platform.system()} has no background Chrome "
+            f"updater on the runner images — nothing to freeze"
+        ]
+    return [_run_freeze_step(step) for step in steps]
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
         description="Resolve the image-provided Google Chrome Stable identity."
@@ -149,7 +303,20 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help="write the JSON identity to this path (in addition to stdout)",
     )
+    parser.add_argument(
+        "--freeze-updater",
+        action="store_true",
+        help=(
+            "neutralise the OS's background Chrome updater BEFORE reading the "
+            "version, so the resolved identity stays true for the whole job "
+            "(F-819). Changes machine state; intended for CI runners only."
+        ),
+    )
     args = parser.parse_args(argv)
+
+    if args.freeze_updater:
+        for note in freeze_updater():
+            print(f"freeze-updater: {note}", file=sys.stderr)
 
     try:
         identity = resolve_chrome()


### PR DESCRIPTION
## What

CI-side fix for the macOS gate reds arbitrated on PR #64: GitHub's macOS runners let Keystone swap the image's Chrome Stable **mid-run**, so the identity resolved at job start no longer matches the browser launched minutes later. Evidence (PR #64, byte-identical trees, red both runs): `test_autodiscovery_and_cdp_match_image_chrome` — `AssertionError: ('Chrome/151.0.7922.76', '150.0.7871.187')` — CDP saw 151.x where the resolved identity said 150.x. No product change can fix a comparison of two different binaries; the **run environment** must be frozen.

## How

`tools/resolve_chrome.py` (the one home of the expected Chrome identity) gains `--freeze-updater`: before the version is read it neutralizes the OS's background Chrome updater, best-effort and idempotent — every sub-step's exit code is recorded, never checked, so a missing service/dir/task can never turn a green run red.

- **macOS** — unload+delete Keystone's launchd jobs (user agents in the user's domain, system jobs under sudo), delete both `GoogleSoftwareUpdate` trees, and leave each path as a root-owned mode-000 stub inside a root-owned parent. The soft knob (`defaults write … checkInterval 0`) was rejected: Chrome re-registers Keystone via `KeystoneRegistration.framework` on every launch — and launching Chrome is exactly what the job does next. The stub gives a reinstall nowhere to land.
- **Windows** — `sc.exe stop` then `config start= disabled` for `gupdate`/`gupdatem` (stop-first ordering pinned), disable the `GoogleUpdateTaskMachine*` tasks, and set the documented policy pair `UpdateDefault=0` + `AutoUpdateCheckPeriodMinutes=0`.
- **Linux** — explicit narrated no-op (the images ship no background updater).

Off by default (the freeze is one-way; only ephemeral runners should ask for it). Without the flag, behavior is byte-identical; `resolve_chrome()` itself stays side-effect-free for importers. The flag is added to all 5 CI invocations (4 release-gate jobs + canary), and a new workflow pin fails any future job that resolves an identity without freezing first. Canary's honesty prose now says the identity is **frozen at run start** rather than "whichever Stable the image supplied at run time".

## Tests / gates

- `tests/test_resolve_chrome_freeze.py` (25 nodes, all hermetic — fake `subprocess.run`, nothing touches the real machine) + 1 structural pin in `tests/test_release_workflows.py`. 22 pins RED-first against the unmodified module.
- Full hermetic lane: **1444 passed, 1 skipped** (main baseline 1418 + 26 new). ruff format/check clean; budget gate exit 0 (no cap touched).
- Finding: `audit/stage2/finding_F819_ci_image_chrome_updates_mid_run.md`; F-806's Residual now points here for the environment side.

## Residual (stated in the finding)

The pins assert what argv is *issued*, not what it *accomplishes* — the first real evidence is this PR's own macOS integration cell no longer disagreeing with itself. Note the macOS cell may still show the pre-existing F-773 transport exclusion and F-779 teardown noise; those are documented known gaps, not this PR.

Relands nothing and touches no `src/` code. Companion product-side PR: the F-806 re-land (stacked on the 2.0.8 batch).

🤖 Generated with Claude Code (Opus subagent implementation, Fable orchestration)