### PR TITLE
ci: store workflow artifacts on self-hosted MinIO (DevinoSolutions/artifact)

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -58,6 +58,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ on:
       - "v*"
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
@@ -45,7 +46,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download the gated dist artifact (no rebuild)
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: DevinoSolutions/artifact/download@v1
         with:
           name: dist
 

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -44,6 +44,7 @@ on:
         value: ${{ jobs.build-dist.outputs.version }}
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
@@ -103,7 +104,7 @@ jobs:
           --artifact "runner-identity=runner-identity.json"
       - name: Upload this cell's release-evidence record
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: DevinoSolutions/artifact/upload@v1
         with:
           name: release-evidence-quality
           path: release-evidence
@@ -146,7 +147,7 @@ jobs:
           --python "${{ matrix.python-version }}"
           --out "runner-identity.json"
       - name: Upload runner identity
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: DevinoSolutions/artifact/upload@v1
         with:
           name: runner-identity-unit-${{ matrix.runner_os }}-${{ matrix.runner_arch }}-py${{ matrix.python-version }}
           path: runner-identity.json
@@ -176,7 +177,7 @@ jobs:
           --mq "MQ-130"
       - name: Upload this cell's release-evidence record
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: DevinoSolutions/artifact/upload@v1
         with:
           name: release-evidence-unit-${{ matrix.runner_os }}-${{ matrix.runner_arch }}-py${{ matrix.python-version }}
           path: release-evidence
@@ -223,7 +224,7 @@ jobs:
           --cov-fail-under=55
           --junitxml=junit.xml -o junit_family=xunit1
       - name: Upload coverage report + runner identity
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: DevinoSolutions/artifact/upload@v1
         with:
           name: coverage-${{ matrix.runner_os }}-${{ matrix.runner_arch }}
           path: |
@@ -250,7 +251,7 @@ jobs:
           --artifact "runner-identity=runner-identity.json"
       - name: Upload this cell's release-evidence record
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: DevinoSolutions/artifact/upload@v1
         with:
           name: release-evidence-coverage-${{ matrix.runner_os }}-${{ matrix.runner_arch }}
           path: release-evidence
@@ -328,7 +329,7 @@ jobs:
           STEALTH_MCP_BROWSER_SESSION_ROOT: ${{ runner.temp }}/stealth-mcp-session-root
       - name: Upload Chrome + runner identity
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: DevinoSolutions/artifact/upload@v1
         with:
           name: identity-integration-${{ matrix.runner_os }}-${{ matrix.runner_arch }}
           path: |
@@ -432,7 +433,7 @@ jobs:
           --mq "MQ-162"
       - name: Upload this cell's release-evidence record
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: DevinoSolutions/artifact/upload@v1
         with:
           name: release-evidence-integration-${{ matrix.runner_os }}-${{ matrix.runner_arch }}
           path: release-evidence
@@ -501,7 +502,7 @@ jobs:
           STEALTH_MCP_BROWSER_SESSION_ROOT: ${{ runner.temp }}/stealth-mcp-session-root
       - name: Upload Chrome + runner identity
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: DevinoSolutions/artifact/upload@v1
         with:
           name: identity-transport-${{ matrix.runner_os }}-${{ matrix.runner_arch }}
           path: |
@@ -560,7 +561,7 @@ jobs:
           --mq "MQ-144"
       - name: Upload this cell's release-evidence record
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: DevinoSolutions/artifact/upload@v1
         with:
           name: release-evidence-transport-${{ matrix.runner_os }}-${{ matrix.runner_arch }}
           path: release-evidence
@@ -619,7 +620,7 @@ jobs:
           --artifact "runner-identity=runner-identity.json"
       - name: Upload this cell's release-evidence record
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: DevinoSolutions/artifact/upload@v1
         with:
           name: release-evidence-known-gaps
           path: release-evidence
@@ -703,7 +704,7 @@ jobs:
           --artifact "runner-identity=runner-identity.json"
       - name: Upload this cell's release-evidence record
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: DevinoSolutions/artifact/upload@v1
         with:
           name: release-evidence-offline-stealth-${{ matrix.runner_os }}-${{ matrix.runner_arch }}
           path: release-evidence
@@ -745,7 +746,7 @@ jobs:
           python3 tools/package_verify.py assert-version
           --manifest release-manifest.json --tag "${{ inputs.release_tag }}"
       - name: Upload the one immutable dist artifact
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: DevinoSolutions/artifact/upload@v1
         with:
           name: dist
           path: |
@@ -778,7 +779,7 @@ jobs:
           --artifact "runner-identity=runner-identity.json"
       - name: Upload this cell's release-evidence record
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: DevinoSolutions/artifact/upload@v1
         with:
           name: release-evidence-build-dist
           path: release-evidence
@@ -795,7 +796,7 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
       - name: Download the one dist artifact
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: DevinoSolutions/artifact/download@v1
         with:
           name: dist
       - name: Verify the downloaded artifacts against the build manifest
@@ -859,7 +860,7 @@ jobs:
           --manifest release-manifest.json
       - name: Upload package-verify evidence
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: DevinoSolutions/artifact/upload@v1
         with:
           name: package-verify-evidence
           path: |
@@ -893,7 +894,7 @@ jobs:
           --artifact "runner-identity=runner-identity.json"
       - name: Upload this cell's release-evidence record
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: DevinoSolutions/artifact/upload@v1
         with:
           name: release-evidence-package-verify
           path: release-evidence
@@ -965,7 +966,7 @@ jobs:
           Xvfb :99 -screen 0 1920x1080x24 -ac +extension GLX +render -noreset &
           sleep 3
       - name: Download the one dist artifact
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: DevinoSolutions/artifact/download@v1
         with:
           name: dist
       - name: 'KNOWN GAP: this macOS cell verifies NO navigation (F-773)'
@@ -991,7 +992,7 @@ jobs:
           STEALTH_MCP_NO_ERROR_REPORTING: "true"
       - name: Upload smoke result + identity
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: DevinoSolutions/artifact/upload@v1
         with:
           name: install-smoke-${{ matrix.kind }}-${{ matrix.cell.runner_os }}-${{ matrix.cell.runner_arch }}
           path: |
@@ -1021,7 +1022,7 @@ jobs:
           --artifact "runner-identity=runner-identity.json"
       - name: Upload this cell's release-evidence record
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: DevinoSolutions/artifact/upload@v1
         with:
           name: release-evidence-install-smoke-${{ matrix.kind }}-${{ matrix.cell.runner_os }}-${{ matrix.cell.runner_arch }}
           path: release-evidence
@@ -1067,7 +1068,7 @@ jobs:
         # so it needs the package importable -- the count is never typed.
         run: uv sync --extra test --extra sentry
       - name: Download every cell's evidence record
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: DevinoSolutions/artifact/download@v1
         with:
           pattern: release-evidence-*
           merge-multiple: true
@@ -1083,7 +1084,7 @@ jobs:
           --event "${{ github.event_name }}"
       - name: Upload the aggregate ledger
         if: always()
-        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        uses: DevinoSolutions/artifact/upload@v1
         with:
           name: release-evidence-aggregate
           path: release-evidence

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,5 @@ jobs:
   # W3's publish.yml calls the SAME workflow for tags. The stable required check a
   # ruleset pins is this job's aggregate child: `release-gate / release-gate`.
   release-gate:
+    permissions: write-all # GITHUB_TOKEN defaults + id-token for DevinoSolutions/artifact (OIDC)
     uses: ./.github/workflows/release-gate.yml

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -98,6 +98,7 @@ def test_publish_requires_the_green_gate_and_downloads_that_runs_artifact():
         step
         for step in publish["steps"]
         if "download-artifact" in str(step.get("uses", ""))
+        or "/artifact/download@" in str(step.get("uses", ""))
     ]
     assert len(downloads) == 1, "publish must download the one gated dist artifact"
     assert downloads[0]["with"]["name"] == "dist"
@@ -308,7 +309,10 @@ def test_every_emitting_job_uploads_what_it_emitted(gate_jobs):
         uploads = [
             s
             for s in steps
-            if str(s.get("uses", "")).startswith("actions/upload-artifact")
+            if (
+                str(s.get("uses", "")).startswith("actions/upload-artifact")
+                or str(s.get("uses", "")).startswith("DevinoSolutions/artifact/upload")
+            )
             and s.get("with", {}).get("path") == "release-evidence"
         ]
         assert uploads, f"job {name!r} emits a record but never uploads it"
@@ -416,14 +420,17 @@ def test_the_canary_reuses_the_gate_instead_of_restating_it(canary_jobs):
 
 def test_the_canary_has_no_write_permission_anywhere():
     doc = _load(CANARY)
-    assert doc["permissions"] == {"contents": "read"}, (
+    # `id-token: write` is not a repository write scope: it only lets the job
+    # mint an OIDC token, which DevinoSolutions/artifact exchanges for
+    # short-lived credentials on the self-hosted artifact store.
+    assert doc["permissions"] == {"contents": "read", "id-token": "write"}, (
         "the canary is read-only by construction, not by convention"
     )
     for name, job in doc["jobs"].items():
         perms = job.get("permissions")
         if perms is None:
             continue
-        assert "write" not in str(perms), (
+        assert "write" not in str({k: v for k, v in dict(perms).items() if k != "id-token"}), (
             f"canary job {name!r} requests write permission: {perms}"
         )
 

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -430,9 +430,9 @@ def test_the_canary_has_no_write_permission_anywhere():
         perms = job.get("permissions")
         if perms is None:
             continue
-        assert "write" not in str({k: v for k, v in dict(perms).items() if k != "id-token"}), (
-            f"canary job {name!r} requests write permission: {perms}"
-        )
+        assert "write" not in str(
+            {k: v for k, v in dict(perms).items() if k != "id-token"}
+        ), f"canary job {name!r} requests write permission: {perms}"
 
 
 def test_the_canary_never_reaches_outside_the_run():


### PR DESCRIPTION
Moves every `actions/upload-artifact` / `actions/download-artifact` step to
[`DevinoSolutions/artifact`](https://github.com/DevinoSolutions/artifact), a drop-in
replacement that stores artifacts on Devino's own MinIO (`storage.devino.ca`) instead
of GitHub's metered artifact storage.

**Why:** the org is on the free plan (500 MB artifact quota) with a $0 hard-stop Actions
budget, so once the quota is exceeded every artifact upload is rejected. Self-hosted
runners do not avoid this; the upstream action always writes to GitHub's blob store.

**What changed**
- `uses:` lines swapped to `DevinoSolutions/artifact/upload@v1` / `download@v1`; all inputs are compatible.
- Jobs that upload/download now request `id-token: write`, because the action authenticates to MinIO with the job's GitHub OIDC token (no secrets). Where a job had no `permissions` block, `permissions: write-all` is added, which equals the repo's current default token scopes plus `id-token`.
- `retention-days` is honoured via bucket lifecycle rules (rounded up to 1/3/5/7/14/30 days; anything above 30 keeps the 90-day default).

Artifacts are listed in each job's step summary as `s3://gh-artifacts/<owner>/<repo>/<run_id>/<name>.tgz` and can be fetched with `mc` or browsed at `minio-console.devino.ca`.
