### PR TITLE
test(audit): five defects schema v2's own tests could not see

### DIFF
--- a/src/stealth_chrome_devtools_mcp/embedded/animation_analysis.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/animation_analysis.py
@@ -354,17 +354,25 @@ def build_animations(facts: Facts, caps: Caps) -> tuple[list[Record], bool]:
     for a model that cannot know which duration belongs to which name.
     """
     computed = as_obj(facts.get("computed"))
-    names = [
-        name
-        for name in split_css_list(as_text(computed.get("animation_name")))
-        if name and name != "none"
+    # The SLOT index is kept, not the position in the filtered list. Every other
+    # ``animation-*`` list stays as long as ``animation-name`` and is read
+    # positionally, so dropping a ``none`` slot without keeping its index hands
+    # every later animation the switched-off slot's duration, delay, easing and
+    # iteration count -- and addresses its edit recipe at the wrong comma item.
+    # That is F-847's list-cycling defect returning by a side door: the cycling
+    # rule applied correctly, to the wrong index.
+    declared = split_css_list(as_text(computed.get("animation_name")))
+    slots = [
+        (slot, name) for slot, name in enumerate(declared) if name and name != "none"
     ]
-    truncated = len(names) > caps.animations
+    truncated = len(slots) > caps.animations
     rule = applying_rule(facts)
     records: list[Record] = []
-    for index, name in enumerate(names[: caps.animations]):
+    # ``id`` counts RECORDS, not slots: ``build_waapi`` numbers the live records
+    # from ``len(animations)``, so a hole here would collide with anim-N.
+    for position, (index, name) in enumerate(slots[: caps.animations]):
         record: Record = {
-            "id": f"anim-{index}",
+            "id": f"anim-{position}",
             "kind": "css-animation",
             "name": name,
             "target": {"relation": "self", "selector": facts.get("selector")},

--- a/src/stealth_chrome_devtools_mcp/embedded/animation_edits.py
+++ b/src/stealth_chrome_devtools_mcp/embedded/animation_edits.py
@@ -48,6 +48,7 @@ from stealth_chrome_devtools_mcp.embedded.animation_facts import (
     keyframe_offsets,
     specificity,
     split_css_list,
+    warn,
 )
 
 # Measured, not chosen round (R12). After the boilerplate hoist below a recipe
@@ -103,6 +104,24 @@ _EASING_WORDS = {
     "step-end",
 }
 _EASING_FUNCTIONS = ("cubic-bezier(", "steps(", "linear(")
+
+# ``!important`` belongs to the DECLARATION, not to any comma item of its value,
+# so no knob's token may include it. A ``replace`` that swallowed the priority
+# would turn "set the duration to 3s" into "set the duration to 3s AND stop
+# winning the cascade" — precisely the "applying it cannot drop the rest of the
+# declaration" promise this module exists to keep. It is not a rare path either:
+# ``winning_rule`` ranks ``!important`` FIRST, so an important rule is the one a
+# recipe most often points at.
+_PRIORITY = re.compile(r"\s*!\s*important\s*$", re.IGNORECASE)
+
+
+def value_body(value: str) -> str:
+    """A declaration's value without its ``!important`` priority.
+
+    A prefix of ``value``, so an offset into it is also an offset into ``value``
+    and ``_swap``'s arithmetic is unchanged.
+    """
+    return _PRIORITY.sub("", value)
 
 
 # ---------------------------------------------------------------------------
@@ -324,6 +343,22 @@ def rule_declaring(facts: Facts, name: str, pseudo: str = "") -> Record | None:
     return found
 
 
+def _layer_of(rule: Record) -> str | None:
+    """Which ``@layer`` block this rule sits in, or ``None`` when unlayered.
+
+    Membership only. Layer ORDER is deliberately not inferred: a bare
+    ``@layer a, b;`` statement declares it, that rule has no ``cssRules``, and
+    the collector's walk therefore never sees it. Which is exactly why a
+    disagreement between candidates is undecidable here rather than rankable —
+    the cascade puts every layered declaration below every unlayered one, so
+    ranking by specificity would hand the win to a rule that cannot render.
+    """
+    for context in as_strings(rule.get("at_rule_context")):
+        if context.strip().lower().startswith("@layer"):
+            return context.strip()
+    return None
+
+
 def contributed_value(knob: Knob, rule: Record, props: list[str]) -> str | None:
     """What ``rule`` gives this knob, or ``None`` when it cannot be read.
 
@@ -391,6 +426,16 @@ def winning_rule(facts: Facts, knob: Knob, rules: list[Record] | None = None) ->
         return (int(important), spec, position)
 
     _, rule, props = max(candidates, key=rank)
+    if len({_layer_of(other) for _, other, _ in candidates}) > 1:
+        return Winner(
+            rule,
+            props,
+            "low",
+            "these rules are not all in the same @layer: an unlayered "
+            "declaration beats a layered one however specific the layered "
+            "selector is, and the layer ORDER is not readable from here, so "
+            "which of them renders is not decidable — open them at source_ref",
+        )
     undecidable = any(
         specificity(as_text(other.get("selector_text"))) is None
         for _, other, _ in candidates
@@ -684,14 +729,17 @@ def knob_recipe(facts: Facts, knob: Knob, rules: list[Record] | None = None) -> 
     if not located.literal:
         return recipe
     literal, value = located.literal, located.value
+    # Spans are taken against the value WITHOUT its priority, so `!important`
+    # can never end up inside a token a caller is told to replace.
+    body = value_body(value)
     if prop == knob.longhand:
         # The knob's own longhand: the token is this animation's item of the
         # comma list. Taking the whole list would report "2s, 3s" as one
         # animation's duration and rewrite both.
-        start, end = item_span(value, knob.list_index)
+        start, end = item_span(body, knob.list_index)
     else:
-        item_start, item_end = item_span(value, knob.list_index)
-        inside = token_verdict(knob, value[item_start:item_end])
+        item_start, item_end = item_span(body, knob.list_index)
+        inside = token_verdict(knob, body[item_start:item_end])
         if not inside.found:
             recipe["confidence"] = inside.confidence
             recipe["note"] = inside.reason
@@ -723,7 +771,9 @@ def keyframe_recipe(
     if not located.literal:
         return recipe
     recipe["find_unique_in_rule"] = located.confidence == "high"
-    recipe.update(_swap(located.literal, located.value, 0, len(located.value)))
+    recipe.update(
+        _swap(located.literal, located.value, 0, len(value_body(located.value)))
+    )
     return recipe
 
 
@@ -769,6 +819,21 @@ def build_edits(
         block = keyframe_span_for(span, offset)
         for prop, value in as_obj(frame.get("properties")).items():
             if len(edits) >= EDIT_CAP:
+                # Announced, never silent (F-853/F-855). ``caps.truncated``
+                # reports animations and keyframes only, so a model handed 20 of
+                # 38 recipes would otherwise conclude the keyframes it can find
+                # no recipe for are not editable. EDIT_CAP is not caller-
+                # settable, so the remedy named here is one the reader has.
+                warn(
+                    record,
+                    "edit_cap_reached",
+                    f"edit recipes truncated at {EDIT_CAP}; the keyframes "
+                    f"without a recipe are still listed in this record's "
+                    f"keyframes array, and their @keyframes block is at "
+                    f"source_ref — edit it there. Extract a narrower selector "
+                    f"for fewer animations per call.",
+                    {"cap": EDIT_CAP, "name": record.get("name")},
+                )
                 return edits
             recipe = keyframe_recipe(source, block, prop, as_text(value))
             recipe["knob"] = f"keyframe[{frame['offset']}].{prop}"

--- a/src/stealth_chrome_devtools_mcp/embedded/js/extract_animations.js
+++ b/src/stealth_chrome_devtools_mcp/embedded/js/extract_animations.js
@@ -434,6 +434,43 @@
         }
     }
 
+    // ── shadow roots: motion we can see happening and cannot describe ──
+    //
+    // `getAnimations({subtree: true})` does NOT cross a shadow boundary, and
+    // `document.styleSheets` does not list a shadow root's own <style>. So a
+    // host whose shadow content is visibly animating reports has_motion: false
+    // with nothing else to go on -- a SILENT FALSE NEGATIVE, which is the one
+    // failure mode M11 ranks below saying nothing at all: a model told an
+    // element is static will not look again. Say we cannot see in there.
+    (function () {
+        try {
+            const hosts = [];
+            if (element.shadowRoot) hosts.push(element);
+            const inner = element.querySelectorAll ? element.querySelectorAll('*') : [];
+            for (let i = 0; i < inner.length && hosts.length < 20; i++) {
+                if (inner[i].shadowRoot) hosts.push(inner[i]);
+            }
+            if (!hosts.length) return;
+            let moving = 0;
+            hosts.forEach(function (host) {
+                try {
+                    const kids = host.shadowRoot.querySelectorAll('*');
+                    for (let k = 0; k < kids.length; k++) {
+                        if (typeof kids[k].getAnimations === 'function'
+                            && kids[k].getAnimations().length) moving++;
+                    }
+                } catch (e) { /* a closed root answers nothing */ }
+            });
+            warn('shadow_root_not_traversed',
+                hosts.length + ' shadow root(s) under this element were not traversed: '
+                + 'getAnimations({subtree:true}) does not cross a shadow boundary and '
+                + 'document.styleSheets does not list a shadow root\'s <style>, so any '
+                + 'motion declared inside them is NOT in this payload'
+                + (moving ? ' (' + moving + ' element(s) in there are animating now)' : ''),
+                { hosts: hosts.length, animating_elements: moving });
+        } catch (e) { /* never let the warning break the collection */ }
+    })();
+
     // ── @keyframes: emit only the blocks anything here could reference ──
     //
     // Every @keyframes block in the document used to be shipped with its full

--- a/tests/fixture_app/animations_edge.html
+++ b/tests/fixture_app/animations_edge.html
@@ -1,0 +1,99 @@
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>fixture-animations-edge-page</title>
+    <!-- The CSS shapes only a real Chrome can settle. Every one of these is a
+         question about the COLLECTOR, not about the Python derivation: what the
+         CSSOM actually reports for a var() shorthand, whether an adopted
+         constructed sheet is even enumerable, what a @layer block looks like in
+         at_rule_context. A hermetic fixture answers all three by assertion,
+         which is how a fixture ends up agreeing with the bug.
+
+         AUTHOR TEXT, deliberately un-normalized (bare decimals, name-first
+         shorthand, tight spacing). Chrome's cssText rewrites all of it, so a
+         recipe built from cssText matches nothing here. -->
+    <style>
+      /* --- 1. A value hidden behind a custom property. Chrome resolves
+             animation-duration to .75s in computed style while the file says
+             var(--edge-dur). There is no `.75s` in this file to find. --- */
+      :root { --edge-dur: 750ms; }
+      #var-target {
+        height: 20px;
+        animation: edge-fade var(--edge-dur) ease-in;
+      }
+
+      /* --- 2. @layer. An UNLAYERED declaration beats a layered one however
+             specific the layered selector is, so #layer-target.layered (inside
+             the layer) LOSES to .layer-plain (outside it). Both declare 4s, so
+             there is no value disagreement to catch a wrong pick. --- */
+      @layer edge-base {
+        #layer-target { animation-name: edge-fade; animation-duration: 4s; }
+      }
+      .layer-plain { animation-name: edge-fade; animation-duration: 4s; }
+
+      /* --- 3. !important on a longhand: the priority must survive a recipe. --- */
+      #important-target {
+        animation-name: edge-fade;
+        animation-duration: 1.5s !important;
+      }
+
+      /* --- 4. A `none` slot between two live ones. Every other animation-*
+             list stays three items long and is read positionally. --- */
+      #none-slot {
+        animation-name: edge-fade, none, edge-slide;
+        animation-duration: 1s, 2s, 3s;
+        animation-delay: 0s, 0s, 5s;
+        animation-iteration-count: 1, 1, infinite;
+      }
+
+      @keyframes edge-fade {
+        from { opacity: .1 }
+        to   { opacity: 1 }
+      }
+      @keyframes edge-slide {
+        from { transform: translateX(0) }
+        to   { transform: translateX(40px) }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="var-target">var</div>
+    <div id="layer-target" class="layer-plain">layer</div>
+    <div id="important-target">important</div>
+    <div id="none-slot">none-slot</div>
+
+    <!-- 5. A constructed stylesheet, adopted. There is NO author file for these
+         bytes at all: the rule exists only inside the script below. A recipe
+         that handed back a file pointer here would be pointing at nothing. -->
+    <div id="adopted-host">adopted</div>
+
+    <!-- 6. Shadow DOM. getAnimations({subtree:true}) crosses into a shadow
+         root, but document.styleSheets does not, so the live animation is
+         visible while its @keyframes is not. -->
+    <div id="shadow-host"></div>
+
+    <script>
+      // --- constructed + adopted (no author file) ---
+      const sheet = new CSSStyleSheet();
+      sheet.replaceSync(
+        "@keyframes edge-adopted { from { opacity: .2 } to { opacity: .9 } }" +
+        "#adopted-host { animation: edge-adopted 2.5s linear infinite; }"
+      );
+      document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet];
+
+      // --- shadow root with its own <style> and its own @keyframes ---
+      const root = document.getElementById("shadow-host").attachShadow({ mode: "open" });
+      root.innerHTML =
+        "<style>" +
+        "  @keyframes edge-shadow { from { opacity: 0 } to { opacity: 1 } }" +
+        "  .inner { animation: edge-shadow 1.75s ease-out infinite; }" +
+        "</style>" +
+        "<div class='inner'>inner</div>";
+
+      // Marker the test waits on, so no assertion races the script.
+      window.__edgeReady = true;
+    </script>
+  </body>
+</html>

--- a/tests/test_animation_v2_audit.py
+++ b/tests/test_animation_v2_audit.py
@@ -1,0 +1,594 @@
+"""Adversarial audit of schema v2: the inputs the merged suite does not write.
+
+Every case here is CSS an author really writes and the merged tests never fed
+in. They split into two kinds, and the distinction is the point:
+
+* **A recipe that lies.** The payload emits ``confidence: "high"`` plus a
+  ``find``/``replace`` pair that either rewrites the wrong thing or cannot
+  change what renders. These are worse than a missing recipe, which is the
+  premise ``animation_edits`` is built on, so they are the tests that matter.
+* **A recipe that degrades.** No ``find``, a note saying why. That is the
+  contract working, and it is pinned here so a later "improvement" cannot
+  quietly start guessing.
+
+The fixtures are written the way an author writes CSS, never the way Chrome
+re-serializes it — bare decimals, name-first shorthand, ``!important`` where an
+author would put it. A fixture in CSSOM shape shares a serializer with the code
+under test and therefore cannot fail (the trap this repo has already been caught
+by once).
+"""
+
+from __future__ import annotations
+
+from stealth_chrome_devtools_mcp.embedded.animation_edits import EDIT_CAP
+from test_animation_edit_recipes import recipes, rule, source
+from test_animation_schema_v2 import computed, extract, facts
+
+
+def _timing(payload, name):
+    """The timing block of the one animation called ``name``."""
+    found = [a for a in payload["animations"] if a["name"] == name]
+    assert len(found) == 1, (
+        f"expected one {name!r}, got {[a['name'] for a in payload['animations']]}"
+    )
+    return found[0]
+
+
+class TestAnimationNameNoneKeepsEveryOtherListInStep:
+    """``animation-name: fade, none, spin`` is legal CSS, and every other
+    ``animation-*`` list stays THREE items long and positional.
+
+    Dropping the ``none`` from the name list without keeping its slot shifts
+    every list index after it by one, so ``spin`` inherits the timing of the
+    switched-off slot. This is the F-847 list-cycling defect returning by a side
+    door: the cycling rule is applied correctly, to the wrong index.
+
+    It is the worst shape a defect can take here — the numbers are not missing,
+    they are confidently wrong, and ``derived.total_ms`` is computed from them.
+    """
+
+    THREE_SLOTS = facts(
+        selector="#hero",
+        computed=computed(
+            animation_name="fade, none, spin",
+            animation_duration="1s, 2s, 3s",
+            animation_delay="0s, 0s, 5s",
+            animation_iteration_count="1, 1, infinite",
+            animation_timing_function="linear, linear, ease-in",
+            animation_direction="normal, normal, alternate",
+        ),
+    )
+
+    async def test_the_animation_after_a_none_slot_keeps_its_own_timing(self):
+        payload = await extract(self.THREE_SLOTS)
+        spin = _timing(payload, "spin")["timing"]
+        assert spin["duration_raw"] == "3s", (
+            "spin sits in slot 2, so its duration is the third item of "
+            "'1s, 2s, 3s'; reading the second means the `none` slot was dropped "
+            "without keeping its index"
+        )
+        assert spin["delay_raw"] == "5s"
+        assert spin["iterations"] == "infinite"
+        assert spin["easing"] == "ease-in"
+        assert spin["direction"] == "alternate"
+
+    async def test_the_animation_before_a_none_slot_is_untouched(self):
+        payload = await extract(self.THREE_SLOTS)
+        fade = _timing(payload, "fade")["timing"]
+        assert fade["duration_raw"] == "1s"
+        assert fade["delay_raw"] == "0s"
+
+    async def test_the_switched_off_slot_produces_no_record(self):
+        payload = await extract(self.THREE_SLOTS)
+        assert [a["name"] for a in payload["animations"]] == ["fade", "spin"]
+
+    async def test_the_ids_stay_dense_so_a_live_record_cannot_collide(self):
+        """``build_waapi`` numbers its records from ``len(animations)``. If a
+        skipped slot left a hole in the CSS ids, the first live record would be
+        handed an id that already exists."""
+        payload = await extract(self.THREE_SLOTS)
+        ids = [a["id"] for a in payload["animations"]]
+        assert ids == ["anim-0", "anim-1"]
+        assert len(ids) == len(set(ids))
+
+    async def test_the_edit_recipe_addresses_the_right_comma_item(self):
+        """The recipe's ``list_index`` is the same index the timing used, so a
+        wrong index here rewrites a DIFFERENT animation's duration in the
+        author's file — at ``confidence: high``."""
+        payload = facts(
+            selector="#hero",
+            raw_sources={
+                "0": "#hero {\n"
+                "  animation-name: fade, none, spin;\n"
+                "  animation-duration: 1s, 2s, 3s;\n"
+                "}\n"
+            },
+            computed=computed(
+                animation_name="fade, none, spin",
+                animation_duration="1s, 2s, 3s",
+            ),
+            matched_rules=[
+                rule(
+                    "#hero",
+                    {
+                        "animation-name": "fade, none, spin",
+                        "animation-duration": "1s, 2s, 3s",
+                    },
+                )
+            ],
+            sources=[source("src-0", selector="#hero")],
+        )
+        found = await recipes(payload, name="spin")
+        assert found["duration"]["token"] == "3s", (
+            "spin's duration token is the third comma item; handing back '2s' "
+            "would retime the wrong animation"
+        )
+        assert (
+            found["duration"]["replace"] == "animation-duration: 1s, 2s, {{NEW_VALUE}}"
+        )
+
+
+class TestImportantSurvivesTheReplaceTemplate:
+    """``!important`` is a property of the DECLARATION, not of any comma item.
+
+    ``animation_edits``' whole promise is that ``replace`` carries the rest of
+    the declaration so nothing can be lost. A token span that swallows the
+    priority breaks exactly that promise, and it breaks it on the most
+    authoritative rule in the file — ``winning_rule`` RANKS ``!important``
+    first, so this is the rule the recipe is most likely to point at.
+    """
+
+    IMPORTANT = facts(
+        selector="#hero",
+        raw_sources={
+            "0": "#hero {\n"
+            "  animation-name: fade;\n"
+            "  animation-duration: 2s !important;\n"
+            "}\n"
+        },
+        computed=computed(animation_name="fade", animation_duration="2s"),
+        matched_rules=[
+            rule(
+                "#hero",
+                {"animation-name": "fade", "animation-duration": "2s"},
+                important=["animation-duration"],
+            )
+        ],
+        sources=[source("src-0", selector="#hero")],
+    )
+
+    async def test_the_token_is_the_value_not_the_priority(self):
+        found = await recipes(self.IMPORTANT, name="fade")
+        assert found["duration"]["token"] == "2s", (
+            "the token a model swaps is the duration; including '!important' "
+            "means substituting '3s' silently drops the priority"
+        )
+
+    async def test_the_replacement_still_carries_the_priority(self):
+        found = await recipes(self.IMPORTANT, name="fade")
+        replace = found["duration"]["replace"]
+        assert "!important" in replace, (
+            "applying this recipe must not change the cascade; a replacement "
+            "that drops '!important' rewrites which rule wins"
+        )
+        # The mechanical check: apply the recipe the way EDIT_PROTOCOL says to.
+        assert replace.replace("{{NEW_VALUE}}", "3s") == (
+            "animation-duration: 3s !important"
+        )
+
+    async def test_the_find_literal_is_still_the_authors_whole_declaration(self):
+        found = await recipes(self.IMPORTANT, name="fade")
+        assert found["duration"]["find"] == "animation-duration: 2s !important"
+        assert found["duration"]["find"] in self.IMPORTANT["raw_sources"]["0"]
+
+
+class TestALayerMakesTheWinnerUndecidable:
+    """``@layer`` reverses the rule ``winning_rule`` ranks by.
+
+    An UNLAYERED normal declaration beats a layered one no matter how specific
+    the layered selector is. ``winning_rule`` ranks ``!important``, then
+    specificity, then document order, and never reads ``at_rule_context`` —
+    which the recipe itself carries. So a layered ``#hero`` outranks an
+    unlayered ``.hero`` in our ordering and loses in the browser's.
+
+    The computed-value cross-check cannot save this one: when both rules declare
+    the SAME value there is no disagreement to notice, and the recipe goes out
+    at ``confidence: "high"`` pointing at a rule whose edit changes nothing.
+
+    Layer ORDER is not recoverable from the captured facts either — a bare
+    ``@layer a, b;`` statement rule has no ``cssRules`` and the collector's walk
+    skips it — so the honest verdict is the one the module already has a
+    vocabulary for: undecidable, degrade, say why.
+    """
+
+    LAYERED = facts(
+        selector="#hero",
+        raw_sources={
+            "0": "@layer base {\n"
+            "  #hero { animation-name: fade; animation-duration: 2s; }\n"
+            "}\n"
+            ".hero { animation-name: fade; animation-duration: 2s; }\n"
+        },
+        computed=computed(animation_name="fade", animation_duration="2s"),
+        matched_rules=[
+            rule(
+                "#hero",
+                {"animation-name": "fade", "animation-duration": "2s"},
+                at_rule_context=["@layer base"],
+            ),
+            rule(
+                ".hero",
+                {"animation-name": "fade", "animation-duration": "2s"},
+                source_ref="src-1",
+            ),
+        ],
+        sources=[
+            source("src-0", selector="#hero"),
+            source("src-1", selector=".hero"),
+        ],
+    )
+
+    async def test_no_find_is_offered_when_a_layer_decides_the_cascade(self):
+        found = await recipes(self.LAYERED, name="fade")
+        assert "find" not in found["duration"], (
+            "an unlayered .hero beats a layered #hero, so a find inside the "
+            "layered rule is an edit that cannot change what renders"
+        )
+
+    async def test_the_note_names_the_layer_as_the_reason(self):
+        found = await recipes(self.LAYERED, name="fade")
+        assert found["duration"]["confidence"] == "low"
+        assert "layer" in found["duration"]["note"].lower()
+
+    async def test_the_record_says_it_is_not_editable(self):
+        payload = await extract(self.LAYERED)
+        fade = _timing(payload, "fade")
+        assert fade["editable"] is False
+        assert fade["not_editable_reason"]
+
+    async def test_one_layer_alone_still_yields_a_usable_recipe(self):
+        """The degradation is about DISAGREEMENT between candidates. A single
+        layered rule is as decidable as a single unlayered one, and turning
+        every ``@layer`` user's payload into pointers would be a worse defect
+        than the one being fixed."""
+        payload = facts(
+            selector="#hero",
+            raw_sources={
+                "0": "@layer base {\n"
+                "  #hero { animation-name: fade; animation-duration: 2s; }\n"
+                "}\n"
+            },
+            computed=computed(animation_name="fade", animation_duration="2s"),
+            matched_rules=[
+                rule(
+                    "#hero",
+                    {"animation-name": "fade", "animation-duration": "2s"},
+                    at_rule_context=["@layer base"],
+                )
+            ],
+            sources=[source("src-0", selector="#hero")],
+        )
+        found = await recipes(payload, name="fade")
+        assert found["duration"]["token"] == "2s"
+        assert found["duration"]["confidence"] == "high"
+
+    async def test_two_rules_in_the_same_layer_are_still_decidable(self):
+        payload = facts(
+            selector="#hero",
+            raw_sources={
+                "0": "@layer base {\n"
+                "  .hero { animation-name: fade; animation-duration: 9s; }\n"
+                "  #hero { animation-name: fade; animation-duration: 2s; }\n"
+                "}\n"
+            },
+            computed=computed(animation_name="fade", animation_duration="2s"),
+            matched_rules=[
+                rule(
+                    ".hero",
+                    {"animation-name": "fade", "animation-duration": "9s"},
+                    at_rule_context=["@layer base"],
+                ),
+                rule(
+                    "#hero",
+                    {"animation-name": "fade", "animation-duration": "2s"},
+                    source_ref="src-1",
+                    at_rule_context=["@layer base"],
+                ),
+            ],
+            sources=[
+                source("src-0", selector=".hero"),
+                source("src-1", selector="#hero"),
+            ],
+        )
+        found = await recipes(payload, name="fade")
+        assert found["duration"]["rule_selector"] == "#hero"
+        assert found["duration"]["token"] == "2s"
+
+
+class TestTruncatedEditsAnnounceThemselves:
+    """``EDIT_CAP`` cuts the recipe list at 20 and used to say nothing.
+
+    The caps discipline this batch landed (F-853/F-855) is that a bound the
+    reader cannot see is a bound that lies: the payload's ``caps.truncated``
+    block reports only animations and keyframes, so a model handed 20 of 38
+    recipes has no way to learn the other 18 exist. It will conclude the
+    keyframes it cannot find a recipe for are not editable.
+    """
+
+    @staticmethod
+    def _many_keyframes():
+        frames = [
+            {
+                "key_text": f"{i * 10}%",
+                "css_text": "opacity: 0.5; transform: scale(1); color: red;",
+                "easing": "",
+                "composite": "",
+            }
+            for i in range(11)
+        ]
+        return facts(
+            selector="#hero",
+            raw_sources={"0": "#hero { animation: fade 2s ease; }\n"},
+            computed=computed(animation_name="fade", animation_duration="2s"),
+            matched_rules=[
+                rule(
+                    "#hero",
+                    {"animation": "fade 2s ease", "animation-duration": "2s"},
+                )
+            ],
+            keyframe_rules=[
+                {"name": "fade", "source_ref": "src-1", "keyframes": frames}
+            ],
+            sources=[
+                source("src-0", selector="#hero"),
+                source("src-1", name="fade", kind="keyframes"),
+            ],
+        )
+
+    async def test_the_cut_really_happens(self):
+        payload = await extract(self._many_keyframes())
+        fade = _timing(payload, "fade")
+        assert len(fade["edits"]) == EDIT_CAP
+        # 11 keyframes x 3 declarations + 5 timing knobs is well past the cap.
+        assert len(fade["keyframes"]) * 3 + 5 > EDIT_CAP
+
+    async def test_the_record_warns_that_recipes_were_dropped(self):
+        payload = await extract(self._many_keyframes())
+        fade = _timing(payload, "fade")
+        codes = [w["code"] for w in fade["warnings"]]
+        assert "edit_cap_reached" in codes, (
+            f"edits were cut from {len(fade['keyframes']) * 3 + 5} to "
+            f"{len(fade['edits'])} with no warning; silent truncation is the "
+            f"exact failure F-853/F-855 named"
+        )
+
+    async def test_the_warning_names_a_remedy_that_works(self):
+        """F-855's rule: a truncation message must not name a lever the reader
+        does not have. ``EDIT_CAP`` is not caller-settable at all, so the
+        message must not invite anyone to raise it."""
+        payload = await extract(self._many_keyframes())
+        fade = _timing(payload, "fade")
+        message = next(
+            w["message"] for w in fade["warnings"] if w["code"] == "edit_cap_reached"
+        )
+        assert "source_ref" in message or "narrower selector" in message
+        assert "max_edits" not in message
+
+    async def test_an_uncut_record_carries_no_such_warning(self):
+        payload = facts(
+            selector="#hero",
+            raw_sources={"0": "#hero { animation: fade 2s ease; }\n"},
+            computed=computed(animation_name="fade", animation_duration="2s"),
+            matched_rules=[
+                rule("#hero", {"animation": "fade 2s ease", "animation-duration": "2s"})
+            ],
+        )
+        result = await extract(payload)
+        fade = _timing(result, "fade")
+        assert "edit_cap_reached" not in [w["code"] for w in fade["warnings"]]
+
+
+class TestValuesBehindACustomPropertyDegrade:
+    """``animation: fade var(--dur) ease`` has no ``<time>`` token to address.
+
+    Chrome resolves the duration to ``0.4s`` in computed style while the
+    author's bytes say ``var(--dur)``. A recipe that pointed at the resolved
+    value would be addressing text that is not in the file; one that swapped
+    ``var(--dur)`` would delete the indirection the author wanted.
+
+    Degrading is the right answer, and this pins it so a later pass cannot
+    start substituting the resolved value.
+    """
+
+    VAR_SHORTHAND = facts(
+        selector="#hero",
+        raw_sources={"0": "#hero { animation: fade var(--dur) ease; }\n"},
+        computed=computed(animation_name="fade", animation_duration="0.4s"),
+        matched_rules=[rule("#hero", {"animation": "fade var(--dur) ease"})],
+        sources=[source("src-0", selector="#hero")],
+    )
+
+    async def test_no_find_literal_is_offered_for_the_duration(self):
+        found = await recipes(self.VAR_SHORTHAND, name="fade")
+        assert "find" not in found["duration"]
+        assert found["duration"]["confidence"] == "low"
+
+    async def test_the_resolved_value_is_never_presented_as_the_authors_text(self):
+        """``0.4s`` appears nowhere in the file, so it must appear in no
+        ``find``, ``token`` or ``replace`` on any recipe for this record."""
+        payload = await extract(self.VAR_SHORTHAND)
+        fade = _timing(payload, "fade")
+        for edit in fade["edits"]:
+            for field in ("find", "token", "replace"):
+                text = edit.get(field, "")
+                assert "0.4s" not in text, (
+                    f"{edit['knob']}.{field} offers {text!r}, which is Chrome's "
+                    f"resolved value and is not in the author's stylesheet"
+                )
+
+    async def test_the_declared_duration_is_still_reported(self):
+        """Degrading the RECIPE must not degrade the FACT: the model still
+        needs to know the animation runs for 400ms."""
+        payload = await extract(self.VAR_SHORTHAND)
+        assert _timing(payload, "fade")["timing"]["duration_ms"] == 400.0
+
+
+class TestDuplicateKeyframesResolveToTheLastBlock:
+    """Two ``@keyframes fade`` blocks is ordinary CSS and the LAST one wins.
+
+    Resolving to the first would describe motion the page does not perform, and
+    the recipe must not point into either block: with two identical headers in
+    the file there is no way to tell which one the CSSOM record came from.
+    """
+
+    @staticmethod
+    def _block(start, end, source_ref):
+        return {
+            "name": "fade",
+            "source_ref": source_ref,
+            "keyframes": [
+                {
+                    "key_text": "from",
+                    "css_text": f"opacity: {start};",
+                    "easing": "",
+                    "composite": "",
+                },
+                {
+                    "key_text": "to",
+                    "css_text": f"opacity: {end};",
+                    "easing": "",
+                    "composite": "",
+                },
+            ],
+        }
+
+    DUPLICATE = facts(
+        selector="#hero",
+        raw_sources={
+            "0": "#hero { animation: fade 2s ease; }\n"
+            "@keyframes fade { from { opacity: 0 } to { opacity: 1 } }\n"
+            "@keyframes fade { from { opacity: 1 } to { opacity: .25 } }\n"
+        },
+        computed=computed(animation_name="fade", animation_duration="2s"),
+        matched_rules=[
+            rule("#hero", {"animation": "fade 2s ease", "animation-duration": "2s"})
+        ],
+        sources=[
+            source("src-0", selector="#hero"),
+            source("src-1", name="fade", kind="keyframes"),
+            source("src-2", name="fade", kind="keyframes"),
+        ],
+    )
+
+    def _facts(self):
+        payload = dict(self.DUPLICATE)
+        payload["keyframe_rules"] = [
+            self._block("0", "1", "src-1"),
+            self._block("1", "0.25", "src-2"),
+        ]
+        return payload
+
+    async def test_the_last_block_is_the_one_reported(self):
+        payload = await extract(self._facts())
+        fade = _timing(payload, "fade")
+        values = [k["properties"]["opacity"] for k in fade["keyframes"]]
+        assert values == ["1", "0.25"], (
+            "the cascade gives the last @keyframes block of a name; reporting "
+            "0 -> 1 describes motion this page does not perform"
+        )
+
+    async def test_no_keyframe_recipe_guesses_which_block_to_edit(self):
+        payload = await extract(self._facts())
+        fade = _timing(payload, "fade")
+        for edit in fade["edits"]:
+            if edit["knob"].startswith("keyframe["):
+                assert "find" not in edit, (
+                    "two identical @keyframes headers are in this file; "
+                    "picking one is a coin flip dressed as a verified address"
+                )
+
+
+class TestAnInlineAnimationIsNotBlamedOnACrossOriginSheet:
+    """An ``animation`` in the element's ``style=""`` has no rule to edit.
+
+    Degrading is right. But the collector already captured
+    ``element.inline_properties``, so the payload KNOWS where the declaration
+    is, and telling the reader its stylesheet is "likely cross-origin" sends a
+    weak model looking for a file that is not involved.
+
+    This pins the safe half (no ``find``) and records the misdirection as the
+    thing to fix, rather than asserting a message we have not fixed yet.
+    """
+
+    INLINE = facts(
+        selector="#hero",
+        element={
+            "tag": "div",
+            "id": "hero",
+            "classes": [],
+            "inline_properties": ["animation-name", "animation-duration"],
+            "is_canvas": False,
+        },
+        computed=computed(animation_name="fade", animation_duration="2s"),
+    )
+
+    async def test_no_recipe_points_at_a_stylesheet_that_declares_nothing(self):
+        payload = await extract(self.INLINE)
+        fade = _timing(payload, "fade")
+        assert fade["editable"] is False
+        assert all("find" not in edit for edit in fade["edits"])
+
+    async def test_the_timing_is_still_read_from_computed_style(self):
+        payload = await extract(self.INLINE)
+        assert _timing(payload, "fade")["timing"]["duration_ms"] == 2000.0
+
+
+class TestStepsEasingAndNegativeDelayStayMechanical:
+    """Two shapes a weak model gets wrong on its own, both fully decidable."""
+
+    STEPPED = facts(
+        selector="#hero",
+        raw_sources={
+            "0": "#hero { animation: tick 2s steps(4, jump-end) -0.5s infinite; }\n"
+        },
+        computed=computed(
+            animation_name="tick",
+            animation_duration="2s",
+            animation_delay="-0.5s",
+            animation_timing_function="steps(4, jump-end)",
+            animation_iteration_count="infinite",
+        ),
+        matched_rules=[
+            rule(
+                "#hero",
+                {"animation": "tick 2s steps(4, jump-end) -0.5s infinite"},
+            )
+        ],
+        sources=[source("src-0", selector="#hero")],
+    )
+
+    async def test_a_negative_delay_starts_now_partway_in(self):
+        payload = await extract(self.STEPPED)
+        derived = _timing(payload, "tick")["derived"]
+        assert derived["active_start_ms"] == 0.0
+        assert derived["starts_at_progress_ms"] == 500.0
+
+    async def test_the_steps_easing_classifies_as_stepped(self):
+        payload = await extract(self.STEPPED)
+        semantics = _timing(payload, "tick")["semantics"]
+        assert semantics["easing_class"]["value"] == "stepped"
+
+    async def test_the_easing_recipe_addresses_the_whole_steps_function(self):
+        """``steps(4, jump-end)`` has a comma inside it. A token split that did
+        not keep the function whole would hand back ``steps(4,`` — a find that
+        matches and a replace that produces invalid CSS."""
+        found = await recipes(self.STEPPED, name="tick")
+        assert found["easing"]["token"] == "steps(4, jump-end)"
+        assert found["easing"]["replace"] == (
+            "animation: tick 2s {{NEW_VALUE}} -0.5s infinite"
+        )
+
+    async def test_the_delay_recipe_takes_the_second_time_not_the_first(self):
+        found = await recipes(self.STEPPED, name="tick")
+        assert found["delay"]["token"] == "-0.5s"
+        assert found["duration"]["token"] == "2s"

--- a/tests/test_e2e_animations_edge.py
+++ b/tests/test_e2e_animations_edge.py
@@ -1,0 +1,350 @@
+"""E2E: the CSS shapes only a real Chrome can settle (audit of schema v2).
+
+``test_e2e_animations.py`` proves the happy path over the real transport. This
+file is the adversarial half: every case here is one where a HERMETIC fixture
+would have to encode an assumption about the CSSOM, and encoding that assumption
+is how a fixture ends up agreeing with the bug. What does Chrome report for a
+shorthand containing ``var()``? Is an adopted constructed stylesheet even
+enumerable? What does a ``@layer`` block look like in ``at_rule_context``?
+
+Two properties are asserted throughout, and only these two are worth an E2E:
+
+* **The find literal is the author's bytes.** Every ``find`` is checked against
+  the fixture file's own text, read off disk — never against a string this test
+  also composes. That is the only check Chrome's re-serialization cannot pass by
+  accident (F-849).
+* **A payload never claims more than it saw.** Where the collector genuinely
+  cannot reach the CSS (a constructed sheet, a shadow root), the record has to
+  say so rather than degrade into silence, because silence reads as "nothing to
+  do here".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from e2e_helpers import (
+    get_fn,
+    integration_pytestmark,
+    navigate_and_settle,
+    sandbox_kwargs,
+    warmup_once,
+)
+
+pytestmark = integration_pytestmark()
+
+PAGE = Path(__file__).parent / "fixture_app" / "animations_edge.html"
+
+
+@pytest.fixture(autouse=True)
+async def _warm():
+    await warmup_once()
+
+
+@pytest.fixture(scope="module")
+def author_bytes() -> str:
+    """The fixture page's own text, read off disk.
+
+    THE point of this file: a ``find`` literal is only trustworthy if it occurs
+    in the bytes an editor would open. Comparing it to a string this test also
+    builds compares one serializer to itself.
+    """
+    return PAGE.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+async def payloads(fixture_app_server):
+    """One extraction per target element, taken in a single browser session."""
+    spawn, close = get_fn("spawn_browser"), get_fn("close_instance")
+    extract = get_fn("extract_element_animations")
+    instance = await spawn(headless=True, **sandbox_kwargs())
+    iid = instance["instance_id"]
+    try:
+        await navigate_and_settle(iid, f"{fixture_app_server}/animations_edge.html")
+        out = {}
+        for selector in (
+            "#var-target",
+            "#layer-target",
+            "#important-target",
+            "#none-slot",
+            "#adopted-host",
+            "#shadow-host",
+        ):
+            out[selector] = await extract(instance_id=iid, selector=selector)
+        yield out
+    finally:
+        await close(instance_id=iid)
+
+
+def animation(payload, name):
+    found = [a for a in payload["animations"] if a["name"] == name]
+    assert len(found) == 1, (
+        f"expected one {name!r}, got {[a['name'] for a in payload['animations']]}"
+    )
+    return found[0]
+
+
+def knobs(payload, name):
+    return {edit["knob"]: edit for edit in animation(payload, name)["edits"]}
+
+
+def applied(edit) -> str:
+    """The recipe applied the way ``edit_protocol`` says to apply it."""
+    assert edit["token"] in edit["find"], "the token must be inside the find literal"
+    return edit["replace"].replace("{{NEW_VALUE}}", "NEW")
+
+
+class TestEveryFindLiteralIsInTheFileOnDisk:
+    """The load-bearing E2E assertion: recipes address the author's bytes.
+
+    Chrome's ``cssText`` re-serializes (name to the end of the shorthand, ``.1``
+    expanded to ``0.1``, ``running`` injected). Any recipe built from it would
+    fail this check, and no hermetic fixture can make that failure visible.
+    """
+
+    async def test_no_recipe_offers_a_literal_that_is_not_in_the_page(
+        self, payloads, author_bytes
+    ):
+        checked = 0
+        for selector, payload in payloads.items():
+            for record in payload["animations"]:
+                for edit in record.get("edits", []):
+                    if "find" not in edit:
+                        continue
+                    assert edit["find"] in author_bytes, (
+                        f"{selector} / {edit['knob']}: find={edit['find']!r} does "
+                        f"not occur in animations_edge.html; it came from a "
+                        f"re-serialization, not from the author's text"
+                    )
+                    checked += 1
+        assert checked >= 10, f"only {checked} applicable recipes — fixture too thin"
+
+    async def test_applying_a_recipe_yields_a_declaration_not_a_fragment(
+        self, payloads
+    ):
+        """R1's corruption case: a ``replace`` that is not a whole declaration
+        turns ``animation: fade 2s ease`` into ``3s``."""
+        for payload in payloads.values():
+            for record in payload["animations"]:
+                for edit in record.get("edits", []):
+                    if "find" not in edit:
+                        continue
+                    result = applied(edit)
+                    assert ":" in result, f"{edit['knob']} replace is not a declaration"
+                    assert result.split(":")[0].strip(), edit["knob"]
+
+
+class TestAValueBehindACustomProperty:
+    """``animation: edge-fade var(--edge-dur) ease-in``.
+
+    Chrome resolves the duration to ``0.75s`` in computed style; the file says
+    ``var(--edge-dur)``. There is no ``0.75s`` anywhere on disk, so the duration
+    knob must degrade — while the knobs that ARE literal in the shorthand (the
+    easing, the name) stay fully editable. Losing those too would be an
+    over-degradation nearly as bad as the lie.
+    """
+
+    async def test_the_duration_degrades_rather_than_addressing_a_resolved_value(
+        self, payloads, author_bytes
+    ):
+        edit = knobs(payloads["#var-target"], "edge-fade")["duration"]
+        assert "find" not in edit
+        assert edit["confidence"] == "low"
+        assert "0.75s" not in author_bytes
+
+    async def test_the_easing_beside_it_is_still_mechanically_editable(self, payloads):
+        edit = knobs(payloads["#var-target"], "edge-fade")["easing"]
+        assert edit["token"] == "ease-in"
+        assert applied(edit) == "animation: edge-fade var(--edge-dur) NEW", (
+            "the var() must survive verbatim in the replacement — rewriting it "
+            "to the resolved value would delete the author's indirection"
+        )
+
+    async def test_the_duration_is_still_reported_as_a_fact(self, payloads):
+        """Degrading the RECIPE must not degrade the MEASUREMENT."""
+        record = animation(payloads["#var-target"], "edge-fade")
+        assert record["timing"]["duration_ms"] == 750.0
+
+
+class TestALayeredRuleDoesNotOutrankAnUnlayeredOne:
+    """``@layer edge-base { #layer-target { … } }`` vs an unlayered
+    ``.layer-plain``.
+
+    The browser puts every layered declaration below every unlayered one, so
+    ``.layer-plain`` renders even though ``#layer-target`` is far more specific.
+    Ranking by specificity picks the layered rule; both declare ``4s``, so there
+    is no value disagreement to catch the mistake, and the recipe would go out
+    at ``confidence: high`` pointing at a rule whose edit changes nothing.
+    """
+
+    async def test_the_collector_really_captured_the_layer(self, payloads):
+        """If ``at_rule_context`` were empty this whole class would pass for the
+        wrong reason, so it is asserted before anything is concluded from it."""
+        contexts = [
+            source.get("at_rule_context")
+            for source in payloads["#layer-target"]["sources"]
+        ]
+        assert ["@layer edge-base"] in contexts, contexts
+
+    async def test_the_duration_recipe_refuses_to_pick_a_winner(self, payloads):
+        edit = knobs(payloads["#layer-target"], "edge-fade")["duration"]
+        assert "find" not in edit
+        assert edit["confidence"] == "low"
+        assert "@layer" in edit["note"]
+
+    async def test_the_keyframes_are_still_editable(self, payloads):
+        """The ``@keyframes`` block is unlayered and unambiguous; the layer
+        problem is about which RULE sets the duration, not about the frames."""
+        frames = [
+            edit
+            for knob, edit in knobs(payloads["#layer-target"], "edge-fade").items()
+            if knob.startswith("keyframe[")
+        ]
+        assert frames and all("find" in edit for edit in frames)
+
+    async def test_editable_is_a_whole_record_verdict_not_a_per_knob_one(
+        self, payloads
+    ):
+        """Worth pinning because it is the shape most likely to be misread.
+
+        ``editable`` means "some recipe here can be applied", and the editable
+        recipes on this record are the KEYFRAMES — every timing knob is a
+        pointer. So the record carries no ``editable: false``, and a reader that
+        stops at that flag would conclude it can retime this animation.
+
+        That is not a lie (the per-recipe ``confidence`` is right there and
+        says low), but it is the reason the flag must never be read alone. If a
+        later change makes ``editable`` per-knob, this test is the one that
+        should be revisited deliberately rather than silently.
+        """
+        record = animation(payloads["#layer-target"], "edge-fade")
+        assert "editable" not in record
+        timing_knobs = knobs(payloads["#layer-target"], "edge-fade")
+        assert all(
+            "find" not in timing_knobs[knob]
+            for knob in ("duration", "delay", "easing", "iterations", "name")
+        )
+
+
+class TestImportantSurvivesTheRoundTrip:
+    """``animation-duration: 1.5s !important`` — the rule ``winning_rule`` ranks
+    FIRST, so it is the rule recipes point at most often."""
+
+    async def test_the_token_is_the_time_not_the_priority(self, payloads):
+        edit = knobs(payloads["#important-target"], "edge-fade")["duration"]
+        assert edit["token"] == "1.5s"
+
+    async def test_applying_the_recipe_keeps_the_declaration_winning(
+        self, payloads, author_bytes
+    ):
+        edit = knobs(payloads["#important-target"], "edge-fade")["duration"]
+        assert edit["find"] == "animation-duration: 1.5s !important"
+        assert edit["find"] in author_bytes
+        assert applied(edit) == "animation-duration: NEW !important", (
+            "dropping '!important' changes which rule wins the cascade — a "
+            "retime that silently becomes a cascade edit"
+        )
+
+
+class TestANoneSlotDoesNotShiftTheListsAfterIt:
+    """``animation-name: edge-fade, none, edge-slide`` with three-item duration,
+    delay and iteration lists. ``edge-slide`` owns slot 2, not slot 1."""
+
+    async def test_the_second_live_animation_keeps_its_own_timing(self, payloads):
+        timing = animation(payloads["#none-slot"], "edge-slide")["timing"]
+        assert timing["duration_ms"] == 3000.0
+        assert timing["delay_ms"] == 5000.0
+        assert timing["iterations"] == "infinite"
+
+    async def test_its_recipe_swaps_the_third_comma_item(self, payloads, author_bytes):
+        edit = knobs(payloads["#none-slot"], "edge-slide")["duration"]
+        assert edit["find"] in author_bytes
+        assert edit["token"] == "3s"
+        assert applied(edit) == "animation-duration: 1s, 2s, NEW", (
+            "swapping the second item would retime edge-fade instead"
+        )
+
+    async def test_the_first_animation_is_unaffected(self, payloads):
+        edit = knobs(payloads["#none-slot"], "edge-fade")["duration"]
+        assert edit["token"] == "1s"
+        assert applied(edit) == "animation-duration: NEW, 2s, 3s"
+
+    async def test_the_switched_off_slot_is_not_a_record(self, payloads):
+        names = [a["name"] for a in payloads["#none-slot"]["animations"]]
+        assert names == ["edge-fade", "edge-slide"]
+
+
+class TestAConstructedStylesheetHasNoFileToPointAt:
+    """``new CSSStyleSheet()`` + ``adoptedStyleSheets``.
+
+    ``document.styleSheets`` does not list an adopted constructed sheet, so the
+    rule and its ``@keyframes`` are invisible to the collector while the
+    animation itself is plainly running. The only honest answer is the animation
+    with no recipe and a stated reason; fabricating a ``<style> #N`` pointer
+    would send an editor to a file that does not contain the rule.
+    """
+
+    async def test_the_animation_is_still_reported(self, payloads):
+        record = animation(payloads["#adopted-host"], "edge-adopted")
+        assert record["timing"]["duration_ms"] == 2500.0
+        assert record["timing"]["iterations"] == "infinite"
+
+    async def test_no_recipe_fabricates_a_source_pointer(self, payloads):
+        record = animation(payloads["#adopted-host"], "edge-adopted")
+        assert record["editable"] is False
+        for edit in record["edits"]:
+            assert "find" not in edit
+            assert "file" not in edit, (
+                "there is no file: these bytes exist only inside the script that "
+                "called replaceSync()"
+            )
+
+    async def test_the_missing_keyframes_are_announced_not_merely_empty(self, payloads):
+        record = animation(payloads["#adopted-host"], "edge-adopted")
+        assert record["keyframes"] == []
+        assert "keyframes_not_found" in [w["code"] for w in record["warnings"]], (
+            "an empty keyframes array with no warning reads as 'this animation "
+            "has no keyframes', which would make a model add a duplicate block"
+        )
+
+
+class TestAShadowRootIsNotSilentlyReportedAsStatic:
+    """``getAnimations({subtree:true})`` does not cross a shadow boundary and
+    ``document.styleSheets`` does not list a shadow root's ``<style>``.
+
+    So a host whose shadow content is visibly animating produced
+    ``has_motion: false`` and NOT ONE WARNING. That is the failure this schema
+    ranks below saying nothing at all: a model told an element is static stops
+    looking. It does not have to be captured; it has to be admitted.
+    """
+
+    async def test_the_host_really_is_invisible_to_the_collector(self, payloads):
+        """Pinned so the warning below cannot quietly become redundant: if a
+        future Chrome starts traversing shadow roots this fails, which is the
+        signal to revisit the warning rather than to keep emitting it."""
+        assert payloads["#shadow-host"]["animations"] == []
+
+    async def test_the_payload_admits_it_could_not_look_inside(self, payloads):
+        codes = [w["code"] for w in payloads["#shadow-host"]["warnings"]]
+        assert "shadow_root_not_traversed" in codes, (
+            f"the shadow content is animating and the payload says nothing: {codes}"
+        )
+
+    async def test_the_warning_says_motion_is_actually_running_in_there(self, payloads):
+        warning = next(
+            w
+            for w in payloads["#shadow-host"]["warnings"]
+            if w["code"] == "shadow_root_not_traversed"
+        )
+        assert warning["detail"]["hosts"] >= 1
+        assert warning["detail"]["animating_elements"] >= 1, (
+            "the collector can count animations inside an OPEN root even though "
+            "getAnimations(subtree) will not return them; saying 'something is "
+            "moving in here' is the difference between a caveat and a shrug"
+        )
+
+    async def test_an_element_with_no_shadow_root_gets_no_such_warning(self, payloads):
+        codes = [w["code"] for w in payloads["#none-slot"]["warnings"]]
+        assert "shadow_root_not_traversed" not in codes

--- a/tests/test_e2e_animations_edge.py
+++ b/tests/test_e2e_animations_edge.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+import pytest_asyncio
 
 from e2e_helpers import (
     get_fn,
@@ -54,9 +55,18 @@ def author_bytes() -> str:
     return PAGE.read_text(encoding="utf-8")
 
 
-@pytest.fixture(scope="module")
+@pytest_asyncio.fixture(scope="module", loop_scope="module")
 async def payloads(fixture_app_server):
-    """One extraction per target element, taken in a single browser session."""
+    """One extraction per target element, taken in a single browser session.
+
+    ``loop_scope`` is stated rather than inherited. This is the suite's only
+    non-function-scoped async fixture, and pytest-asyncio currently falls the
+    loop scope back to the caching scope only under a deprecation warning
+    (``asyncio_default_fixture_loop_scope`` is unset); once that default flips
+    to function scope, the browser would be spawned on a loop that closes
+    before the teardown that has to await ``close_instance`` on it. Stating it
+    keeps the session's setup and teardown on one loop under either default.
+    """
     spawn, close = get_fn("spawn_browser"), get_fn("close_instance")
     extract = get_fn("extract_element_animations")
     instance = await spawn(headless=True, **sandbox_kwargs())


### PR DESCRIPTION
## Independent adversarial audit of PR #72

An Opus reviewer audited the merged animation-parsing v2 feature from a clean worktree at `4c0ccba`, with the standing rule that nothing changes on a code-read alone: **every fix in this PR is here because a new test reproduced the defect first** (red on merged code, green after).

All five confirmed defects share one signature: **the payload was confident and wrong**, which the subsystem's own premise (F-850) ranks below saying nothing — and in each case the fact needed to catch it was already *in* the payload, just never read.

### Confirmed defects, fixed here

| # | Sev | Defect |
|---|---|---|
| D1 | HIGH | `animation-name: fade, none, spin` — filtering `none` dropped the slot index, so `spin` received slot 1's duration/delay/easing/iteration at `confidence: "high"`, and its edit recipe addressed the wrong comma item. F-847's cycling rule applied correctly to the wrong index. Fixed: the list index stays the CSS slot; record `id` counts records (a hole would collide with `build_waapi`'s numbering). |
| D2 | HIGH | `animation-duration: 2s !important` — token was `2s !important`, replace template dropped the priority. A retime silently became a cascade edit, on the rule `winning_rule` ranks *first*. Fixed via `value_body()` at both knob branches and `keyframe_recipe`. |
| D3 | HIGH | `@layer` reverses the cascade; ranking never read `at_rule_context` (which the recipe itself carries). An unlayered rule beats a layered one regardless of specificity, so recipes went out at `confidence: "high"` pointing at a rule whose edit changes nothing. Layer *order* is unrecoverable (a bare `@layer a, b;` has no `cssRules`), so mixed-layer cases degrade to a pointer — the vocabulary the module already had for `:is`/`:where`. Verified firing in real Chrome. |
| D4 | MED | The 20-recipe `EDIT_CAP` truncated silently (38 recipes → 20 delivered, 18 dropped, `caps.truncated` all-false, no warning) — directly against F-853/F-855. Fixed with a per-record `edit_cap_reached` warning naming a remedy the reader actually has. |
| D5 | MED | A shadow host with visibly animating shadow content returned `has_motion: false`, zero animations, zero warnings — `getAnimations({subtree:true})` doesn't cross the boundary and `document.styleSheets` doesn't see shadow styles. Fixed in the collector: it counts animating elements in open roots and admits when it could not look in. |

### Reported, not fixed (degrade safely; the *reason text* is wrong)

- **D6 (MED)**: three distinct causes — `var()`-indirect values, inline `style=""` animations, adopted constructed sheets — all share the one fallback message "likely cross-origin; edit that instead", sending a weak model hunting for a file that isn't involved. The payload already carries the discriminating facts.
- **D7 (LOW, pinned as a test)**: `editable` is whole-record; a record whose timing knobs are all pointers but whose keyframes are editable emits no `editable: false`.

### New tests

- `tests/test_animation_v2_audit.py` — 28 hermetic. 9 proved D1–D4 by failing on merged code; the other 19 pin contracts proved falsifiable by briefly mutating the product (each red-condition documented in the file). Notably: `var()` degradation survived removing `token_verdict` alone — it is defense-in-depth, only failing when the computed-value cross-check was also removed.
- `tests/test_e2e_animations_edge.py` + `tests/fixture_app/animations_edge.html` — 22 against real Chrome. The load-bearing test checks **every** `find` literal against the fixture's own on-disk bytes, never a string the test composes (the fixtures-from-the-same-serializer lesson). Settled empirically: adopted constructed sheets are absent from `document.styleSheets` and fabricate no pointer; a `var()` shorthand arrives as author text, leaving name/easing knobs editable while only duration degrades; `@layer` context is captured verbatim.

### Verification

- Full unit lane before fixes: **2199 passed** (baseline reproduced). After: **2227 passed, 1 skipped, 176 deselected** — reconciles exactly (+28 hermetic, +22 integration-marked deselected).
- Both E2E animation files: **30 passed** against real Chrome.
- Independently spot-checked by the orchestrating session: audit file 28/28, budgets green, `server.py` untouched at 3411/3411.
- ruff, ty (byte-identical diagnostic baseline), vulture, suppression owners, budgets: all green. Pre-push hook passed on this exact ref.

### Conventions verdict on PR #72: PASS

All four CLAUDE.md conventions hold. The `{"error": ...}` aspect shape remains the documented owner-ruled deferral (one sweep across all six aspects).

### Most valuable follow-up

`EDIT_PROTOCOL`'s addressing stops one step short of mechanical: `file` is `"<style> #0"` or an href, never an openable path — while `rule_span` already computes and discards the byte offset, and `extract_related_files` already answers URL→repo-file, unjoined. Closing that would make recipes end-to-end applicable and fix D6's wrong messages for free.