### PR TITLE
F-820 — confirm before condemning: a busy backend is not a dead one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+### Fixed — the watchdog no longer disconnects every session when the shared backend is briefly slow (F-820)
+
+This is the user-reported "stealth randomly disconnects", and it was neither
+random nor per-session. The stdio proxy's liveness watchdog tore itself down
+after three consecutive misses of its 2s `initialize` probe — about six
+seconds of slowness. Under a multi-session fleet the one shared backend
+answers that probe in more than 2s for stretches of 20–40s while serving
+everyone perfectly well, and because every proxy probes the *same* backend
+they all reached the same wrong verdict in the same second: production logs
+for 2026-08-30 show four waves (7, 30, 3 and 10 proxies) torn down while
+backend pid 52396 went on serving `navigate` and `screenshot` throughout, with
+the strike counters visibly resetting in between — the signature of slow, not
+gone.
+
+Three strikes now open a **confirmation phase** instead of passing sentence,
+and the verdict comes from the gate the cold-start lock already trusts
+(`_same_identity_backend_ready`, F-807) rather than a second busy-vs-dead
+policy: **busy** answers inside the existing 60s patience window and the proxy
+stays up; **dead** fails on the first refused connection and buys none of it,
+so hard-down detection keeps its ~12s window; **wedged** (socket open, nothing
+answering) is still condemned, only now confirmed first — which costs it up to
+60s more. The fast loop, its interval, its timeout and its strike counter are
+unchanged. Details and residuals in
+`audit/stage2/finding_F820_watchdog_condemns_busy_backend.md`.
+
 ### Fixed — the masked User-Agent no longer advertises a Chrome version the browser no longer has (F-806)
 
 The stealth mask renders the browser's major version into a `--user-agent=`

--- a/audit/stage2/finding_F820_watchdog_condemns_busy_backend.md
+++ b/audit/stage2/finding_F820_watchdog_condemns_busy_backend.md
@@ -1,0 +1,164 @@
+# F-820 — the liveness watchdog condemned a BUSY backend, disconnecting every session at once
+
+**Status: RESOLVED** on `fix/f820-watchdog-busy-vs-dead`.
+**Severity: HIGH (observed in production)** — this is the user-reported
+"stealth randomly disconnects". Not random, and not one session: under fleet
+load *every* Claude Code session lost the MCP server inside the same second,
+repeatedly, while the backend they all share was healthy the entire time.
+
+---
+
+## Symptom
+
+A stdio proxy tears itself down; Claude Code reports the `stealth-chrome-devtools-mcp`
+server as disconnected and its 94 tools vanish mid-task. It recurs in waves,
+minutes apart, and hits every concurrent session simultaneously — which is the
+tell that it is not per-session flakiness but a shared cause read the same
+wrong way by every proxy at once.
+
+## Production evidence (2026-08-30)
+
+Four waves, from the proxy logs, against **one** backend (pid 52396):
+
+| Time  | Proxies torn down |
+|-------|-------------------|
+| 05:12 | 7                 |
+| 05:19 | 30                |
+| 05:28 | 3                 |
+| 05:34 | 10                |
+
+Two facts make the verdict wrong rather than merely unlucky:
+
+1. **The backend kept serving.** Backend pid 52396 answered `navigate` and
+   `screenshot` calls before, during, and after each wave, and outlived all
+   four. Nothing died; nothing was restarted; the socket never closed.
+2. **The probe counters reset.** Within the run-up to a wave the strike counter
+   climbs and then goes back to `1/3` — i.e. probes *were* intermittently
+   succeeding. That is the signature of a backend that is slow, not one that is
+   gone. A dead backend never resets anything.
+
+The slow spans lasted roughly 20–40 seconds — long enough to lose three
+consecutive 2s probes, far short of "dead".
+
+## Mechanism
+
+`singleton._watch_backend_liveness` is armed once the backend answers a real
+`initialize`. It then probed every `interval` (2.0s) with
+`_backend_http_ready(port)` at `LIVENESS_PROBE_TIMEOUT` (2.0s), and returned —
+which the caller (`_proxy_streams.monitor_backend`) treats as "backend gone,
+tear the proxy down" — after `failures_before_teardown` (3) consecutive
+failures. One success reset the run.
+
+The probe is an app-level `initialize` round trip against the shared backend.
+Under a multi-session fleet, that backend is one process serving every
+session's tool calls, and a burst of real work makes it answer `initialize` in
+more than 2s for a stretch. Three such ticks is ~6s of slowness. So the whole
+watchdog reduced to: *6 seconds of slow = dead*.
+
+Worse, it is correlated by construction. Every proxy probes the same backend,
+so when it is busy they all miss together and all condemn it together — hence
+7, 30, 3, 10 teardowns inside one second rather than a trickle.
+
+The discrimination this needed already existed. **F-807** hit the identical
+"busy is not dead" confusion on the cold-start path and resolved it: a
+same-identity backend gets `REUSE_PATIENCE_SECONDS` (60s) of
+`REUSE_PROBE_TIMEOUT` (10s) probes before a lock-holder may evict it, while a
+socket-dead one fails on the first refused connection and buys no window at
+all (`_same_identity_backend_ready`). The watchdog was simply never brought
+onto that policy — it stayed on the pre-F-807 "one short probe verdict is
+final" reading that F-807 removed everywhere else.
+
+## Fix
+
+The three strikes no longer condemn. They now open a **confirmation phase**,
+and the verdict comes from the gate the cold-start lock already trusts:
+
+```python
+confirm = confirm_probe or (lambda: run(_same_identity_backend_ready, port))
+...
+if consecutive < failures_before_teardown:
+    continue
+if not await _ask(confirm):
+    _logger.warning("backend on port %d confirmed unusable", port)
+    return
+_logger.info("backend on port %d was busy, not dead", port)
+consecutive = 0
+```
+
+Deliberately **not** a second policy (CLAUDE.md convention 4: a second way to
+do something already done is a defect). Reusing `_same_identity_backend_ready`
+means F-820 introduces no new constant, no new tunable, and no second
+definition of "dead" — and it inherits, already pinned by
+`tests/test_singleton_cold_start_patience.py`:
+
+* **busy** → answers inside the 60s window → the strike run resets and the
+  proxy stays up. This is the whole fix.
+* **dead** → no socket and no process of ours → fails on the *first* probe,
+  buying none of the window. This is what preserves the human-pinned ~12s
+  hard-down detection (plan_M1 appendix): 3 × 2s of strikes plus a
+  connection-refused that resolves in milliseconds.
+* **wedged** (F-501: dispatch loop dead, socket held open) → answers nothing
+  for the whole window → still condemned, just confirmed first.
+
+The gate is blocking, so it runs via `anyio.to_thread.run_sync` like the fast
+probe — the stdio pump is never frozen.
+
+The fast loop is untouched: same 2s interval, same 2s per-probe timeout, same
+strike counter, same reset-on-success. Only the meaning of "three strikes"
+changed, from *verdict* to *question*.
+
+## Cost
+
+Wedged detection now takes ~12s plus up to 60s of confirmation, instead of
+~12s. That is the deliberate trade: the wedged case is rare and already has a
+manual escape hatch (`stealth-chrome-devtools restart`), while the busy case
+was firing in waves against a healthy backend several times an hour. Hard-down
+detection is unchanged. A slow-but-healthy backend now costs two log lines
+(`probe failed n/3`, then `was busy, not dead`) and nothing else.
+
+## Residuals — NOT fixed here
+
+1. **Why the backend has multi-second event-loop stalls under fleet load.**
+   This finding makes the watchdog stop *misreading* those spans; it does not
+   remove them. A shared backend that cannot answer `initialize` for 20–40s
+   while serving is worth its own investigation (candidates: a blocking call
+   on the event loop inside a tool body, CDP work not offloaded, GIL pressure
+   from many concurrent sessions). Own finding.
+2. **`backend-boot.log` is unrotated** — observed at **733 MB** on the
+   reporting machine. `_start_server_process` appends every backend's raw
+   stdout/stderr to one file forever (F-303/F-503 added the redirect precisely
+   so crashes are not silent, and that part is working). Needs rotation or a
+   size cap. Separate follow-up; deliberately untouched here.
+3. **Wedged-verdict latency** is now ~72s worst case. If that proves too slow
+   in practice the lever is `REUSE_PATIENCE_SECONDS`, which is shared with the
+   cold-start gate — changing it is a policy decision for both consumers, not
+   a watchdog-local tweak.
+
+## Pins
+
+`tests/test_watchdog_busy_vs_dead.py`:
+
+* `test_a_passing_confirmation_resets_the_strike_run` — THE pin. Fast probe
+  never answers, gate says alive: the watchdog must not return, and the strike
+  run restarts (`[1, 2, 3, 1, 2, 3]`). RED before the fix with "DID NOT RAISE"
+  — i.e. it tore down.
+* `test_confirmation_is_not_consulted_before_the_strike_limit` — the patient
+  gate is not paid for on every tick.
+* `test_failed_confirmation_returns_on_the_third_strike` — teardown still
+  lands on strike 3 with no extra tick, and logs a verdict distinguishable
+  from the strikes. Guards the ~12s hard-down window.
+* `test_default_seam_drives_same_identity_backend_ready_off_thread` — the
+  one-policy pin: the default confirmation IS the cold-start gate, run
+  off-thread.
+
+The busy/dead/wedged behaviour *inside* the gate stays pinned where it already
+was, in `tests/test_singleton_cold_start_patience.py` (untouched).
+
+## Note on the LOC budget
+
+`embedded/singleton.py` sat at exactly 1000/1000 (`tools/check_file_budgets.py`,
+not grandfathered). The fix was written to its minimum honest size and the
+remaining lines were paid for by densifying prose in the same
+liveness/lifecycle region — the file lands back at **exactly 1000**. No cap was
+raised or padded, and no rationale was dropped: every claim in the rewritten
+comments survives, more tightly worded. Net `93 insertions / 93 deletions`.

--- a/src/stealth_chrome_devtools_mcp/embedded/singleton.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/singleton.py
@@ -126,10 +126,9 @@ def _server_is_healthy(port: int) -> bool:
 # patch surface the rest of the tree (cli.py, the tests) already targets.
 def _read_server_state() -> dict | None:
     """The RAW record — v1 flat or v2 per-context (F-808) — not a backend.
-
-    Kept raw because it is a patch surface: test_cli / test_cli_status_wedged
-    stub it with v1-flat dicts. Every consumer therefore reads backends out of
-    it through backend_registry's normalizers (`first_backend` /
+    Kept raw because it is a patch surface (test_cli / test_cli_status_wedged
+    stub it with v1-flat dicts), so every consumer reads backends out of it
+    through backend_registry's normalizers (`first_backend` /
     `backend_on_port`), which accept both shapes, rather than indexing it.
     """
     return backend_registry.read_record(SERVER_STATE_FILE)
@@ -159,11 +158,9 @@ def _probe_backend_status() -> tuple[str, int | None]:
     socket check cannot see). Read-only: never evicts, never spawns. Doctor
     runs this same ladder per-entry in `cli._probe_recorded_backend`.
 
-    Returns one of:
-        ("none", None)        - no recorded backend
-        ("down", port)         - recorded but the socket itself is closed
-        ("wedged", port)       - socket open, but no real MCP initialize answer
-        ("responsive", port)  - socket open AND initialize answers 200
+    Returns ("none", None) no recorded backend | ("down", port) socket closed |
+    ("wedged", port) socket open, no real MCP initialize answer |
+    ("responsive", port) socket open AND initialize answers 200.
     """
     entry = backend_registry.first_backend(_read_server_state())
     if entry is None:
@@ -190,10 +187,11 @@ def _same_identity_backend_ready(port: int, patience: float | None = None) -> bo
     path: a backend absorbing a many-session startup herd can miss a single 2s
     probe while perfectly healthy — and a lock-holder that trusts that one miss
     "evicts" (kills) the backend everyone else is using, then double-spawns.
-    Identity-gated on purpose: a version- or source-stale record gets NO
-    patience and is evicted immediately. ``patience=0.0`` (discovery's
-    single-shot probe) probes exactly once and never sleeps. ``None`` means
-    ``REUSE_PATIENCE_SECONDS`` (read at call time, so tests can shrink it).
+    ``_watch_backend_liveness`` applies the same discrimination mid-session
+    (F-820). Identity-gated on purpose: a version- or source-stale record gets
+    NO patience and is evicted immediately. ``patience=0.0`` (discovery's
+    single-shot probe) probes once and never sleeps; ``None`` means
+    ``REUSE_PATIENCE_SECONDS``, read at call time so tests can shrink it.
     """
     # The entry recorded ON THIS PORT, not merely the first one: with a
     # per-context record (F-808) another desktop's backend can be recorded
@@ -227,8 +225,7 @@ def _find_running_server() -> int | None:
     (F-808; the policy and its asymmetry live in
     :func:`backend_registry.adoption_candidates`), but IDENTITY, never display
     context, is the gate. Single-shot per candidate on the proxy's hot path,
-    behind a socket pre-filter: a dead record then costs ms, not a 2s timeout.
-    """
+    behind a socket pre-filter: a dead record costs ms, not a 2s timeout."""
     own = display_context.display_context()
     for entry in backend_registry.adoption_candidates(SERVER_STATE_FILE, own):
         port = entry.get("port")
@@ -418,19 +415,15 @@ def _backend_http_ready(port: int, *, timeout: float = LIVENESS_PROBE_TIMEOUT) -
     """Single-shot, synchronous app-level liveness probe: True iff the backend
     on ``port`` answers a real ``initialize`` with HTTP 200.
 
-    This is the promoted, reusable form of the mechanism `_await_backend_http`
-    already proves at startup (initialize->200), turned into ONE attempt
-    instead of a poll loop, so sync callers (discovery, CLI) can call it
-    directly and the watchdog can drive it off-thread. Never raises: any
-    failure (connection refused, timeout, malformed response) resolves to
-    False, matching `_server_is_healthy`'s fail-closed contract - a probe
-    error must always read as "not ready," never propagate.
-
-    NOTE: this intentionally duplicates ~10 lines of `_await_backend_http`'s
-    `initialize` request shape rather than sharing a helper (plan_M1 SS2.2
-    rejected-alternative #4, cross-review ruling: M1/M3 singleton regions stay
-    disjoint - `_await_backend_http` is M3's). `grep '"initialize"'` finds
-    both twins; consolidating them is a future finding, not this plan's scope.
+    The promoted, reusable form of what `_await_backend_http` proves at startup
+    (initialize->200), as ONE attempt instead of a poll loop, so sync callers
+    (discovery, CLI) can call it directly and the watchdog can drive it
+    off-thread. Never raises: any failure (connection refused, timeout,
+    malformed response) resolves to False - `_server_is_healthy`'s fail-closed
+    contract, where a probe error reads as "not ready" and never propagates.
+    The ~10 duplicated lines of that twin's `initialize` shape are deliberate
+    (plan_M1 SS2.2 rejected-alternative #4, cross-review ruling: M1/M3
+    singleton regions stay disjoint); consolidating is a future finding.
     """
     import httpx
     from mcp.types import DEFAULT_NEGOTIATED_VERSION
@@ -472,11 +465,10 @@ def _backend_http_ready(port: int, *, timeout: float = LIVENESS_PROBE_TIMEOUT) -
         # Fail-closed: connection refused (down), a hung/wedged backend that
         # never answers (timeout), or any other transport error all read as
         # "not ready" - matching _server_is_healthy's contract. DEBUG, not
-        # WARNING (M10a convention, cf. _await_backend_http's identical
-        # catch): this fires routinely during a normal cold start and on
-        # every watchdog tick while a backend is briefly busy - the caller
-        # (the watchdog) is the one that decides when repeated failures are
-        # WARNING-worthy, not this single-attempt probe.
+        # WARNING (M10a convention, cf. _await_backend_http's identical catch):
+        # this fires routinely during a normal cold start and on every watchdog
+        # tick while a backend is briefly busy - the caller decides when
+        # repeated failures are WARNING-worthy, not this single-attempt probe.
         _logger.debug("liveness probe attempt failed", exc_info=e)
         return False
 
@@ -534,10 +526,10 @@ def _start_backend_holding_lock(port: int) -> None:
                 return  # ours, merely busy or mid-boot — never evict it (F-807)
             # M2-3: surface WHY a fresh backend is about to spawn when the cause
             # is a source change (version matches, fingerprint differs) - the
-            # eviction is otherwise silent. Logged once per spawn HERE rather
-            # than inside _find_running_server (which runs up to 3x per locked
-            # cold start); the state re-read is a cheap diagnostic probe,
-            # deliberately NOT a second reuse gate (that stays single-homed in
+            # eviction is otherwise silent. Logged once per spawn HERE, not in
+            # _find_running_server (which runs up to 3x per locked cold start);
+            # the state re-read is a cheap diagnostic probe, deliberately NOT a
+            # second reuse gate (that stays single-homed in
             # _find_running_server). Source-only: a version-change eviction
             # (issue #14) must not emit this line.
             entry = backend_registry.backend_on_port(_read_server_state(), port)
@@ -571,16 +563,15 @@ def stop_backend() -> tuple[str, int | None]:
     that terminates every live browser session on it — that is the verb's
     purpose, not a side effect to guard against.
 
-    Consumes M1's `_probe_backend_status()` for the state read (binding
-    ruling: no new liveness check anywhere) — only a responsive/wedged
-    backend is actually targeted for termination; a stale `down` record is
-    cleared without anything left to kill; `none` is reported as-is. Lock
-    contention (a concurrent cold start/stop/restart already holding it)
-    reports "busy" so the operator can retry instead of racing it.
+    Consumes M1's `_probe_backend_status()` for the state read (binding ruling:
+    no new liveness check anywhere) — only a responsive/wedged backend is
+    actually targeted for termination; a stale `down` record is cleared with
+    nothing left to kill; `none` is reported as-is. Lock contention (a
+    concurrent cold start/stop/restart already holding it) reports "busy" so
+    the operator can retry instead of racing it.
 
-    Returns ``(result, pid)``: ``result`` is one of "stopped" |
-    "already stopped" | "not running" | "busy". ``pid`` is the terminated
-    pid when ``result == "stopped"``, else None.
+    Returns ``(result, pid)``: "stopped" | "already stopped" | "not running" |
+    "busy", with ``pid`` the terminated pid only when ``result == "stopped"``.
     """
     status, port = _probe_backend_status()
     if status == "none":
@@ -608,22 +599,22 @@ def stop_backend() -> tuple[str, int | None]:
 
 
 def restart_backend() -> tuple[str, int | None]:
-    """Restart the shared backend (CLI `restart` verb): the manual escape
-    hatch for a wedged (M1) or stale same-version (M2) backend — terminate
-    whatever is on the target port, then run the exact cold-start spawn
-    sequence under the same lock, with the SAME primitives (plan_M8 SS2.1-B:
-    no second spawn path, no new kill logic). Unconditional by design, so a
-    "down"/"none" backend also ends up running, not merely evicted. The spawn
-    port is chosen FIRST — `_select_backend_port()` (F-509 A1) — and terminate
-    then targets exactly it, so both halves agree BY CONSTRUCTION (F-808), not
-    via two reads that can diverge onto a sibling desktop's backend. Selection
-    means a squatter on the dead backend's port forces a fresh `_free_port()`
-    pick instead of a repeat 120s outage — the fallback port stays recorded
-    (SSA1.5); `stop` clears `server.json`, the reset path to `DEFAULT_PORT`.
-    Lock contention reports "busy" so the operator retries instead of racing.
-    The post-restart state is reported via `_probe_backend_status()` (binding
-    ruling: ONE liveness vocabulary) — a restart that comes back wedged or
-    down must be visible, not assumed "responsive".
+    """Restart the shared backend (CLI `restart` verb): the manual escape hatch
+    for a wedged (M1) or stale same-version (M2) backend — terminate whatever
+    is on the target port, then run the exact cold-start spawn sequence under
+    the same lock, with the SAME primitives (plan_M8 SS2.1-B: no second spawn
+    path, no new kill logic). Unconditional by design, so a "down"/"none"
+    backend also ends up running, not merely evicted. The spawn port is chosen
+    FIRST — `_select_backend_port()` (F-509 A1) — and terminate then targets
+    exactly it, so both halves agree BY CONSTRUCTION (F-808), not via two reads
+    that can diverge onto a sibling desktop's backend. Selection means a
+    squatter on the dead backend's port forces a fresh `_free_port()` pick
+    instead of a repeat 120s outage — the fallback port stays recorded (SSA1.5);
+    `stop` clears `server.json`, the reset path to `DEFAULT_PORT`. Lock
+    contention reports "busy" so the operator retries instead of racing. The
+    post-restart state is reported via `_probe_backend_status()` (binding
+    ruling: ONE liveness vocabulary) — a restart that comes back wedged or down
+    must be visible, not assumed "responsive".
 
     Returns ``(status, pid)``: `_probe_backend_status`'s status or "busy";
     ``pid`` is the freshly recorded pid once the lock is acquired, else None.
@@ -766,60 +757,69 @@ async def _await_backend_http(
     return False
 
 
-async def _watch_backend_liveness(
+async def _watch_backend_liveness(  # noqa: PLR0913  PERMANENT(function interface)
     port: int,
     *,
     interval: float = 2.0,
     failures_before_teardown: int = 3,
     is_healthy=None,
     sleep=None,
+    confirm_probe=None,
 ) -> None:
-    """Return once the backend on ``port`` has been unreachable for
-    ``failures_before_teardown`` consecutive checks.
-
-    Armed only after the backend was confirmed up; the caller tears the proxy
-    down when this returns. That converts a backend death mid-session into a
+    """Return once the backend on ``port`` is CONFIRMED unusable; the caller
+    tears the proxy down then, converting a backend death mid-session into a
     clean client reconnect (which respawns a fresh backend) instead of an
-    unbounded hang on requests a dead backend can never answer. A single healthy
-    check resets the failure run, so a transient blip never tears down a live
-    backend. ``is_healthy``/``sleep`` are injectable for testing.
+    unbounded hang on requests a dead backend can never answer. Armed only
+    after the backend was confirmed up; one healthy check resets the failure
+    run, so a transient blip never tears down a live backend. ``is_healthy``/
+    ``sleep``/``confirm_probe`` are injectable, sync or awaitable.
 
-    F-501: the default check used to be a bare socket connect
+    F-501: the fast check used to be a bare socket connect
     (``_server_is_healthy``), which a wedged backend (dispatch loop dead,
-    socket still open) always passes - so the sole auto-recovery watchdog
-    never armed against the exact failure it exists for. The default now runs
-    the app-level probe (``_backend_http_ready``) off-thread via
-    ``anyio.to_thread.run_sync`` (plan_M1 SS2.2 rejected alternative #3: a
-    blocking httpx call run inline would freeze the stdio pump for up to
-    ``LIVENESS_PROBE_TIMEOUT`` every ``interval``). The loop is await-aware
-    (``inspect.isawaitable``) so this async default and every existing
-    injected SYNC ``is_healthy`` callable both drive it unchanged.
+    socket still open) always passes - so the sole auto-recovery watchdog never
+    armed against the exact failure it exists for. It now runs the app-level
+    ``_backend_http_ready`` off-thread (plan_M1 SS2.2 rejected alternative #3:
+    a blocking httpx call run inline would freeze the stdio pump for up to
+    ``LIVENESS_PROBE_TIMEOUT`` every ``interval``).
+
+    F-820: those strikes no longer condemn on their own. Under fleet load a
+    healthy shared backend answers ``initialize`` slower than 2s for 20-40s at
+    a time, and whole waves of proxies tore down in the same second while it
+    went on serving (evidence in the finding). They now only open a
+    CONFIRMATION phase whose verdict comes from the SAME gate the cold-start
+    lock trusts - ``_same_identity_backend_ready``, driven off-thread, so there
+    is no second busy-vs-dead policy: dead (no socket, no process of ours)
+    fails in ms, keeping the human-pinned ~12s hard-down window; busy gets
+    ``REUSE_PATIENCE_SECONDS`` of ``REUSE_PROBE_TIMEOUT`` probes and survives;
+    only a backend silent for that whole window is condemned, ~12s + 60s in.
     """
     import anyio
 
-    def _default_check():
-        return anyio.to_thread.run_sync(_backend_http_ready, port)
+    async def _ask(probe):
+        res = probe()
+        return await res if inspect.isawaitable(res) else res
 
-    check = is_healthy if is_healthy is not None else _default_check
-    nap = sleep if sleep is not None else anyio.sleep
+    run = anyio.to_thread.run_sync
+    check = is_healthy or (lambda: run(_backend_http_ready, port))
+    confirm = confirm_probe or (lambda: run(_same_identity_backend_ready, port))
+    nap = sleep or anyio.sleep
     consecutive = 0
     while True:
         await nap(interval)
-        res = check()
-        if inspect.isawaitable(res):
-            res = await res
-        if res:
+        if await _ask(check):
             consecutive = 0
             continue
         consecutive += 1
         _logger.warning(
-            "liveness probe failed for backend on port %d (%d/%d)",
-            port,
-            consecutive,
-            failures_before_teardown,
+            "probe failed %d/%d on port %d", consecutive, failures_before_teardown, port
         )
-        if consecutive >= failures_before_teardown:
+        if consecutive < failures_before_teardown:
+            continue
+        if not await _ask(confirm):
+            _logger.warning("backend on port %d confirmed unusable", port)
             return
+        _logger.info("backend on port %d was busy, not dead", port)
+        consecutive = 0
 
 
 async def _proxy_streams(client_read, client_write, port: int) -> None:

--- a/tests/test_proxy_backend_death.py
+++ b/tests/test_proxy_backend_death.py
@@ -86,6 +86,10 @@ class TestWatchBackendLiveness:
                 failures_before_teardown=3,
                 is_healthy=health,
                 sleep=tiny_sleep,
+                # F-820: strikes alone no longer condemn — the gone backend of
+                # this test's premise is stated explicitly, which also keeps
+                # the case off the real server.json the default gate reads.
+                confirm_probe=lambda: False,
             )
 
         assert calls["n"] == 3  # tore down after exactly 3 consecutive failures
@@ -112,6 +116,7 @@ class TestWatchBackendLiveness:
                 failures_before_teardown=3,
                 is_healthy=health,
                 sleep=tiny_sleep,
+                confirm_probe=lambda: False,  # F-820: gone, not merely busy
             )
 
         assert idx["i"] == 6  # needed all 6 checks: the True reset the run of failures

--- a/tests/test_watchdog_app_level.py
+++ b/tests/test_watchdog_app_level.py
@@ -78,6 +78,11 @@ class TestWatchdogDefaultUsesAppProbe:
                 failures_before_teardown=3,
                 sleep=tiny_sleep,
                 # is_healthy intentionally omitted: pins the DEFAULT wiring.
+                # F-820: the strikes now open a confirmation phase, so a
+                # teardown needs the gate to agree. Injected False = "not
+                # merely busy", which is this test's wedged premise, and keeps
+                # the case hermetic (the real gate would read server.json).
+                confirm_probe=lambda: False,
             )
 
         assert calls["n"] == 3  # tore down after exactly 3 consecutive failures
@@ -136,6 +141,7 @@ class TestWatchdogAwaitAwareLoop:
                 failures_before_teardown=2,
                 is_healthy=sync_check,
                 sleep=tiny_sleep,
+                confirm_probe=lambda: False,  # F-820: dead, not busy
             )
 
         assert calls["n"] == 2
@@ -162,6 +168,7 @@ class TestWatchdogAwaitAwareLoop:
                 failures_before_teardown=2,
                 is_healthy=async_check,
                 sleep=tiny_sleep,
+                confirm_probe=lambda: False,  # F-820: dead, not busy
             )
 
         assert calls["n"] == 2

--- a/tests/test_watchdog_busy_vs_dead.py
+++ b/tests/test_watchdog_busy_vs_dead.py
@@ -1,0 +1,219 @@
+"""F-820 — the watchdog must not condemn a backend that is merely BUSY.
+
+``_watch_backend_liveness`` used to tear the stdio proxy down after
+``failures_before_teardown`` (3) consecutive misses of the 2s app-level probe.
+Production, 2026-08-30: under multi-session fleet load the shared backend
+answered ``initialize`` slower than 2s for 20-40s stretches while staying
+perfectly healthy — four waves (05:12 x7, 05:19 x30, 05:28 x3, 05:34 x10
+proxies) where every proxy tore down inside the same second while backend pid
+52396 kept serving navigate/screenshot before, during and after. Every Claude
+Code session lost the server at once: the user-visible "stealth randomly
+disconnects".
+
+The fix does NOT add a second busy-vs-dead policy. The strikes now merely open
+a CONFIRMATION phase, and the verdict comes from the gate the cold-start lock
+already trusts — ``_same_identity_backend_ready`` (F-807) — driven off-thread.
+So the three behaviours the confirmation depends on are pinned once, in
+``test_singleton_cold_start_patience.py``: a busy backend that answers inside
+``REUSE_PATIENCE_SECONDS`` passes, a socket-dead one fails on the first probe
+without buying the window (which is what keeps the human-pinned ~12s hard-down
+detection intact), and one that answers nothing for the whole window fails.
+
+What THIS file pins is the watchdog's half: that it consults that gate at all,
+that a passing verdict resets the strike run instead of tearing down, that a
+failing one still tears down promptly, and that the default seam really is
+that gate. Everything is injected — no sockets, no HTTP, no state file.
+``sleep`` doubles as the loop bound: a watchdog that correctly decides "busy,
+not dead" never returns on its own, so the injected nap raises
+``_StopWatchingError`` once the loop has run long enough for the assertion.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import anyio
+import anyio.lowlevel
+import pytest
+
+from stealth_chrome_devtools_mcp.embedded import singleton
+
+PORT = 47820
+
+
+class _StopWatchingError(Exception):
+    """Raised by the injected nap to end an endless (== healthy) watch loop."""
+
+
+def _bounded_nap(limit: int):
+    """A ``sleep`` seam that never really sleeps and stops the loop after
+    ``limit`` naps, so a non-returning watchdog is observable as an exception
+    instead of a hang."""
+
+    async def nap(_seconds):
+        nap.calls += 1
+        if nap.calls > limit:
+            raise _StopWatchingError
+        await anyio.lowlevel.checkpoint()
+
+    nap.calls = 0
+    return nap
+
+
+class _Probe:
+    """A recorded seam popping scripted results (the last one sticks)."""
+
+    def __init__(self, *results):
+        self.calls = 0
+        self._results = list(results)
+
+    def __call__(self):
+        self.calls += 1
+        if len(self._results) > 1:
+            return self._results.pop(0)
+        return self._results[0]
+
+
+@pytest.fixture()
+def captured_proxy_records():
+    """Direct handler attachment, not caplog — configure_logging sets
+    propagate=False by design (same convention as test_watchdog_app_level)."""
+    records = []
+
+    class _ListHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    logger = logging.getLogger("stealth.proxy")
+    handler = _ListHandler()
+    logger.addHandler(handler)
+    prior_level = logger.level
+    logger.setLevel(logging.DEBUG)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(prior_level)
+
+
+def _strike_counts(records) -> list[int]:
+    """The ``n`` out of every ``n/3`` strike WARNING, in order — a reset shows
+    up here as a second run starting back at 1."""
+    return [
+        r.args[0]
+        for r in records
+        if r.levelno == logging.WARNING and "probe failed" in r.msg
+    ]
+
+
+class TestBusyBackendIsNotCondemned:
+    @pytest.mark.asyncio
+    async def test_a_passing_confirmation_resets_the_strike_run(
+        self, captured_proxy_records
+    ):
+        """THE F-820 pin: the fast probe never answers, but the confirmation
+        gate says the backend is alive — the watchdog must NOT return, and must
+        start its strike run over instead of accumulating toward teardown."""
+        confirm = _Probe(True)
+        nap = _bounded_nap(6)
+
+        with anyio.fail_after(5), pytest.raises(_StopWatchingError):
+            await singleton._watch_backend_liveness(
+                port=PORT,
+                interval=0.0,
+                failures_before_teardown=3,
+                is_healthy=lambda: False,
+                sleep=nap,
+                confirm_probe=confirm,
+            )
+
+        assert _strike_counts(captured_proxy_records) == [1, 2, 3, 1, 2, 3], (
+            "the strike run must restart once the backend is confirmed alive"
+        )
+        assert confirm.calls == 2, "confirmation must run on every strike run"
+        assert any(
+            r.levelno == logging.INFO and "busy" in r.msg
+            for r in captured_proxy_records
+        ), "a survived confirmation must be reported at INFO, not silently"
+
+    @pytest.mark.asyncio
+    async def test_confirmation_is_not_consulted_before_the_strike_limit(self):
+        """One or two misses are still just misses: the (blocking, patient)
+        gate must not be paid for on every tick."""
+        confirm = _Probe(True)
+        # Misses that never reach three in a row: a healthy answer in between
+        # resets the run, so the confirmation phase is never entered.
+        fast = _Probe(False, False, True, False, True)
+
+        with anyio.fail_after(5), pytest.raises(_StopWatchingError):
+            await singleton._watch_backend_liveness(
+                port=PORT,
+                interval=0.0,
+                failures_before_teardown=3,
+                is_healthy=fast,
+                sleep=_bounded_nap(5),
+                confirm_probe=confirm,
+            )
+
+        assert confirm.calls == 0
+
+
+class TestConfirmedDeadStillTearsDownPromptly:
+    @pytest.mark.asyncio
+    async def test_failed_confirmation_returns_on_the_third_strike(
+        self, captured_proxy_records
+    ):
+        """The human-pinned ~12s hard-down window survives F-820: when the gate
+        confirms the backend is not merely busy, teardown lands on the third
+        strike, with no extra tick in between."""
+        confirm = _Probe(False)
+        nap = _bounded_nap(50)
+
+        with anyio.fail_after(5):
+            await singleton._watch_backend_liveness(
+                port=PORT,
+                interval=0.0,
+                failures_before_teardown=3,
+                is_healthy=lambda: False,
+                sleep=nap,
+                confirm_probe=confirm,
+            )
+
+        assert nap.calls == 3, "teardown must land on the third strike, not later"
+        assert confirm.calls == 1
+        assert any(
+            r.levelno == logging.WARNING and "confirmed unusable" in r.msg
+            for r in captured_proxy_records
+        ), "the confirmed verdict must be distinguishable from the strikes"
+
+
+class TestDefaultConfirmationIsTheColdStartGate:
+    @pytest.mark.asyncio
+    async def test_default_seam_drives_same_identity_backend_ready_off_thread(
+        self, monkeypatch
+    ):
+        """The one-policy pin. The default confirmation must be the SAME gate
+        the cold-start lock trusts — that is what buys the patience window and
+        the fast dead-check without a second copy of the policy here — and it
+        must run off-thread, since it blocks for up to REUSE_PATIENCE_SECONDS.
+        """
+        run_sync_calls = []
+
+        async def fake_run_sync(fn, *args, **kwargs):
+            run_sync_calls.append((fn, args))
+            return False
+
+        monkeypatch.setattr(anyio.to_thread, "run_sync", fake_run_sync)
+
+        with anyio.fail_after(5):
+            await singleton._watch_backend_liveness(
+                port=PORT,
+                interval=0.0,
+                failures_before_teardown=1,
+                sleep=_bounded_nap(50),
+            )
+
+        assert run_sync_calls == [
+            (singleton._backend_http_ready, (PORT,)),
+            (singleton._same_identity_backend_ready, (PORT,)),
+        ]


### PR DESCRIPTION
## Emergency fix: mass disconnects of every Claude Code session

**Symptom** — "stealth consistently disconnects randomly after some time." Production evidence (2026-08-30): four mass-disconnect waves — 05:12 (7 proxies), 05:19 (**30 proxies**), 05:28 (3), 05:34 (10) — each wave tearing down *every* connected session within the same second, while backend pid 52396 stayed alive and kept serving `navigate`/`take_screenshot` before, during, and after. Probe counters resetting mid-run (1/3 → 2/3 → 1/3) prove the backend was answering intermittently: busy, not dead.

**Root cause** — `_watch_backend_liveness` tears down after 3 consecutive misses of a 2s `initialize` probe (~12s window). Under fleet load the backend answers slower than 2s for 20–40s stretches (30s screenshots, 4–8s spawn spans) while perfectly healthy. F-807 already ratified busy-vs-dead discrimination for the cold-start reuse gate; the watchdog was left on the hair-trigger policy.

**Fix** — after 3 strikes the watchdog no longer condemns: it runs F-807's own gate (`_same_identity_backend_ready`, off-thread) as a confirmation phase. Dead (socket refused, no process) → teardown inside the same ~12s window as before. Busy → confirmed alive within the 60s patience window, strikes reset, watching resumes. Wedged → condemned after the full window (F-501 recovery preserved, now ~12s + 60s). Zero new policy, constants, or tunables — the confirmation inherits behavior already pinned in `test_singleton_cold_start_patience.py` (untouched).

Side effect (intended): identity is checked at confirmation, so a mid-session source edit gets no patience — matching "code edits apply via a fresh backend."

**Verification** — 4 new pins in `tests/test_watchdog_busy_vs_dead.py` with honest RED→GREEN (RED reproduced the defect: teardown of a backend confirmed alive). Full hermetic lane **1689 passed / 0 failed**; reduced startup herd green; `singleton.py` lands at exactly 1000/1000 LOC (cap untouched). Finding doc: `audit/stage2/finding_F820_watchdog_condemns_busy_backend.md`.

Residuals documented, deliberately not fixed here: backend event-loop stalls under fleet load; `backend-boot.log` unrotated (733 MB observed).