### PR TITLE
F-806 re-land: masked-UA version skew, with the spawn-path CDP read bounded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,52 @@
 # Changelog
 
+## Unreleased
+
+### Fixed — the masked User-Agent no longer advertises a Chrome version the browser no longer has (F-806)
+
+The stealth mask renders the browser's major version into a `--user-agent=`
+launch flag, and that version was probed once and cached on the executable's
+**path**. Chrome updates in place, so under the long-lived backend the cache
+could not see an upgrade: the mask kept claiming `Chrome/150` while the browser
+it was masking — and the `sec-ch-ua` client hints Chrome generates from its own
+build — said `151`. A User-Agent that contradicts its own client hints is a
+sharper tell than the headless token the mask exists to remove. It turned the
+macOS stealth-gate cell red against byte-identical product code.
+
+Three defenses now.
+
+**The Windows probe reads the binary.** It used to list the version-named
+directories beside `chrome.exe` and take the newest. Chrome's updater lands that
+directory long before it swaps the launcher stub, and the browser keeps running
+the old build until it next restarts — days on a workstation — so during that
+whole window the probe answered with a version Chrome would not run, and the
+first spawn of every fresh backend shipped a skewed UA. It now reads
+`chrome.exe`'s own embedded file-version resource, which is the executable
+answering for itself; the directory scan remains as the fallback for a binary
+whose resource cannot be read, so no machine gets a worse answer than before.
+(Windows still does not shell out: `chrome.exe --version` hands the flag to an
+already-running Chrome instead of printing.)
+
+**The memo expires with the binary.** The version probe is memoized on the
+executable's on-disk identity — `(mtime_ns, size)` — rather than on its path, so
+an in-place upgrade expires it while an unchanged binary is still probed only
+once.
+
+**The launched browser has the last word.** Every spawn reads CDP
+`Browser.getVersion` after launch and writes the *actual* launched version back,
+so a version that changed between probe and launch corrects every later spawn.
+`Browser.getVersion`'s `product` field is not rewritten by `--user-agent=`,
+which is what makes it authoritative — the regression test re-measures that on
+every run rather than assuming it.
+
+That third defense is now **bounded**. This fix shipped in 2.0.3 and was pulled
+back out of it: the post-launch read was the first await of every spawn and had
+no timeout, so against a stale or dead CDP connection a probe that must never
+even *fail* a spawn could hang one indefinitely. It waits 10 seconds — the same
+bound the pre-launch version probe already uses for the same question — then
+cancels the read, logs, and leaves the mask exactly as the pre-launch probe set
+it. A spawn is never delayed by more than that, and never fails because of it.
+
 ## 2.0.6
 
 ### Fixed — a failed spawn tells you the machine is out of process capacity (F-811)

--- a/audit/stage2/finding_F806_masked_ua_advertises_a_version_the_browser_no_longer_has.md
+++ b/audit/stage2/finding_F806_masked_ua_advertises_a_version_the_browser_no_longer_has.md
@@ -1,17 +1,26 @@
 # F-806 — the masked User-Agent keeps advertising a Chrome version the browser no longer has
 
-**Status: FIXED, NOT YET SHIPPED — targeted at 2.0.4.** The fix landed on `main`
-(merge `ca63b77`) and was then reverted back out of the 2.0.3 release, so the
-defect described below is still present in every published version. Reason for
-the revert: the fix adds `reconcile_launched_browser_version` — an **unbounded**
-CDP `Browser.getVersion` — to *every* spawn, first in the post-launch sequence.
-The `integration (Windows/X64)` gate cell failed three times running with three
+**Status: FIXED — RE-LANDED 2026-08-09** on branch
+`fix/f806-reland-ua-version-skew`, with the condition the revert attached to it
+discharged.
+
+The history, because it is the reason this file reads as it does. The fix first
+landed on `main` (merge `ca63b77`) and was reverted back out of the 2.0.3 release
+by `b628b61`. Reason for the revert: the fix adds
+`reconcile_launched_browser_version` — an **unbounded** CDP `Browser.getVersion`
+— to *every* spawn, first in the post-launch sequence. The
+`integration (Windows/X64)` gate cell failed three times running with three
 different spawn-path symptoms (an F-801 cookie race, "Failed to connect to
 browser", then a job-level hang producing no pytest report at all), having
-passed on 2.0.2. That is suspicion, not proof — it was never reproduced off CI —
-but 2.0.3 exists to fix a backend-killing config bug, so the release was reduced
-to the smallest diff that does it. Before this re-lands, bound that CDP call.
-The work itself is preserved on branch `fix/ua-version-skew`.
+passed on 2.0.2. That was suspicion, not proof — it was never reproduced off CI
+— but 2.0.3 existed to fix a backend-killing config bug, so the release was
+reduced to the smallest diff that does it, and the recorded condition was: bound
+that CDP call before re-landing.
+
+**That bound now exists** (see "The CDP read is bounded" below), so the two
+commits preserved on `fix/ua-version-skew` (`39927a0`, `b863878`) are re-landed
+here unchanged in substance, reconciled against 2.0.3→2.0.6 and the Sentry
+batches.
 **Severity: MEDIUM-HIGH (stealth)** — the mask exists to remove one tell and
 this replaces it with a sharper one. A UA reading `Chrome/150` on a browser
 whose own `sec-ch-ua` says `151` is not a version anyone's browser reports; it
@@ -171,7 +180,7 @@ reports the binary rather than the mask, which is what makes it usable as the
 yardstick. The regression test re-measures it on every run rather than citing
 this paragraph (see Tests, node 3).
 
-Wiring: `browser_manager._apply_post_launch_setup` now takes the resolved
+Wiring: `browser_manager._apply_post_launch` now takes the resolved
 `browser_executable` and awaits the reconciliation once per spawn, before the
 extra-headers / window-size / timezone overrides. It is guarded the way
 `window_sizing` guards its measurement — a diagnostic probe must never fail a
@@ -181,9 +190,44 @@ as well as the CDP call: `_executable_identity` swallows only `OSError` and the
 skew warning is unguarded, so a `try` around `tab.send` alone did not deliver
 what the docstring promised.
 
+### The CDP read is bounded
+
+This is the condition the 2.0.3 revert attached to the re-land, and it is the
+one substantive change this re-land makes to the reverted work.
+
+Defence 3 is the **first await of every spawn**, and a guard that catches
+exceptions does nothing about a call that never returns: against a stale or dead
+CDP connection `tab.send` simply hangs, and with it the spawn. "A diagnostic
+probe must never *fail* a spawn" is the weaker half of the promise; it must not
+be able to *wedge* one either.
+
+`server.py`'s `_with_cdp_timeout` is the established wrapper for exactly this,
+and it is **not reachable from here**: convention 1 forbids any module under
+`embedded/` importing `server` (it double-registers the tools under `runpy`).
+So the bound is a local `asyncio.wait_for` inside
+`reconcile_launched_browser_version`, on the module's existing
+`_VERSION_PROBE_TIMEOUT_SECONDS` — **10s**, the same bound the pre-launch
+`subprocess.run([exe, "--version"], timeout=…)` probe already waits for the same
+answer about the same binary. One question gets one number; a second constant
+beside it would be the second way convention 4 calls a defect, and 30s (the
+`_with_cdp_timeout` default) is a long time to hold a spawn for a reading that
+is only ever advisory.
+
+On expiry `wait_for` **cancels** the pending send — it is not left running
+behind the spawn — and the `TimeoutError` lands in the guard that was already
+there, so the outcome is the one every other probe failure already produces: log
+it, return `None`, leave the memo exactly as the pre-launch probe set it. The
+warning names the bound so an operator reading `TimeoutError` knows how long was
+waited. A spawn's worst case therefore grows by at most 10s, and never fails.
+
+Scope is deliberately narrow. The **other** unbounded awaits in
+`_apply_post_launch` are untouched, per the round-2 note below: they are
+pre-existing, they are not what the revert named, and bounding them is a
+separate finding's job. This bounds the call this fix introduced.
+
 ## Tests
 
-**Unit — `tests/test_platform_utils.py`** (44 nodes total in the file), four new
+**Unit — `tests/test_platform_utils.py`** (46 nodes total in the file), five new
 classes, no Chrome:
 
 * `TestWindowsProbeReadsTheBinaryNotItsNeighbours` — the version resource wins
@@ -206,6 +250,18 @@ classes, no Chrome:
   the write-back, the skew warning, the guard that keeps a failed
   `Browser.getVersion` from failing a spawn, and the guard covering a failing
   write-back too.
+* `TestTheReconcileCdpCallIsBounded` — the re-land condition. A `tab.send` that
+  **never answers** must still let the reconciliation return: with the bound
+  patched to 50ms the call returns `None` promptly, the memo still holds the
+  pre-launch probe's answer (nothing was written back from a reading that never
+  arrived), and the pending send is observed **cancelled** rather than left
+  running behind the spawn. The node's own `asyncio.wait_for(…, timeout=5)` is
+  what makes this a terminating RED: against the unbounded code it fails there
+  in 5s instead of wedging the suite the way the reverted code wedged the CI
+  job — verified red before the bound was written. A second node checks the
+  bound is not so tight that a merely slow browser loses its reconciliation (it
+  passes pre-fix too, and says so), and the default is asserted positive and
+  finite so a regression to `None` cannot quietly restore the unbounded await.
 
 **Real Chrome — `tests/test_stealth.py`** (the existing home for UA facts
 measured against a live browser; no parallel file was created), two new nodes:
@@ -253,10 +309,19 @@ things came out of it; three are fixed here.
    cover the write-back, as its docstring already promised.
 
 A fifth observation — `reconcile_launched_browser_version` has no CDP timeout —
-was deliberately **not** fixed here. Its neighbours in `_apply_post_launch_setup`
-are equally unbounded and `_with_cdp_timeout` lives in `server.py`, which
-`embedded/` may not import; a fix belongs in a finding of its own that covers
-all of them.
+was deliberately **not** fixed in round 2. Its neighbours in
+`_apply_post_launch` are equally unbounded and `_with_cdp_timeout` lives in
+`server.py`, which `embedded/` may not import; a fix was left to a finding of
+its own that covers all of them.
+
+**That deferral did not survive contact with CI.** The reds that got this fix
+reverted out of 2.0.3 were all on the spawn path, one of them a job-level hang,
+and this call was the one await whose *position* the fix had changed. Being
+right that the neighbours are equally unbounded was not the same as being right
+to ship a new unbounded await ahead of them. It is bounded as of the re-land —
+see "The CDP read is bounded" above — using a local `asyncio.wait_for` rather
+than the forbidden `server` import. The neighbours remain unbounded and remain a
+separate finding; that part of the round-2 judgement stands.
 
 By the time this round was implemented the workstation's Chrome had finished
 updating (sibling dirs `['151.0.7922.72', …]`, file version `151.0.7922.72`), so
@@ -279,6 +344,15 @@ instance. Every later spawn is corrected by the write-back. Widening the fix to
 cover that instance was judged the wrong trade. The wide window the first round
 left open on Windows — days, one skewed browser per backend — is closed, not
 narrowed.
+
+The bounded CDP read costs a spawn **up to 10s** in the one case where the
+connection is dead but the launch otherwise succeeded, and in that case the
+reconciliation is skipped, so the mask keeps the pre-launch probe's answer and
+the next spawn tries again. That is the price of the bound and it is deliberate:
+the alternative the revert measured is an unbounded hang. The remaining
+unbounded awaits in `_apply_post_launch` (extra headers, window sizing, timezone
+override) are **not** addressed here and are the subject of their own finding —
+this one bounds only the call it introduced.
 
 F-774 (Chrome blanks the *high-entropy* UA client hints whenever a
 `--user-agent` override is active) is unchanged by this work and remains an

--- a/src/stealth_chrome_devtools_mcp/embedded/browser_manager.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/browser_manager.py
@@ -32,6 +32,7 @@ from stealth_chrome_devtools_mcp.embedded.platform_utils import (
     check_browser_executable,
     get_platform_info,
     merge_browser_args,
+    reconcile_launched_browser_version,
 )
 from stealth_chrome_devtools_mcp.embedded.process_cleanup import process_cleanup
 from stealth_chrome_devtools_mcp.embedded.proxy_forwarder import (
@@ -556,9 +557,10 @@ class BrowserManager:
         instance_id: str,
         actual_user_data_dir: str | None,
         uses_custom_data_dir: bool,
+        browser_executable: str,
     ) -> tuple[str | None, window_sizing.WindowSizeMetrics]:
-        """Register the process for cleanup and apply the per-instance CDP
-        overrides (extra headers, window size, timezone).
+        """Register the process, reconcile the masked User-Agent (F-806), then
+        apply the per-instance CDP overrides (headers, window size, timezone).
 
         Returns ``(applied IANA timezone id or None, window-size metrics)``. Runs
         after the browser is orchestrator-owned, so a failure here still routes
@@ -580,6 +582,8 @@ class BrowserManager:
                 "spawn_browser",
                 f"Browser {instance_id} has no process to track",
             )
+
+        await reconcile_launched_browser_version(tab, browser_executable)
 
         if options.extra_headers:
             headers = uc.cdp.network.Headers(options.extra_headers)
@@ -651,6 +655,7 @@ class BrowserManager:
                 instance_id,
                 actual_user_data_dir,
                 uses_custom_data_dir,
+                browser_executable,
             )
 
             await self._setup_dynamic_hooks(tab, instance_id)
@@ -880,14 +885,9 @@ class BrowserManager:
             try:
                 import nodriver.cdp.browser as cdp_browser
 
-                if (
-                    getattr(browser, "connection", None)
-                    and not browser.connection.closed
-                ):
-                    await asyncio.wait_for(
-                        browser.connection.send(cdp_browser.close()),
-                        timeout=2.0,
-                    )
+                conn = getattr(browser, "connection", None)
+                if conn and not conn.closed:
+                    await asyncio.wait_for(conn.send(cdp_browser.close()), timeout=2.0)
             except (TimeoutError, Exception) as cdp_err:
                 debug_logger.log_info(
                     "browser_manager",

--- a/src/stealth_chrome_devtools_mcp/embedded/platform_utils.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/platform_utils.py
@@ -1,5 +1,8 @@
 """Platform-specific utility functions for browser automation."""
 
+from __future__ import annotations
+
+import asyncio
 import ctypes
 import os
 import platform
@@ -7,11 +10,16 @@ import re
 import shutil
 import subprocess
 import sys
-from functools import lru_cache
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+from nodriver import cdp
 
 from stealth_chrome_devtools_mcp.embedded.debug_logger import debug_logger
 from stealth_chrome_devtools_mcp.settings import get_settings
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from nodriver import Tab
 
 
 def is_running_as_root() -> bool:
@@ -210,36 +218,193 @@ _REDUCED_UA_PLATFORM_TOKEN = {
 
 _USER_AGENT_ARG_PREFIX = "--user-agent="
 _BROWSER_VERSION_RE = re.compile(r"(\d+)\.\d+\.\d+\.\d+")
+# How long we will wait to learn a binary's version, over EITHER transport: the
+# pre-launch `<exe> --version` subprocess and the post-launch CDP
+# `Browser.getVersion` ask one question, so they share one number (F-806).
 _VERSION_PROBE_TIMEOUT_SECONDS = 10.0
+_VERSION_MEMO_MAX_ENTRIES = 8
+
+# ── The browser-version memo (F-806) ────────────────────────────────────────
+# The mask above is only coherent while the version it was built from is the
+# version that actually launches. Two things have to hold for that, and F-806
+# was each of them failing in turn:
+#
+#   * the PROBE must read the binary that will run — not something beside it.
+#     See `_windows_file_version`: guessing from the newest version-named
+#     sibling directory answers with a staged update days before the browser
+#     will run it.
+#   * the MEMO must expire when that binary changes. The probe is memoized
+#     because it runs on the spawn path, so it is keyed on the executable's
+#     on-disk IDENTITY, never on its path alone: Chrome auto-updates IN PLACE,
+#     so a path-keyed memo in a long-lived backend keeps advertising the version
+#     the machine had when the process started.
+#
+# Either failure ends the same way: a masked UA claiming Chrome/150 while the
+# browser (and its `sec-ch-ua` client hints) say 151 — a self-contradicting UA,
+# i.e. exactly the WORSE tell this mask exists to avoid.
+#
+# ``None`` is memoized too: an executable whose version cannot be resolved must
+# not re-pay for a failed subprocess on every spawn.
+_ExecutableIdentity = tuple[int, int]
+_BROWSER_VERSION_MEMO: dict[tuple[str, _ExecutableIdentity | None], str | None] = {}
 
 
-@lru_cache(maxsize=8)
-def resolve_browser_major_version(executable: str) -> str | None:
-    """Return the major version of a Chromium-family executable, or ``None``.
+def _executable_identity(executable: str) -> _ExecutableIdentity | None:
+    """The executable's on-disk identity: ``(mtime_ns, size)``.
 
-    Cached per executable path: this runs on the spawn path, so an uncached
-    subprocess per spawn would be a real performance regression.
+    One ``stat`` call, no subprocess — microseconds, so it can run on every spawn
+    where the version probe itself cannot. The executable's own bytes are the
+    WHOLE key because every branch of the probe answers from the executable
+    itself: POSIX runs ``<exe> --version``, Windows reads ``<exe>``'s version
+    resource. An earlier revision also hashed the parent directory's mtime, to
+    chase the Windows sibling-directory scan; that scan is now only the fallback,
+    and even there the directory component bought nothing but re-probes. During a
+    pending update the staged directory is a version the browser will not run
+    until its launcher stub is swapped — and swapping the stub moves this key
+    anyway — so re-probing on the directory could only re-derive the same wrong
+    guess, sooner. Off Windows it was pure cost: ``/usr/bin`` changes mtime on any
+    package install, putting a blocking subprocess back on the spawn path.
+
+    An unstattable executable yields ``None``, which degrades to the old
+    path-only memo rather than failing the spawn.
+    """
+    try:
+        exe_stat = Path(executable).stat()
+    except OSError as error:
+        debug_logger.log_debug("platform_utils", "_executable_identity", str(error))
+        return None
+    return (exe_stat.st_mtime_ns, exe_stat.st_size)
+
+
+def _remember_browser_major_version(
+    key: tuple[str, _ExecutableIdentity | None], major: str | None
+) -> None:
+    """Write *major* into the memo, evicting the oldest entry past the bound."""
+    if (
+        key not in _BROWSER_VERSION_MEMO
+        and len(_BROWSER_VERSION_MEMO) >= _VERSION_MEMO_MAX_ENTRIES
+    ):
+        _BROWSER_VERSION_MEMO.pop(next(iter(_BROWSER_VERSION_MEMO)))
+    _BROWSER_VERSION_MEMO[key] = major
+
+
+def reset_browser_version_memo() -> None:
+    """Forget every memoized browser version.
+
+    THE way to invalidate by hand (tests, and ops after an out-of-band swap).
+    Routine in-place upgrades need no call: the identity key expires itself.
+    """
+    _BROWSER_VERSION_MEMO.clear()
+
+
+class _VsFixedFileInfo(ctypes.Structure):
+    """The fixed (numeric) part of a Win32 ``VS_VERSIONINFO`` resource.
+
+    Only the ``dwFileVersion*`` words are wanted, so nothing here has to touch
+    the string table or its code pages.
+    """
+
+    _fields_ = (
+        ("dwSignature", ctypes.c_uint32),
+        ("dwStrucVersion", ctypes.c_uint32),
+        ("dwFileVersionMS", ctypes.c_uint32),
+        ("dwFileVersionLS", ctypes.c_uint32),
+        ("dwProductVersionMS", ctypes.c_uint32),
+        ("dwProductVersionLS", ctypes.c_uint32),
+        ("dwFileFlagsMask", ctypes.c_uint32),
+        ("dwFileFlags", ctypes.c_uint32),
+        ("dwFileOS", ctypes.c_uint32),
+        ("dwFileType", ctypes.c_uint32),
+        ("dwFileSubtype", ctypes.c_uint32),
+        ("dwFileDateMS", ctypes.c_uint32),
+        ("dwFileDateLS", ctypes.c_uint32),
+    )
+
+
+_VS_FFI_SIGNATURE = 0xFEEF04BD
+
+
+def _windows_file_version(executable: str) -> str | None:
+    """Read ``executable``'s own embedded file-version resource, e.g.
+    ``"150.0.7871.186"`` — or ``None`` if it has none / cannot be read.
+
+    This is the executable answering for ITSELF, which is the whole point: it is
+    the one Windows reading that tracks the binary that will actually run rather
+    than what happens to be lying next to it (F-806). Non-Windows raises
+    ``AttributeError`` on ``ctypes.windll`` and degrades to ``None``.
+    """
+    try:
+        version_dll = ctypes.windll.version
+        size = version_dll.GetFileVersionInfoSizeW(ctypes.c_wchar_p(executable), None)
+        if not size:
+            return None
+        block = ctypes.create_string_buffer(size)
+        loaded = version_dll.GetFileVersionInfoW(
+            ctypes.c_wchar_p(executable), 0, size, block
+        )
+        fixed = ctypes.c_void_p()
+        fixed_size = ctypes.c_uint()
+        if not loaded or not version_dll.VerQueryValueW(
+            block,
+            ctypes.c_wchar_p("\\"),
+            ctypes.byref(fixed),
+            ctypes.byref(fixed_size),
+        ):
+            return None
+        if fixed_size.value < ctypes.sizeof(_VsFixedFileInfo):
+            return None
+        info = ctypes.cast(fixed, ctypes.POINTER(_VsFixedFileInfo)).contents
+        if info.dwSignature != _VS_FFI_SIGNATURE:
+            return None
+        high, low = info.dwFileVersionMS, info.dwFileVersionLS
+    except (AttributeError, OSError, ValueError) as error:
+        debug_logger.log_debug("platform_utils", "_windows_file_version", str(error))
+        return None
+    return f"{high >> 16}.{high & 0xFFFF}.{low >> 16}.{low & 0xFFFF}"
+
+
+def _windows_newest_sibling_version_directory(executable: str) -> str | None:
+    """FALLBACK: the newest version-named directory beside the binary.
+
+    Every Chromium install keeps its build in a version-named directory next to
+    the launcher stub, so this answers when the version resource cannot be read.
+    It is a GUESS, and a knowably wrong one during an update: Chrome's updater
+    lands the new directory days before it swaps the stub, so this reports a
+    version the browser will not run until it next restarts. That is exactly the
+    F-806 skew ``_windows_file_version`` exists to close — but it is kept as the
+    floor so no machine gets a worse answer than it had before.
+    """
+    try:
+        names = [
+            entry.name for entry in Path(executable).parent.iterdir() if entry.is_dir()
+        ]
+    except OSError as error:
+        debug_logger.log_debug(
+            "platform_utils", "_windows_newest_sibling_version_directory", str(error)
+        )
+        return None
+    majors = [m.group(1) for m in map(_BROWSER_VERSION_RE.fullmatch, names) if m]
+    return max(majors, key=int) if majors else None
+
+
+def _probe_browser_major_version(executable: str) -> str | None:
+    """Ask the executable on disk what version it is. Uncached — see the memo.
 
     Windows deliberately does NOT shell out — ``chrome.exe --version`` hands the
     argument to an already-running Chrome ("Opening in existing browser
-    session.") instead of printing anything, so the version is read from the
-    version-named directory every Chromium install keeps beside its binary.
-    Elsewhere ``<exe> --version`` prints e.g. ``Google Chrome 150.0.7871.186``.
+    session.") instead of printing anything — so it reads the binary's embedded
+    version resource, falling back to the sibling-directory scan only when that
+    resource is unreadable. Elsewhere ``<exe> --version`` prints e.g.
+    ``Google Chrome 150.0.7871.186``, which likewise reports the binary that
+    will actually run.
     """
     if platform.system() == "Windows":
-        try:
-            names = [
-                entry.name
-                for entry in Path(executable).parent.iterdir()
-                if entry.is_dir()
-            ]
-        except OSError as error:
-            debug_logger.log_debug(
-                "platform_utils", "resolve_browser_major_version", str(error)
-            )
-            return None
-        majors = [m.group(1) for m in map(_BROWSER_VERSION_RE.fullmatch, names) if m]
-        return max(majors, key=int) if majors else None
+        match = _BROWSER_VERSION_RE.fullmatch(_windows_file_version(executable) or "")
+        # A zeroed resource is a stripped or repacked binary, not a browser
+        # anyone ships — treat it as unreadable rather than mask as Chrome/0.
+        if match and match.group(1) != "0":
+            return match.group(1)
+        return _windows_newest_sibling_version_directory(executable)
 
     try:
         completed = subprocess.run(  # noqa: S603  RELEASE-FIX-D (F-770)
@@ -251,11 +416,109 @@ def resolve_browser_major_version(executable: str) -> str | None:
         )
     except (OSError, subprocess.SubprocessError) as error:
         debug_logger.log_debug(
-            "platform_utils", "resolve_browser_major_version", str(error)
+            "platform_utils", "_probe_browser_major_version", str(error)
         )
         return None
     match = _BROWSER_VERSION_RE.search(completed.stdout or "")
     return match.group(1) if match else None
+
+
+def resolve_browser_major_version(executable: str) -> str | None:
+    """Return the major version of a Chromium-family executable, or ``None``.
+
+    The probe runs on the spawn path, so it is memoized — but on the
+    executable's on-disk identity, so an in-place upgrade expires the memo
+    instead of surviving it (F-806). Cost per spawn is two ``stat`` calls on the
+    hit path and one subprocess only when the binary has actually changed.
+    """
+    key = (executable, _executable_identity(executable))
+    if key in _BROWSER_VERSION_MEMO:
+        return _BROWSER_VERSION_MEMO[key]
+    major = _probe_browser_major_version(executable)
+    _remember_browser_major_version(key, major)
+    return major
+
+
+def record_launched_browser_major_version(
+    executable: str, product: str | None
+) -> str | None:
+    """Reconcile the memo against the browser that ACTUALLY launched (F-806).
+
+    ``Browser.getVersion``'s ``product`` field reports the running binary's own
+    version and is NOT rewritten by ``--user-agent=`` — measured on Chrome 150:
+    launching with ``--user-agent=…Chrome/1.0.0.0…`` still reported
+    ``product: "Chrome/150.0.7871.186"`` while ``userAgent`` carried the
+    override. It is therefore the one authoritative post-launch reading, and the
+    only way to *know* — rather than predict — which browser the mask is
+    describing.
+
+    A disagreement means the pre-launch probe was wrong for this executable: an
+    upgrade that landed between probe and launch, a second install, or a
+    launcher that chose a different binary. Whatever the cause, the launched
+    browser is the truth, so it is written back and every later spawn masks
+    correctly. The disagreement is logged rather than silently repaired: the
+    instance already running kept the flag it launched with, and a UA that
+    contradicts its own ``sec-ch-ua`` is a stealth defect, not a cosmetic one.
+    """
+    match = _BROWSER_VERSION_RE.search(product or "")
+    if not match:
+        return None
+    major = match.group(1)
+    key = (executable, _executable_identity(executable))
+    previous = _BROWSER_VERSION_MEMO.get(key)
+    if previous and previous != major:
+        debug_logger.log_warning(
+            "platform_utils",
+            "record_launched_browser_major_version",
+            f"version skew: the masked User-Agent was built for Chrome/{previous} "
+            f"but {executable!r} launched as {product!r}, so this instance "
+            f"advertises {previous} while running {major} — later spawns will use "
+            f"{major} (F-806)",
+        )
+    _remember_browser_major_version(key, major)
+    return major
+
+
+async def reconcile_launched_browser_version(tab: Tab, executable: str) -> str | None:
+    """Read the launched browser's real version over CDP and reconcile the memo.
+
+    Guarded the way ``window_sizing`` guards its measurement: a spawn must not
+    fail because a diagnostic probe did, so a failure degrades to ``None``
+    (leaving the memo exactly as the pre-launch probe left it) rather than
+    taking the browser down with it. The guard covers the WRITE-BACK as well as
+    the CDP call, because the write-back can raise too — ``_executable_identity``
+    only swallows ``OSError`` and the skew warning is not guarded at all — and a
+    contract that says "never fails a spawn" has to mean the whole reconciliation.
+
+    The CDP read is BOUNDED, which is the condition this fix's re-land carried:
+    it is the first await in ``_apply_post_launch``, on every spawn, and against
+    a stale or dead connection an unguarded ``tab.send`` never returns — so
+    unbounded, a diagnostic probe could wedge the spawn it must not even fail.
+    ``server.py``'s ``_with_cdp_timeout`` is not reachable from here (convention
+    1: no module under ``embedded/`` imports ``server``), so the bound is a local
+    ``asyncio.wait_for`` on ``_VERSION_PROBE_TIMEOUT_SECONDS`` — the same 10s the
+    pre-launch subprocess probe already waits for the same answer. Expiry cancels
+    the pending send and degrades to ``None`` through the guard below, leaving
+    the memo exactly as the pre-launch probe left it.
+
+    The unbounded awaits that FOLLOW this one in ``_apply_post_launch`` are
+    untouched here: they are pre-existing and belong to their own finding.
+    """
+    try:
+        version = await asyncio.wait_for(
+            tab.send(cdp.browser.get_version()), _VERSION_PROBE_TIMEOUT_SECONDS
+        )
+        product = version[1] if version and len(version) > 1 else None
+        return record_launched_browser_major_version(executable, product)
+    except Exception as error:  # noqa: BLE001  PERMANENT(a diagnostic probe must never fail a spawn - F-806)
+        debug_logger.log_warning(
+            "platform_utils",
+            "reconcile_launched_browser_version",
+            f"reconciliation failed ({type(error).__name__}: {error}); the "
+            "masked User-Agent could not be checked against the running browser "
+            f"(the CDP read is bounded at {_VERSION_PROBE_TIMEOUT_SECONDS:.0f}s)",
+        )
+        return None
 
 
 def build_reduced_user_agent(executable: str) -> str | None:

--- a/tests/test_desktop_launch.py
+++ b/tests/test_desktop_launch.py
@@ -722,8 +722,13 @@ async def test_apply_post_launch_tracks_an_attached_browser(monkeypatch):
 
     options = browser_manager.BrowserOptions(headless=False)
     attached = SimpleNamespace(_process=None, _process_pid=1234)
+    # The trailing executable is F-806's version reconciliation. It is left LIVE
+    # here on purpose: this bare tab has no `send`, so the reconcile's guard
+    # swallows the AttributeError and the tracking below still happens — which is
+    # the guard's actual contract ("a diagnostic probe must never fail a spawn")
+    # exercised on the delegated-launch path rather than stubbed away.
     await manager._apply_post_launch(
-        attached, SimpleNamespace(), options, "i-attached", None, False
+        attached, SimpleNamespace(), options, "i-attached", None, False, "chrome.exe"
     )
 
     assert len(tracked) == 1

--- a/tests/test_extra_headers_cdp.py
+++ b/tests/test_extra_headers_cdp.py
@@ -26,7 +26,11 @@ import nodriver as uc
 import pytest
 
 from fakes import FakeTab
-from stealth_chrome_devtools_mcp.embedded import spawn_exhaustion, window_sizing
+from stealth_chrome_devtools_mcp.embedded import (
+    browser_manager,
+    spawn_exhaustion,
+    window_sizing,
+)
 from stealth_chrome_devtools_mcp.embedded.browser_manager import BrowserManager
 from stealth_chrome_devtools_mcp.embedded.models import BrowserOptions
 from stealth_chrome_devtools_mcp.embedded.process_cleanup import process_cleanup
@@ -92,6 +96,18 @@ def post_launch_manager(monkeypatch):
         return None
 
     monkeypatch.setattr(BrowserManager, "_apply_timezone_override", no_timezone)
+
+    # F-806's version reconciliation is a neighbour like the three above: it
+    # sends its own `Browser.getVersion` frame, which `FakeTab` records like any
+    # other, so leaving it live would put a second command in `cdp_frames` and
+    # make "no header command was sent" untestable. Patched on the module,
+    # because that is where `browser_manager` bound the imported name.
+    async def no_reconcile(tab, executable):
+        return None
+
+    monkeypatch.setattr(
+        browser_manager, "reconcile_launched_browser_version", no_reconcile
+    )
     return BrowserManager()
 
 
@@ -108,6 +124,7 @@ async def _run_post_launch(manager, tab, options):
         instance_id="iid-1",
         actual_user_data_dir=None,
         uses_custom_data_dir=False,
+        browser_executable="chrome",
     )
 
 

--- a/tests/test_platform_utils.py
+++ b/tests/test_platform_utils.py
@@ -8,7 +8,11 @@ stealth-blocked. Sandbox detection is monkeypatched so the tests are
 deterministic across CI environments.
 """
 
+import asyncio
+import os
+import platform
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -19,6 +23,9 @@ from stealth_chrome_devtools_mcp.embedded.platform_utils import (
     get_platform_info,
     get_required_sandbox_args,
     merge_browser_args,
+    reconcile_launched_browser_version,
+    record_launched_browser_major_version,
+    reset_browser_version_memo,
     resolve_browser_major_version,
 )
 
@@ -130,12 +137,12 @@ _REDUCED_UA_CELLS = [
 
 
 @pytest.fixture(autouse=True)
-def _clear_version_cache():
-    """``resolve_browser_major_version`` is lru_cached (it runs on the spawn
-    path); clear it around every test so a fake never bleeds between them."""
-    resolve_browser_major_version.cache_clear()
+def _clear_version_memo():
+    """The browser-version probe is memoized (it runs on the spawn path); clear
+    the memo around every test so a fake never bleeds between them."""
+    reset_browser_version_memo()
     yield
-    resolve_browser_major_version.cache_clear()
+    reset_browser_version_memo()
 
 
 class TestReducedUserAgent:
@@ -179,11 +186,12 @@ class TestReducedUserAgent:
 
 
 class TestResolveBrowserMajorVersion:
-    def test_windows_reads_the_version_named_sibling_directory(
+    def test_windows_falls_back_to_the_version_named_sibling_directory(
         self, monkeypatch, tmp_path
     ):
         # Windows must NOT shell out: `chrome.exe --version` hands the flag to a
-        # running Chrome instead of printing anything.
+        # running Chrome instead of printing anything. A stub with no version
+        # resource (as written here) therefore lands on the directory scan.
         monkeypatch.setattr(platform_utils.platform, "system", lambda: "Windows")
 
         def _explode(*_args, **_kwargs):
@@ -246,3 +254,494 @@ class TestDefaultUserAgentInMergeBrowserArgs:
         monkeypatch.setattr(platform_utils, "check_browser_executable", lambda: None)
         combined, _ = merge_browser_args(["--lang=en-US"])
         assert combined == ["--lang=en-US"]
+
+
+# ---------------------------------------------------------------------------
+# F-806 — the masked User-Agent must describe the browser that ACTUALLY runs.
+#
+# The mask is built from a version probe that is memoized because it sits on the
+# spawn path. Memoized on the executable PATH alone, that probe is a snapshot
+# taken once per process: Chrome auto-updates in place, so a long-lived backend
+# kept advertising `Chrome/<old>` while the browser it launched — and the
+# `sec-ch-ua` client hints Chrome derives from its real version — said `<new>`.
+# A UA that contradicts its own client hints is a SHARPER tell than the honest
+# `HeadlessChrome` token the mask exists to remove, so this is a stealth defect,
+# not a cosmetic one. It turned the 2.0.1 macOS gate red (control 151 vs product
+# 150) with byte-identical product code.
+#
+# Three layers are pinned below:
+#   1. the Windows probe reads the BINARY's own version resource, so a staged
+#      update sitting in a sibling directory cannot answer for a browser that
+#      is not running yet;
+#   2. the memo is keyed on the executable's on-disk identity, so an in-place
+#      upgrade expires it (and only a real change costs a fresh subprocess);
+#   3. `Browser.getVersion().product` — measured NOT to be rewritten by
+#      `--user-agent=` — is read back after launch and wins over the probe.
+# ---------------------------------------------------------------------------
+def _install_chrome(root, version: str):
+    """Lay down a Windows-shaped Chrome install: launcher stub + version dir.
+
+    The stub's length tracks the major so an "upgrade" changes the executable's
+    SIZE as well as its mtime — timestamp granularity varies by filesystem, and
+    a freshness test must not depend on it.
+    """
+    exe = root / "chrome.exe"
+    exe.write_bytes(b"x" * (int(version.split(".", maxsplit=1)[0]) * 8))
+    (root / version).mkdir(exist_ok=True)
+    return exe
+
+
+class TestWindowsProbeReadsTheBinaryNotItsNeighbours:
+    """The launched version, not the newest one staged beside it (F-806).
+
+    Chrome's updater lands the new version-named directory long before it swaps
+    the launcher stub, and that window stays open until the browser is next
+    restarted — days on a workstation. A probe that takes ``max()`` over those
+    directories therefore reports a version the browser will not run, and the
+    first spawn of every fresh backend ships a UA whose ``sec-ch-ua`` disagrees
+    with it. Neither the identity re-key nor the post-launch reconciliation can
+    close that: the executable's bytes do not move while the update is pending,
+    and a launch flag is fixed for the life of the process.
+    """
+
+    def test_the_version_resource_wins_over_a_newer_sibling_directory(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(platform_utils.platform, "system", lambda: "Windows")
+        monkeypatch.setattr(
+            platform_utils, "_windows_file_version", lambda _exe: "150.0.7871.186"
+        )
+        exe = tmp_path / "chrome.exe"
+        exe.write_bytes(b"stub")
+        (tmp_path / "150.0.7871.186").mkdir()
+        # Staged by the updater; the stub still runs 150 until Chrome restarts.
+        (tmp_path / "151.0.7922.72").mkdir()
+
+        assert resolve_browser_major_version(str(exe)) == "150", (
+            "the probe followed a staged update instead of the binary that will "
+            "actually launch (F-806)"
+        )
+
+    @pytest.mark.skipif(
+        platform.system() != "Windows",
+        reason="reads a real Win32 file-version resource",
+    )
+    def test_a_real_binarys_version_resource_beats_a_planted_directory(self, tmp_path):
+        # Nothing is patched and no code under test supplies the expectation: a
+        # real PE that really carries a version resource is copied in as
+        # `chrome.exe`, and a version-named directory that disagrees with it is
+        # planted alongside — the shape a staged Chrome update leaves on disk.
+        # `cmd.exe` is the stand-in because it is present on every Windows and
+        # its file-version resource IS the OS build, so `platform.version()`
+        # yields the expected major independently.
+        source = Path(os.environ.get("COMSPEC") or r"C:\Windows\System32\cmd.exe")
+        if not source.is_file():  # pragma: no cover - defensive
+            pytest.skip(f"{source} not present")
+        exe = tmp_path / "chrome.exe"
+        exe.write_bytes(source.read_bytes())
+        (tmp_path / "9999.0.0.0").mkdir()
+
+        expected_major = platform.version().split(".", maxsplit=1)[0]
+        assert resolve_browser_major_version(str(exe)) == expected_major, (
+            "the planted 9999.0.0.0 directory beat the binary's own version "
+            "resource — a staged Chrome update does exactly this, and the "
+            "browser keeps running the old build until it restarts (F-806)"
+        )
+
+    def test_an_unreadable_resource_still_falls_back_to_the_directories(
+        self, monkeypatch, tmp_path
+    ):
+        # The old behaviour is the floor: no machine may get a worse answer than
+        # it had before, so a binary with no readable resource is still probed.
+        monkeypatch.setattr(platform_utils.platform, "system", lambda: "Windows")
+        monkeypatch.setattr(platform_utils, "_windows_file_version", lambda _exe: None)
+        exe = tmp_path / "chrome.exe"
+        exe.write_bytes(b"stub")
+        (tmp_path / "150.0.7871.186").mkdir()
+        assert resolve_browser_major_version(str(exe)) == "150"
+
+    def test_a_zeroed_resource_is_treated_as_unreadable(self, monkeypatch, tmp_path):
+        # A stripped/repacked binary reports 0.0.0.0. Masking as `Chrome/0.0.0.0`
+        # would be a louder tell than not masking at all.
+        monkeypatch.setattr(platform_utils.platform, "system", lambda: "Windows")
+        monkeypatch.setattr(
+            platform_utils, "_windows_file_version", lambda _exe: "0.0.0.0"
+        )
+        exe = tmp_path / "chrome.exe"
+        exe.write_bytes(b"stub")
+        (tmp_path / "150.0.7871.186").mkdir()
+        assert resolve_browser_major_version(str(exe)) == "150"
+
+
+class TestBrowserVersionMemoFreshness:
+    """The memo must expire when the binary on disk changes — and only then."""
+
+    def test_an_in_place_upgrade_expires_the_memo(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(platform_utils.platform, "system", lambda: "Windows")
+        exe = _install_chrome(tmp_path, "150.0.7871.129")
+        assert resolve_browser_major_version(str(exe)) == "150"
+
+        # Chrome's updater lands a new version directory beside the binary and
+        # rewrites the launcher stub — while THIS process stays alive. That is
+        # the whole F-806 mechanism.
+        _install_chrome(tmp_path, "151.0.7900.1")
+
+        assert resolve_browser_major_version(str(exe)) == "151", (
+            "the memoized version survived an in-place upgrade (F-806)"
+        )
+
+    def test_the_masked_user_agent_follows_the_upgrade(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(platform_utils.platform, "system", lambda: "Windows")
+        exe = _install_chrome(tmp_path, "150.0.7871.129")
+        assert build_reduced_user_agent(str(exe)).endswith(
+            "Chrome/150.0.0.0 Safari/537.36"
+        )
+
+        _install_chrome(tmp_path, "151.0.7900.1")
+
+        assert build_reduced_user_agent(str(exe)).endswith(
+            "Chrome/151.0.0.0 Safari/537.36"
+        ), "the mask kept advertising a version the browser no longer has (F-806)"
+
+    def test_a_staged_version_directory_alone_does_not_move_the_answer(
+        self, monkeypatch, tmp_path
+    ):
+        # The updater lands the new directory BEFORE it swaps the launcher stub,
+        # and the browser keeps running the old build until it restarts. So a new
+        # directory on its own must change nothing: the answer is the binary's,
+        # and the binary has not moved. (An earlier revision put the parent
+        # directory's mtime in the memo key precisely to re-probe here — which
+        # only re-derived the staged guess sooner, and cost a subprocess on every
+        # unrelated write to /usr/bin off Windows.)
+        monkeypatch.setattr(platform_utils.platform, "system", lambda: "Windows")
+        exe = tmp_path / "chrome.exe"
+        exe.write_bytes(b"stub")
+        (tmp_path / "150.0.7871.129").mkdir()
+        assert resolve_browser_major_version(str(exe)) == "150"
+
+        (tmp_path / "151.0.7900.1").mkdir()
+        # Bump the directory mtime explicitly: this test is about the KEY, not
+        # about the filesystem's timestamp granularity.
+        bumped = tmp_path.stat().st_mtime_ns + 5_000_000_000
+        os.utime(tmp_path, ns=(bumped, bumped))
+
+        assert resolve_browser_major_version(str(exe)) == "150"
+
+    def test_the_identity_key_is_the_binarys_own_bytes(self, tmp_path):
+        # Stated directly, because it is what makes the line above true: nothing
+        # outside the executable participates in the freshness key.
+        exe = tmp_path / "chrome.exe"
+        exe.write_bytes(b"stub")
+        before = platform_utils._executable_identity(str(exe))
+        assert before == (exe.stat().st_mtime_ns, exe.stat().st_size)
+
+        bumped = tmp_path.stat().st_mtime_ns + 5_000_000_000
+        os.utime(tmp_path, ns=(bumped, bumped))
+        assert platform_utils._executable_identity(str(exe)) == before
+
+    def test_an_unchanged_executable_is_never_reprobed(self, monkeypatch, tmp_path):
+        # The memo exists because the probe runs on the spawn path; deleting it
+        # would trade a stealth defect for a per-spawn subprocess. Pin that the
+        # freshness key did NOT cost us the memo.
+        monkeypatch.setattr(platform_utils.platform, "system", lambda: "Linux")
+        exe = tmp_path / "google-chrome"
+        exe.write_bytes(b"stub")
+        probes = []
+
+        def _run(*_a, **_k):
+            probes.append(1)
+            return subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="Google Chrome 150.0.7871.186\n"
+            )
+
+        monkeypatch.setattr(platform_utils.subprocess, "run", _run)
+        assert [resolve_browser_major_version(str(exe)) for _ in range(5)] == [
+            "150"
+        ] * 5
+        assert len(probes) == 1, f"one subprocess per spawn is the regression: {probes}"
+
+    def test_a_changed_executable_is_reprobed(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(platform_utils.platform, "system", lambda: "Linux")
+        exe = tmp_path / "google-chrome"
+        exe.write_bytes(b"stub")
+        outputs = iter(
+            ["Google Chrome 150.0.7871.186\n", "Google Chrome 151.0.7900.1\n"]
+        )
+
+        monkeypatch.setattr(
+            platform_utils.subprocess,
+            "run",
+            lambda *_a, **_k: subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=next(outputs)
+            ),
+        )
+        assert resolve_browser_major_version(str(exe)) == "150"
+        exe.write_bytes(b"stub-after-the-upgrade")
+        assert resolve_browser_major_version(str(exe)) == "151"
+
+    def test_an_unresolvable_probe_is_memoized_too(self, monkeypatch, tmp_path):
+        # A browser whose version cannot be read must not re-pay for a failed
+        # subprocess on every spawn (masking is already disabled for it).
+        monkeypatch.setattr(platform_utils.platform, "system", lambda: "Linux")
+        exe = tmp_path / "google-chrome"
+        exe.write_bytes(b"stub")
+        probes = []
+
+        def _run(*_a, **_k):
+            probes.append(1)
+            return subprocess.CompletedProcess(args=[], returncode=1, stdout="")
+
+        monkeypatch.setattr(platform_utils.subprocess, "run", _run)
+        assert [resolve_browser_major_version(str(exe)) for _ in range(3)] == [None] * 3
+        assert len(probes) == 1
+
+
+class TestRecordLaunchedBrowserVersion:
+    """``Browser.getVersion().product`` is the post-launch truth, and it wins.
+
+    Measured on Chrome 150.0.7871.186 (Windows, headless): launching with
+    ``--user-agent=...Chrome/1.0.0.0...SKEW-PROBE`` returned
+    ``product: "Chrome/150.0.7871.186"`` with ``userAgent`` carrying the
+    override — so ``product`` is NOT rewritten by the mask and is a usable
+    reading of what is really running.
+    """
+
+    def _armed(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(platform_utils.platform, "system", lambda: "Windows")
+        return _install_chrome(tmp_path, "150.0.7871.129")
+
+    def test_the_launched_browser_corrects_a_wrong_memo(self, monkeypatch, tmp_path):
+        exe = self._armed(monkeypatch, tmp_path)
+        assert resolve_browser_major_version(str(exe)) == "150"
+
+        assert (
+            record_launched_browser_major_version(str(exe), "Chrome/151.0.7900.1")
+            == "151"
+        )
+
+        # The next spawn masks as the browser that actually ran, not as the probe.
+        assert resolve_browser_major_version(str(exe)) == "151"
+        assert build_reduced_user_agent(str(exe)).endswith(
+            "Chrome/151.0.0.0 Safari/537.36"
+        )
+
+    def test_a_headless_product_string_is_parsed(self, monkeypatch, tmp_path):
+        exe = self._armed(monkeypatch, tmp_path)
+        assert (
+            record_launched_browser_major_version(
+                str(exe), "HeadlessChrome/151.0.7900.1"
+            )
+            == "151"
+        )
+
+    def test_skew_is_logged_not_silently_repaired(self, monkeypatch, tmp_path):
+        exe = self._armed(monkeypatch, tmp_path)
+        resolve_browser_major_version(str(exe))
+        warnings = []
+        monkeypatch.setattr(
+            platform_utils.debug_logger,
+            "log_warning",
+            lambda *args: warnings.append(args),
+        )
+
+        record_launched_browser_major_version(str(exe), "Chrome/151.0.7900.1")
+
+        assert len(warnings) == 1, warnings
+        message = warnings[0][2]
+        assert "150" in message and "151" in message and "F-806" in message
+
+    def test_agreement_is_silent(self, monkeypatch, tmp_path):
+        exe = self._armed(monkeypatch, tmp_path)
+        resolve_browser_major_version(str(exe))
+        warnings = []
+        monkeypatch.setattr(
+            platform_utils.debug_logger,
+            "log_warning",
+            lambda *args: warnings.append(args),
+        )
+
+        record_launched_browser_major_version(str(exe), "Chrome/150.0.7871.129")
+
+        assert warnings == []
+
+    def test_an_unprobed_executable_is_seeded_without_warning(
+        self, monkeypatch, tmp_path
+    ):
+        # A caller-supplied user_agent short-circuits the mask, so the version is
+        # never probed pre-launch. Seeding the memo from the launch is a gain,
+        # not a skew — it must not warn.
+        exe = self._armed(monkeypatch, tmp_path)
+        warnings = []
+        monkeypatch.setattr(
+            platform_utils.debug_logger,
+            "log_warning",
+            lambda *args: warnings.append(args),
+        )
+
+        assert (
+            record_launched_browser_major_version(str(exe), "Chrome/151.0.7900.1")
+            == "151"
+        )
+        assert warnings == []
+        assert resolve_browser_major_version(str(exe)) == "151"
+
+    def test_an_unparseable_product_changes_nothing(self, monkeypatch, tmp_path):
+        exe = self._armed(monkeypatch, tmp_path)
+        assert resolve_browser_major_version(str(exe)) == "150"
+        assert record_launched_browser_major_version(str(exe), "Chrome/dev") is None
+        assert record_launched_browser_major_version(str(exe), None) is None
+        assert resolve_browser_major_version(str(exe)) == "150"
+
+
+class _FakeTab:
+    """Minimal ``tab.send`` seam: returns a canned Browser.getVersion tuple.
+
+    ``delay`` is seconds of CDP latency before the answer; ``NEVER`` models the
+    stale-or-dead connection that answers at all. ``cancelled`` records that a
+    pending send was torn down rather than left running behind the caller.
+    """
+
+    NEVER = 3600.0
+
+    def __init__(self, version=None, error=None, delay=0.0):
+        self._version = version
+        self._error = error
+        self._delay = delay
+        self.cancelled = False
+
+    async def send(self, command):
+        command.close()
+        try:
+            if self._delay:
+                await asyncio.sleep(self._delay)
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
+        if self._error is not None:
+            raise self._error
+        return self._version
+
+
+class TestReconcileLaunchedBrowserVersion:
+    async def test_it_reads_product_over_cdp_and_reconciles(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(platform_utils.platform, "system", lambda: "Windows")
+        exe = _install_chrome(tmp_path, "150.0.7871.129")
+        assert resolve_browser_major_version(str(exe)) == "150"
+
+        tab = _FakeTab(
+            version=(
+                "1.3",
+                "HeadlessChrome/151.0.7900.1",
+                "@abcdef",
+                "Mozilla/5.0 ... Chrome/150.0.0.0 Safari/537.36",
+                "15.1",
+            )
+        )
+        assert await reconcile_launched_browser_version(tab, str(exe)) == "151"
+        assert resolve_browser_major_version(str(exe)) == "151"
+
+    async def test_a_cdp_failure_degrades_to_none(self, monkeypatch, tmp_path):
+        # A spawn must not die because a diagnostic probe did.
+        monkeypatch.setattr(platform_utils.platform, "system", lambda: "Windows")
+        exe = _install_chrome(tmp_path, "150.0.7871.129")
+        assert resolve_browser_major_version(str(exe)) == "150"
+
+        tab = _FakeTab(error=ConnectionError("target closed"))
+        assert await reconcile_launched_browser_version(tab, str(exe)) is None
+        assert resolve_browser_major_version(str(exe)) == "150"
+
+    async def test_a_short_version_tuple_is_tolerated(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(platform_utils.platform, "system", lambda: "Windows")
+        exe = _install_chrome(tmp_path, "150.0.7871.129")
+        assert (
+            await reconcile_launched_browser_version(_FakeTab(version=()), str(exe))
+            is None
+        )
+
+    async def test_a_failing_write_back_does_not_escape_the_guard(
+        self, monkeypatch, tmp_path
+    ):
+        # "A spawn must not fail because a diagnostic probe did" has to cover the
+        # WHOLE reconciliation, not just the CDP call: the write-back stats the
+        # executable (swallowing only OSError) and logs the skew warning
+        # unguarded, and it runs inside `_apply_post_launch`, so anything
+        # escaping here takes the spawn down with it.
+        monkeypatch.setattr(platform_utils.platform, "system", lambda: "Windows")
+        exe = _install_chrome(tmp_path, "150.0.7871.129")
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("the debug logger fell over")
+
+        monkeypatch.setattr(
+            platform_utils, "record_launched_browser_major_version", _boom
+        )
+        tab = _FakeTab(version=("1.3", "Chrome/151.0.7900.1", "@abc", "UA", "15.1"))
+        assert await reconcile_launched_browser_version(tab, str(exe)) is None
+
+
+class TestTheReconcileCdpCallIsBounded:
+    """The condition the revert attached to this fix's re-land.
+
+    F-806 was reverted out of 2.0.3 (b628b61) because it put an UNBOUNDED
+    ``Browser.getVersion`` first in the post-launch sequence of every spawn, and
+    the Windows integration cell then went red three times running on three
+    different spawn-path symptoms — one of them a job-level hang that produced
+    no pytest report at all. The recorded condition was to re-land "only after
+    bounding its unbounded CDP ``Browser.getVersion`` on the spawn path".
+
+    ``server.py``'s ``_with_cdp_timeout`` cannot be the bound here: convention 1
+    forbids any module under ``embedded/`` importing ``server``. So the bound is
+    a local ``asyncio.wait_for`` on the module's own
+    ``_VERSION_PROBE_TIMEOUT_SECONDS`` — the SAME 10s the pre-launch
+    ``subprocess`` probe already waits to learn this binary's version. One
+    question, one number; a second constant beside it would be the second way
+    convention 4 calls a defect.
+    """
+
+    async def test_a_cdp_call_that_never_answers_cannot_hang_the_spawn(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(platform_utils.platform, "system", lambda: "Windows")
+        exe = _install_chrome(tmp_path, "150.0.7871.129")
+        assert resolve_browser_major_version(str(exe)) == "150"
+
+        # A finite, positive default is the whole point: None or 0 would hand
+        # `asyncio.wait_for` back the unbounded (or instantly-expired) behaviour.
+        assert 0 < platform_utils._VERSION_PROBE_TIMEOUT_SECONDS <= 30
+
+        monkeypatch.setattr(platform_utils, "_VERSION_PROBE_TIMEOUT_SECONDS", 0.05)
+        tab = _FakeTab(version=("1.3", "Chrome/151.0.7900.1"), delay=_FakeTab.NEVER)
+
+        # The outer bound belongs to the TEST, not the product: against an
+        # unbounded reconcile this node fails right here instead of wedging the
+        # suite the way the reverted code wedged the CI job.
+        result = await asyncio.wait_for(
+            reconcile_launched_browser_version(tab, str(exe)), timeout=5
+        )
+
+        # Degrades exactly like any other probe failure: no exception reaches
+        # `_apply_post_launch`, and the memo keeps what the pre-launch probe put
+        # there rather than being cleared by a reading that never arrived.
+        assert result is None
+        assert resolve_browser_major_version(str(exe)) == "150"
+        assert tab.cancelled
+
+    async def test_an_answer_inside_the_bound_still_reconciles(
+        self, monkeypatch, tmp_path
+    ):
+        # The bound must not be so tight that a merely slow browser loses its
+        # reconciliation; this one passes before the bound exists too, and is
+        # here to keep the timeout honest rather than to prove it landed.
+        monkeypatch.setattr(platform_utils.platform, "system", lambda: "Windows")
+        exe = _install_chrome(tmp_path, "150.0.7871.129")
+        assert resolve_browser_major_version(str(exe)) == "150"
+
+        monkeypatch.setattr(platform_utils, "_VERSION_PROBE_TIMEOUT_SECONDS", 5.0)
+        tab = _FakeTab(
+            version=("1.3", "Chrome/151.0.7900.1", "@abc", "UA", "15.1"), delay=0.05
+        )
+        assert await reconcile_launched_browser_version(tab, str(exe)) == "151"
+        assert resolve_browser_major_version(str(exe)) == "151"
+        assert not tab.cancelled

--- a/tests/test_stealth.py
+++ b/tests/test_stealth.py
@@ -64,6 +64,9 @@ from e2e_helpers import (
     server_mod,
     warmup_once,
 )
+from stealth_chrome_devtools_mcp.embedded.platform_utils import (
+    reset_browser_version_memo as _reset_browser_version_memo,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -669,10 +672,31 @@ async def _read_tab_http_ua(tab, base_url: str) -> str:
     return raw[0].value if (raw and raw[0]) else ""
 
 
+async def _read_browser_product(tab) -> str:
+    """The running browser's own version string (``Browser.getVersion``'s
+    ``product``) — NOT the User-Agent, and not rewritten by ``--user-agent=``.
+
+    That last property is what makes it the authoritative reading of which
+    browser actually launched, and therefore the yardstick F-806 is measured
+    against. It is measured, not assumed: see
+    :func:`test_f806_a_stale_version_memo_is_repaired_by_the_launched_browser`,
+    which reads it out of a browser launched with a deliberately wrong
+    ``--user-agent=`` and requires it to still report the real version.
+    """
+    version = await tab.send(uc.cdp.browser.get_version())
+    return version[1] if (version and len(version) > 1) else ""
+
+
 async def _collect_ua_facts(base_url: str, *, user_agent: str | None) -> dict:
     """Spawn once, then read the User-Agent from the spawn tab AND from a tab
     created afterwards through the product's own ``new_tab`` tool."""
     await warmup_once()
+    # F-806: the warmup performs a real spawn, and that spawn RECONCILES the
+    # version memo against the browser it launched. Reading the UA after it would
+    # measure the repaired value and never the pre-launch probe's — i.e. the one
+    # thing the first spawn of a fresh backend actually ships. Clearing the memo
+    # puts the spawn below back in the cold-first-spawn state the warmup absorbs.
+    _reset_browser_version_memo()
     spawn = get_fn("spawn_browser")
     close = get_fn("close_instance")
     open_tab = get_fn("new_tab")
@@ -700,6 +724,8 @@ async def _collect_ua_facts(base_url: str, *, user_agent: str | None) -> dict:
             "spawn_tab_ua": await _read_tab_ua(spawn_tab),
             "new_tab_ua": await _read_tab_ua(later_tab),
             "new_tab_http_ua": await _read_tab_http_ua(later_tab, base_url),
+            # F-806: what the browser this UA is supposed to describe really is.
+            "browser_product": await _read_browser_product(spawn_tab),
         }
     finally:
         if iid is not None:
@@ -1187,6 +1213,125 @@ def test_f770_product_masks_ua_while_control_still_leaks(product_probe, control_
         )
         == product_probe["observations"]["http_user_agent"]
     )
+
+
+# ===========================================================================
+# F-806 — the masked User-Agent must describe the browser that ACTUALLY launched.
+#
+# The mask is built from a version probed BEFORE launch. Chrome auto-updates in
+# place, so under a long-lived backend the version the mask was built from and
+# the version that launches can differ — and then the UA claims Chrome/150 while
+# the browser's own ``sec-ch-ua`` says 151. That is a self-contradicting UA:
+# strictly a WORSE tell than the headless token the mask exists to remove. It
+# turned the 2.0.1 macOS gate red (CI run 30607810053).
+#
+# The invariant below is what the skew broke, and it is pinned against a real
+# browser because both halves of it are real-browser facts: the flag Chrome
+# actually launched with, and the version Chrome actually is.
+# ===========================================================================
+def test_f806_masked_ua_major_is_the_launched_browsers_major(ua_default_facts):
+    """F-806: the masked UA's Chrome major == the running browser's own major.
+
+    ``Browser.getVersion().product`` is the browser reporting itself, so this is
+    an equality between the mask and its subject — not between two readings of
+    the same string.
+
+    The fixture clears the version memo before its spawn, so what is measured
+    here is the PRE-LAUNCH PROBE's answer — the first spawn of a fresh backend —
+    and not a value the warmup spawn already reconciled. That is the spawn the
+    Windows directory-scan probe used to get wrong. It still cannot fail on a
+    machine whose Chrome is not mid-update; the teeth are in the node below and
+    in ``TestWindowsProbeReadsTheBinaryNotItsNeighbours``.
+    """
+    facts = ua_default_facts
+    ua_major = _ua_major(facts["spawn_tab_ua"])
+    product_major = _ua_major(facts["browser_product"])
+    print(
+        f"[F-806] {_os_family()}/{_platform.machine()} "
+        f"masked UA major={ua_major} product={facts['browser_product']!r}"
+    )
+    assert ua_major, f"no Chrome major in the masked User-Agent: {facts!r}"
+    assert product_major, f"Browser.getVersion reported no version: {facts!r}"
+    assert ua_major == product_major, (
+        "the masked User-Agent describes a different browser than the one "
+        "running it (F-806) — a UA that contradicts its own sec-ch-ua is a "
+        f"sharper tell than the headless token the mask removes\n"
+        f"  masked UA: {facts['spawn_tab_ua']!r} (major {ua_major})\n"
+        f"  launched : {facts['browser_product']!r} (major {product_major})"
+    )
+
+
+async def test_f806_a_stale_version_memo_is_repaired_by_the_launched_browser(
+    monkeypatch, ua_default_facts
+):
+    """F-806: reproduce the skew against a live browser, then pin the repair.
+
+    The test above cannot fail on a machine whose Chrome did not update mid-run,
+    so on its own it would have no teeth against either defense being deleted.
+    This one supplies them by forcing the state an in-place upgrade produces —
+    a pre-launch probe answering with a major the browser no longer has — and
+    then requiring three things of a real spawn:
+
+    1. the skew is genuinely reachable: a stale probe really does put a wrong
+       major on the wire, so the invariant above is guarding something;
+    2. ``Browser.getVersion().product`` still reports the REAL version even
+       though this browser launched under a wrong ``--user-agent=``. The whole
+       reconciliation rests on that, and here it is measured rather than cited;
+    3. the post-launch reconciliation wrote the truth back, so the NEXT spawn
+       masks correctly — the memo now answers with the launched major even
+       though the (still-patched) probe would answer stale.
+    """
+    from stealth_chrome_devtools_mcp.embedded import platform_utils as _pu
+
+    real_major = _ua_major(ua_default_facts["browser_product"])
+    assert real_major, ua_default_facts
+    # A stale major is one the machine has genuinely left behind — the shape an
+    # in-place upgrade leaves in a path-keyed memo.
+    stale_major = str(int(real_major) - 1)
+
+    spawn = get_fn("spawn_browser")
+    close = get_fn("close_instance")
+    bm = server_mod.browser_manager
+
+    _pu.reset_browser_version_memo()
+    monkeypatch.setattr(_pu, "_probe_browser_major_version", lambda _exe: stale_major)
+    iid = None
+    try:
+        spawned = await spawn(headless=True, **sandbox_kwargs())
+        iid = spawned["instance_id"]
+        tab = await bm.get_tab(iid)
+        skewed_ua = await _read_tab_ua(tab)
+        launched_product = await _read_browser_product(tab)
+        print(
+            f"[F-806:forced-stale] masked UA major={_ua_major(skewed_ua)} "
+            f"(forced {stale_major}) product={launched_product!r}"
+        )
+
+        assert _ua_major(skewed_ua) == stale_major, (
+            "a stale version could not be forced onto the wire, so this test is "
+            f"not exercising the F-806 mechanism: {skewed_ua!r}"
+        )
+        assert _ua_major(launched_product) == real_major, (
+            "Browser.getVersion().product followed the --user-agent= override, "
+            "which would make it useless as the reconciliation's yardstick "
+            f"(F-806): {launched_product!r}"
+        )
+        assert _pu.resolve_browser_major_version(_pu.check_browser_executable()) == (
+            real_major
+        ), (
+            "the post-launch reconciliation did not write the launched browser's "
+            "version back, so every later spawn would keep masking as "
+            f"{stale_major} while running {real_major} (F-806)"
+        )
+    finally:
+        if iid is not None:
+            try:
+                await close(instance_id=iid)
+            except Exception:  # teardown best-effort
+                pass
+        # The memo is process-global: leaving a forced value in it would leak
+        # into any later test that builds a User-Agent.
+        _pu.reset_browser_version_memo()
 
 
 # ===========================================================================


### PR DESCRIPTION
## What

Re-lands the F-806 fix that was merged as `ca63b77` and then reverted out of the 2.0.3 release by `b628b61` ("defer to 2.0.4") — it never returned, and main still runs the pre-fix `lru_cache` version probe. The revert recorded one condition for re-landing: **"only after bounding its unbounded CDP `Browser.getVersion` on the spawn path."** This PR is the re-land plus that condition, in one commit (`b17e6dc`).

**Stacked on `fix/sentry-2.0.8-batch` (PR #64)** — merge order #63 → #64 → this; retarget to main as parents merge.

## The re-landed fix (commits `39927a0` + `b863878`, applied as their net diff)

- Browser-version memo re-keyed on the executable's on-disk identity `(mtime_ns, size)` — an in-place Chrome upgrade expires the stale entry instead of masking a UA that contradicts the browser's own `sec-ch-ua`.
- Windows probes the binary's own Win32 file-version resource (via ctypes) instead of scanning version-named sibling directories — the directories are staged by the updater long before the launcher stub swaps, and were the days-wide skew window.
- Post-launch `reconcile_launched_browser_version` reads CDP `Browser.getVersion` and writes the real version back, guarded so a diagnostic probe can never fail a spawn.

All four code/test files applied clean over ~5 releases of drift; real drift found and fixed: `_apply_post_launch_setup` → `_apply_post_launch` rename, and 3 post-revert call sites (F-810's `test_desktop_launch.py`, 2.0.7's `test_extra_headers_cdp.py`) that the full lane caught.

## The re-land condition (new in this PR)

`reconcile_launched_browser_version` wraps its send in a local `asyncio.wait_for` reusing the module's existing `_VERSION_PROBE_TIMEOUT_SECONDS` (10s) — the same bound the pre-launch probe already waits for the same answer about the same binary; a second constant would be the "second way" defect. (`server.py`'s `_with_cdp_timeout` is unreachable from `embedded/` by convention 1.) On expiry: pending send cancelled, logged, no memo write, spawn unaffected. RED-proven: before the bound, a never-answering CDP send wedged the reconcile (test's own 5s watchdog fired); after, 46/46 in 0.52s. The other unbounded awaits in `_apply_post_launch` stay untouched per the finding's own round-2 note (separate future finding).

## Gates

- Full hermetic lane: **1659 passed, 1 skipped, 144 deselected** — exactly +23 over the base's 1636, matching the 23 nodes this branch adds (21 re-landed pins + 2 bound pins; the 2 live `test_stealth.py` nodes are integration-gated and prove out in CI).
- ruff format/check clean; budget gate exit 0 with `browser_manager.py` at exactly **1532/1532** (additions paid by hoisting a thrice-repeated `getattr` in `close_instance`).
- Finding doc updated: FIXED / RE-LANDED 2026-08-09, the "fifth observation deliberately not fixed" deferral discharged, Residual carries the bound's cost. CHANGELOG entry restored under Unreleased.

## Relationship to PR #66

#66 (F-819) freezes the CI image's Chrome updater — the environment side. This PR fixes the product side. Both are needed: the re-land closes the stealth-gate UA-coherence reds; the freeze closes the image-identity comparison red (mid-run binary swap is outside any product code's reach). The accepted one-instance probe-to-launch residual from the finding is unchanged.

🤖 Generated with Claude Code (Opus subagent implementation, Fable orchestration)